### PR TITLE
OML codec: reader (Core+Extended), writer (Core), shared depth guard

### DIFF
--- a/omnist/src/document.rs
+++ b/omnist/src/document.rs
@@ -134,7 +134,7 @@ struct Entry {
 /// the tree calls this before creating a node -- see the module-level test
 /// `every_tree_mutating_entry_point_enforces_the_depth_guard` for the audit
 /// that walks every public entry point and confirms each one does.
-fn check_write_depth(depth: usize, path: &str) -> Result<(), DocumentError> {
+pub(crate) fn check_write_depth(depth: usize, path: &str) -> Result<(), DocumentError> {
     if depth > MAX_DEPTH {
         return Err(DocumentError::new(
             path,
@@ -547,6 +547,74 @@ impl<'a> Cursor<'a> {
     }
 }
 
+/// The *raw* canonical Document node: either a leaf scalar, or an ordered
+/// list of `(label, child)` edges that may repeat **and interleave** a label
+/// arbitrarily (`[("b",1),("c",2),("b",3)]` is representable exactly).
+///
+/// This is distinct from [`Value`]: `Value::Object`'s `IndexMap` can't hold
+/// a repeated key, so its "repeated label" convention (a `Value::Array`
+/// under one key, per [`child_specs`]) only ever expands to a *contiguous*
+/// run of same-label edges. OML is the one format that must round-trip
+/// arbitrary interleaving losslessly (per its own docs: "no adjustment ever
+/// needed"), so its reader/writer (`crate::oml`) builds/walks a `Doc`
+/// through this type instead of going through `Value`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RawNode {
+    Leaf(Scalar),
+    Edges(Vec<(String, RawNode)>),
+}
+
+impl Doc {
+    /// Build a `Doc` from a [`RawNode`], preserving edge order and
+    /// interleaving exactly. Depth-guarded via the same
+    /// [`check_write_depth`] every other construction path uses.
+    pub fn from_raw(root: RawNode) -> Result<Doc, DocumentError> {
+        let mut arena = Vec::new();
+        let root_id = push_raw(&mut arena, root, 0)?;
+        Ok(Doc {
+            arena,
+            root: root_id,
+        })
+    }
+
+    /// The inverse of [`Doc::from_raw`]: a lossless walk back into
+    /// [`RawNode`] form, preserving edge order and interleaving exactly.
+    pub fn to_raw(&self) -> RawNode {
+        self.raw_at(self.root)
+    }
+
+    fn raw_at(&self, id: NodeId) -> RawNode {
+        match &self.entry(id).data {
+            NodeData::Leaf(s) => RawNode::Leaf(s.clone()),
+            NodeData::Internal(edges) => RawNode::Edges(
+                edges
+                    .iter()
+                    .map(|(label, child)| (label.clone(), self.raw_at(*child)))
+                    .collect(),
+            ),
+        }
+    }
+}
+
+fn push_raw(arena: &mut Vec<Entry>, node: RawNode, depth: usize) -> Result<NodeId, DocumentError> {
+    // Path information isn't meaningful during a from-source OML parse (no
+    // dotted-key path exists yet), so a fixed placeholder is used here --
+    // matching the depth guard's own error message, which never mentions
+    // path for depth violations anyway (see `check_write_depth`).
+    check_write_depth(depth, "$")?;
+    match node {
+        RawNode::Leaf(s) => Ok(push(arena, NodeData::Leaf(s), depth)),
+        RawNode::Edges(edges) => {
+            let mut out = Vec::with_capacity(edges.len());
+            for (label, child) in edges {
+                let cid = push_raw(arena, child, depth + 1)?;
+                out.push((label, cid));
+            }
+            Ok(push(arena, NodeData::Internal(out), depth))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -917,5 +985,51 @@ mod tests {
         assert_eq!(Scalar::Int(1).to_string(), "1");
         assert_eq!(Scalar::Float(1.5).to_string(), "1.5");
         assert_eq!(Scalar::Str("x".to_string()).to_string(), "\"x\"");
+    }
+
+    // -- RawNode / from_raw / to_raw (interleaved-edge round trip) ---------
+
+    #[test]
+    fn from_raw_to_raw_round_trips_interleaved_repeated_labels() {
+        // ("b",1),("c",2),("b",3): interleaved, not a contiguous run --
+        // exactly the shape `Value`/`IndexMap` cannot represent, which is
+        // why the OML codec goes through RawNode instead.
+        let raw = RawNode::Edges(vec![
+            ("b".to_string(), RawNode::Leaf(Scalar::Int(1))),
+            ("c".to_string(), RawNode::Leaf(Scalar::Int(2))),
+            ("b".to_string(), RawNode::Leaf(Scalar::Int(3))),
+        ]);
+        let doc = Doc::from_raw(raw.clone()).unwrap();
+        assert_eq!(doc.to_raw(), raw);
+        let labels: Vec<String> = doc
+            .root()
+            .edges()
+            .unwrap()
+            .into_iter()
+            .map(|(l, _)| l)
+            .collect();
+        assert_eq!(labels, vec!["b", "c", "b"]);
+    }
+
+    #[test]
+    fn from_raw_leaf_round_trips() {
+        let raw = RawNode::Leaf(Scalar::Str("hi".to_string()));
+        let doc = Doc::from_raw(raw.clone()).unwrap();
+        assert!(doc.root().is_leaf());
+        assert_eq!(doc.to_raw(), raw);
+    }
+
+    #[test]
+    fn from_raw_enforces_the_depth_guard() {
+        fn nest_raw(levels: usize) -> RawNode {
+            let mut n = RawNode::Leaf(Scalar::Int(0));
+            for _ in 0..levels {
+                n = RawNode::Edges(vec![("a".to_string(), n)]);
+            }
+            n
+        }
+        assert!(Doc::from_raw(nest_raw(MAX_DEPTH)).is_ok());
+        let err = Doc::from_raw(nest_raw(MAX_DEPTH + 1)).unwrap_err();
+        assert!(err.message.contains("maximum depth"));
     }
 }

--- a/omnist/src/error.rs
+++ b/omnist/src/error.rs
@@ -45,6 +45,49 @@ impl SchemaError {
     }
 }
 
+/// An OML source string could not be parsed -- raised by
+/// [`crate::oml::read_oml`], mirroring Python's `ParseError` in
+/// `~/dev/omnist/omnist/errors.py`. Carries the same "line N, col N: msg"
+/// convention the Python reference's scanner/parser produce.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[error("line {line}, col {col}: {message}")]
+pub struct ParseError {
+    pub line: usize,
+    pub col: usize,
+    pub message: String,
+}
+
+impl ParseError {
+    pub fn new(line: usize, col: usize, message: impl Into<String>) -> Self {
+        Self {
+            line,
+            col,
+            message: message.into(),
+        }
+    }
+}
+
+/// An in-memory Document could not be written as OML -- raised by
+/// [`crate::oml::write_oml`], mirroring Python's `WriteError`. In practice
+/// the only way this fires is the shared depth guard (OML is otherwise
+/// lossless for every Document -- see the module doc comment on
+/// `crate::oml`).
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[error("{0}")]
+pub struct WriteError(pub String);
+
+impl WriteError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl From<DocumentError> for WriteError {
+    fn from(e: DocumentError) -> Self {
+        WriteError(e.message)
+    }
+}
+
 /// Crate-wide top-level error, mirroring Python's `OmnistError` base class.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum OmnistError {
@@ -52,6 +95,10 @@ pub enum OmnistError {
     Document(#[from] DocumentError),
     #[error(transparent)]
     Schema(#[from] SchemaError),
+    #[error(transparent)]
+    Parse(#[from] ParseError),
+    #[error(transparent)]
+    Write(#[from] WriteError),
 }
 
 #[cfg(test)]
@@ -92,5 +139,36 @@ mod tests {
         let wrapped: OmnistError = schema_err.clone().into();
         assert_eq!(wrapped.to_string(), schema_err.to_string());
         assert!(matches!(wrapped, OmnistError::Schema(ref inner) if *inner == schema_err));
+    }
+
+    #[test]
+    fn parse_error_display_includes_line_col_and_message() {
+        let e = ParseError::new(3, 7, "stray character '@'");
+        assert_eq!(e.to_string(), "line 3, col 7: stray character '@'");
+    }
+
+    #[test]
+    fn omnist_error_wraps_parse_error_transparently() {
+        let e = ParseError::new(1, 1, "boom");
+        let wrapped: OmnistError = e.clone().into();
+        assert_eq!(wrapped.to_string(), e.to_string());
+        assert!(matches!(wrapped, OmnistError::Parse(ref inner) if *inner == e));
+    }
+
+    #[test]
+    fn write_error_display_and_from_document_error() {
+        let e = WriteError::new("nesting exceeds the maximum depth (200)");
+        assert_eq!(e.to_string(), "nesting exceeds the maximum depth (200)");
+        let doc_err = DocumentError::new("$", "nesting exceeds the maximum depth (200)");
+        let from_doc: WriteError = doc_err.into();
+        assert_eq!(from_doc, e);
+    }
+
+    #[test]
+    fn omnist_error_wraps_write_error_transparently() {
+        let e = WriteError::new("boom");
+        let wrapped: OmnistError = e.clone().into();
+        assert_eq!(wrapped.to_string(), e.to_string());
+        assert!(matches!(wrapped, OmnistError::Write(ref inner) if *inner == e));
     }
 }

--- a/omnist/src/lib.rs
+++ b/omnist/src/lib.rs
@@ -1,9 +1,10 @@
 pub mod document;
 pub mod error;
+pub mod oml;
 pub mod osd;
 pub mod schema;
 
-pub use error::{DocumentError, OmnistError, SchemaError};
+pub use error::{DocumentError, OmnistError, ParseError, SchemaError, WriteError};
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/omnist/src/oml.rs
+++ b/omnist/src/oml.rs
@@ -1,0 +1,1131 @@
+//! OML (Omnist Markup Language) -- the native codec for the Document model.
+//!
+//! Ported from `~/dev/omnist/omnist/oml.py` (issue #10). OML is omnist's own
+//! serialization format: every Document -- every ordered, possibly-repeated,
+//! possibly-interleaved edge list, and all seven scalar kinds (`string`,
+//! `integer`, `number`, `boolean`, `date`, `time`, `datetime`) plus `null` --
+//! round-trips through OML exactly, with no adjustment ever needed (unlike
+//! JSON/YAML/TOML/XML).
+//!
+//! This module implements the **OML-Core** grammar in full for both
+//! [`read_oml`] and [`write_oml`], plus the **OML-Extended** raw-string
+//! (`'...'`, E2) and triple-quoted multiline-string (`"""..."""`, E3)
+//! spellings on read only -- [`write_oml`] only ever emits OML-Core
+//! double-quoted strings, matching the Python reference.
+//!
+//! ## Architecture (per issue #1/#10, "architecture freedom")
+//!
+//! Python's reader is a single-pass scanner built around one compiled
+//! "master" regex, deferring line/col computation and scalar-value
+//! construction until actually needed -- a Python-performance-specific
+//! design (see the module's PR #168 for the profile that motivated it), not
+//! a behavioral requirement. This port uses a straightforward hand-written
+//! recursive-descent scanner/parser over `Vec<char>` instead: idiomatic
+//! Rust, and there's no equivalent hot-path reason to defer decoding here.
+//! Observable behavior (parse results, round-trips, error content) matches
+//! the Python reference; exact error wording does not need to.
+//!
+//! ## Node representation
+//!
+//! [`crate::document::RawNode`] -- not [`crate::document::Value`] -- is the
+//! type this codec reads into and writes from. `Value::Object`'s `IndexMap`
+//! can't hold a repeated key, so it only represents "repeated label" as a
+//! *contiguous* run (an array value under one key); OML must round-trip
+//! arbitrary **interleaving** of repeated labels losslessly (its whole
+//! reason for existing -- "no adjustment ever needed"), which only
+//! `RawNode`'s literal edge list can hold exactly.
+//!
+//! ## Depth guard (omnist-ts#37 / omnist-ts#70)
+//!
+//! [`write_oml`] takes a plain, unchecked [`crate::document::RawNode`] --
+//! exactly like Python's `write_oml(node)`, which accepts any hand-built
+//! canonical node, not necessarily one that passed through a depth-checked
+//! builder. So the writer calls the shared
+//! [`crate::document::check_write_depth`] guard itself, at every nesting
+//! level, rather than assuming its input already got checked somewhere
+//! upstream -- the exact bug class omnist-ts#37/#70 were: a writer (or a
+//! second writer) that skipped this because *some* builder happened to
+//! guard depth already.
+//!
+//! ## Temporal literals (issue #10 pitfall list)
+//!
+//! `date`/`time`/`datetime` literals are recognized by their *shape* here
+//! (this module's own scanner), then validated by
+//! [`crate::schema::is_iso_date`]/[`crate::schema::is_iso_time`]/
+//! [`crate::schema::is_iso_datetime`] -- the single shared temporal
+//! shape-check from issue #6, reused rather than re-implemented. A
+//! recognized-but-semantically-invalid literal (`2024-02-30`) is a
+//! `ParseError`, not silently accepted. [`crate::document::Scalar`] has no
+//! native date/time/datetime variant (see `document.rs`'s module doc), so a
+//! valid temporal literal becomes a `Scalar::Str` holding its exact source
+//! spelling, matching [`crate::schema::matches_kind`]'s own convention.
+
+use crate::document::{self, RawNode, Scalar, check_write_depth};
+use crate::error::{ParseError, WriteError};
+use crate::schema::{is_iso_date, is_iso_datetime, is_iso_time};
+
+/// Same security guard as Python's `_MAX_INT_DIGITS`: reject an integer
+/// literal with more than this many digits before ever attempting to
+/// convert it (unbounded-digit int-to-str/str-to-int conversion is
+/// superlinear). `document.rs` has no equivalent constant -- its `Scalar`
+/// uses `i64` (max 19 digits), so the guard would be permanently dead code
+/// there (see that module's doc comment) -- this module is the one place an
+/// arbitrarily-long *digit run* can actually reach the parser (as OML
+/// source text), so the cap lives here instead.
+const MAX_INT_DIGITS: usize = 4300;
+
+// ---------------------------------------------------------------------------
+// Scanner
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq)]
+enum TokKind {
+    Sep,
+    Eof,
+    LBrace,
+    RBrace,
+    LBracket,
+    RBracket,
+    Comma,
+    Colon,
+    /// A quoted/raw/multiline string value, already decoded. Eligible as a
+    /// field label (per the grammar's "a quoted token is always a field
+    /// label" rule) as well as a scalar value.
+    Str(String),
+    /// A recognized-and-semantically-valid date/time/datetime literal, its
+    /// exact source spelling. Deliberately **not** the same variant as
+    /// `Str` -- see the module doc comment: folding these together would
+    /// let `_looks_like_edge` misfire on a bare temporal value followed by
+    /// a stray `:`, treating the date as a label.
+    Temporal(String),
+    /// `[A-Za-z_][A-Za-z0-9_-]*` -- may be `null`/`true`/`false`, a bare
+    /// label, or (as a scalar) a "bare word" error.
+    Ident(String),
+    Int(i64),
+    Float(f64),
+}
+
+struct Scanner {
+    chars: Vec<char>,
+    n: usize,
+    pos: usize,
+}
+
+impl Scanner {
+    fn new(text: &str) -> Self {
+        // Strip a leading UTF-8 BOM, matching the Python reference.
+        let text = text.strip_prefix('\u{feff}').unwrap_or(text);
+        let chars: Vec<char> = text.chars().collect();
+        let n = chars.len();
+        Scanner { chars, n, pos: 0 }
+    }
+
+    fn line_col(&self, pos: usize) -> (usize, usize) {
+        let mut line = 1usize;
+        let mut last_nl: Option<usize> = None;
+        for (i, &c) in self.chars[..pos].iter().enumerate() {
+            if c == '\n' {
+                line += 1;
+                last_nl = Some(i);
+            }
+        }
+        let col = match last_nl {
+            Some(i) => pos - i,
+            None => pos + 1,
+        };
+        (line, col)
+    }
+
+    fn error_at(&self, pos: usize, msg: String) -> ParseError {
+        let (line, col) = self.line_col(pos);
+        ParseError::new(line, col, msg)
+    }
+
+    fn word_boundary_ok(&self, end: usize) -> bool {
+        !self
+            .chars
+            .get(end)
+            .is_some_and(|c| c.is_ascii_alphanumeric() || *c == '-')
+    }
+
+    /// Advance past (and describe) the next significant token.
+    fn next(&mut self) -> Result<(TokKind, usize, usize), ParseError> {
+        loop {
+            let start = self.pos;
+            if self.consume_ws_or_comment_run() {
+                continue;
+            }
+            if self.pos > start {
+                // A run containing a newline/';' was consumed -- SEP.
+                return Ok((TokKind::Sep, start, self.pos));
+            }
+            if self.pos >= self.n {
+                return Ok((TokKind::Eof, self.pos, self.pos));
+            }
+            let c = self.chars[self.pos];
+            return match c {
+                '"' => self.scan_dquote_family(start),
+                '\'' => self.scan_raw_string(start),
+                '{' => self.single(TokKind::LBrace, start),
+                '}' => self.single(TokKind::RBrace, start),
+                '[' => self.single(TokKind::LBracket, start),
+                ']' => self.single(TokKind::RBracket, start),
+                ',' => self.single(TokKind::Comma, start),
+                ':' => self.single(TokKind::Colon, start),
+                '-' => self.scan_minus(start),
+                c if c.is_ascii_digit() => self.scan_digit_start(start),
+                c if c.is_alphabetic() || c == '_' => self.scan_word(start),
+                other => Err(self.error_at(start, format!("stray character {other:?}"))),
+            };
+        }
+    }
+
+    fn single(
+        &mut self,
+        kind: TokKind,
+        start: usize,
+    ) -> Result<(TokKind, usize, usize), ParseError> {
+        self.pos = start + 1;
+        Ok((kind, start, self.pos))
+    }
+
+    /// Consumes one run of `[ \t]`/`#comment`/`\r\n`/`\n`/`;`. Returns
+    /// `true` if the run was pure hspace/comment (no token, caller should
+    /// loop again); on a newline/`;`-bearing run it advances `self.pos` and
+    /// returns `false`, leaving the caller to notice `self.pos` moved and
+    /// emit SEP. A lone `\r` (not immediately followed by `\n`) is *not*
+    /// part of this run -- matches the Python master regex, which only has
+    /// a `\r\n` alternative, never a bare `\r`.
+    fn consume_ws_or_comment_run(&mut self) -> bool {
+        let start = self.pos;
+        let mut saw_sep = false;
+        loop {
+            match self.chars.get(self.pos) {
+                Some(' ') | Some('\t') => self.pos += 1,
+                Some('#') => {
+                    while !matches!(self.chars.get(self.pos), Some('\n') | None) {
+                        self.pos += 1;
+                    }
+                }
+                Some('\r') if self.chars.get(self.pos + 1) == Some(&'\n') => {
+                    self.pos += 2;
+                    saw_sep = true;
+                }
+                Some('\n') => {
+                    self.pos += 1;
+                    saw_sep = true;
+                }
+                Some(';') => {
+                    self.pos += 1;
+                    saw_sep = true;
+                }
+                _ => break,
+            }
+        }
+        self.pos > start && !saw_sep
+    }
+
+    // -- strings ----------------------------------------------------------
+
+    fn scan_dquote_family(&mut self, start: usize) -> Result<(TokKind, usize, usize), ParseError> {
+        if self.chars.get(start + 1) == Some(&'"') && self.chars.get(start + 2) == Some(&'"') {
+            self.scan_multiline(start)
+        } else {
+            self.scan_dquote(start)
+        }
+    }
+
+    fn scan_dquote(&mut self, start: usize) -> Result<(TokKind, usize, usize), ParseError> {
+        let mut i = start + 1;
+        let mut out = String::new();
+        loop {
+            match self.chars.get(i) {
+                None => {
+                    return Err(self.error_at(
+                        start,
+                        "unterminated string (missing closing \")".to_string(),
+                    ));
+                }
+                Some('"') => {
+                    i += 1;
+                    self.pos = i;
+                    return Ok((TokKind::Str(out), start, i));
+                }
+                Some('\\') => {
+                    let (ch, next_i) = self.decode_escape(start, i)?;
+                    out.push_str(&ch);
+                    i = next_i;
+                }
+                Some(&c) if (c as u32) < 0x20 => {
+                    return Err(self.error_at(
+                        start,
+                        format!("control character U+{:04X} in string", c as u32),
+                    ));
+                }
+                Some(&c) => {
+                    out.push(c);
+                    i += 1;
+                }
+            }
+        }
+    }
+
+    fn scan_multiline(&mut self, start: usize) -> Result<(TokKind, usize, usize), ParseError> {
+        let mut i = start + 3;
+        // Opening-newline elision: a single \n or \r\n right after the
+        // """ delimiter is dropped, not part of the value.
+        if self.chars.get(i) == Some(&'\n') {
+            i += 1;
+        } else if self.chars.get(i) == Some(&'\r') && self.chars.get(i + 1) == Some(&'\n') {
+            i += 2;
+        }
+        let mut out = String::new();
+        loop {
+            match self.chars.get(i) {
+                None => {
+                    return Err(self.error_at(
+                        start,
+                        "unterminated multiline string (missing closing \"\"\")".to_string(),
+                    ));
+                }
+                Some('"') => {
+                    let mut run = 0usize;
+                    let mut j = i;
+                    while self.chars.get(j) == Some(&'"') {
+                        run += 1;
+                        j += 1;
+                    }
+                    if run >= 3 {
+                        // Only the first three quotes close the string;
+                        // any beyond that are literal content (mirrors the
+                        // Python reference's `run >= 3` closing rule).
+                        for _ in 0..(run - 3) {
+                            out.push('"');
+                        }
+                        i += run;
+                        self.pos = i;
+                        return Ok((TokKind::Str(out), start, i));
+                    }
+                    for _ in 0..run {
+                        out.push('"');
+                    }
+                    i = j;
+                }
+                Some('\\') => {
+                    let (ch, next_i) = self.decode_escape(start, i)?;
+                    out.push_str(&ch);
+                    i = next_i;
+                }
+                Some(&c) if c == '\t' || c == '\n' || (c as u32) >= 0x20 => {
+                    out.push(c);
+                    i += 1;
+                }
+                Some(&c) => {
+                    return Err(self.error_at(
+                        start,
+                        format!("control character U+{:04X} in multiline string", c as u32),
+                    ));
+                }
+            }
+        }
+    }
+
+    fn scan_raw_string(&mut self, start: usize) -> Result<(TokKind, usize, usize), ParseError> {
+        let mut i = start + 1;
+        loop {
+            match self.chars.get(i) {
+                None => {
+                    return Err(self.error_at(
+                        start,
+                        "unterminated raw string (missing closing ')".to_string(),
+                    ));
+                }
+                Some('\'') => {
+                    let text: String = self.chars[start + 1..i].iter().collect();
+                    i += 1;
+                    self.pos = i;
+                    return Ok((TokKind::Str(text), start, i));
+                }
+                Some(_) => i += 1,
+            }
+        }
+    }
+
+    /// Decode one escape sequence at `self.chars[i] == '\\'`, reporting any
+    /// error at `tok_start` (the enclosing string's opening delimiter), not
+    /// `i` -- matches the Python reference's error-position convention.
+    fn decode_escape(&self, tok_start: usize, i: usize) -> Result<(String, usize), ParseError> {
+        let Some(&c) = self.chars.get(i + 1) else {
+            return Err(self.error_at(tok_start, "unterminated escape sequence".to_string()));
+        };
+        let simple = match c {
+            '"' => Some('"'),
+            '\\' => Some('\\'),
+            '/' => Some('/'),
+            'b' => Some('\u{8}'),
+            'f' => Some('\u{c}'),
+            'n' => Some('\n'),
+            'r' => Some('\r'),
+            't' => Some('\t'),
+            _ => None,
+        };
+        if let Some(ch) = simple {
+            return Ok((ch.to_string(), i + 2));
+        }
+        if c != 'u' {
+            return Err(self.error_at(tok_start, format!("invalid escape \\{c}")));
+        }
+        let cp = self.read_hex4(tok_start, i + 2)?;
+        let j = i + 6;
+        if (0xD800..=0xDBFF).contains(&cp) {
+            let has_low_escape =
+                self.chars.get(j) == Some(&'\\') && self.chars.get(j + 1) == Some(&'u');
+            let low = if has_low_escape {
+                Some(self.read_hex4(tok_start, j + 2)?)
+            } else {
+                None
+            };
+            let unpaired_err = || {
+                self.error_at(
+                    tok_start,
+                    format!(
+                        "unpaired high surrogate \\u{cp:04x} (needs a following low-surrogate \
+                         \\uDC00-\\uDFFF escape)"
+                    ),
+                )
+            };
+            return match low {
+                Some(low) if (0xDC00..=0xDFFF).contains(&low) => {
+                    let combined = 0x10000 + (cp - 0xD800) * 0x400 + (low - 0xDC00);
+                    // A high surrogate (0xD800..=0xDBFF) paired with a low
+                    // surrogate (0xDC00..=0xDFFF) always combines into a
+                    // value in 0x10000..=0x10FFFF -- always a valid Unicode
+                    // scalar value. There's no reachable failure branch to
+                    // test here (see schema.rs's `mandatory_u32` for the
+                    // same "provably safe by the preceding checks"
+                    // pattern); `.expect` keeps this a single
+                    // always-executed line instead of a lazily-evaluated
+                    // error-construction branch coverage would otherwise
+                    // demand a test for.
+                    let ch = char::from_u32(combined)
+                        .expect("surrogate pair math always yields a valid scalar value");
+                    Ok((ch.to_string(), j + 6))
+                }
+                _ => Err(unpaired_err()),
+            };
+        }
+        if (0xDC00..=0xDFFF).contains(&cp) {
+            return Err(self.error_at(tok_start, format!("unpaired low surrogate \\u{cp:04x}")));
+        }
+        // cp is outside the surrogate range (both branches above already
+        // returned), so it's always a valid Unicode scalar value -- see
+        // the `.expect` above for the same reasoning.
+        let ch = char::from_u32(cp)
+            .expect("cp outside the surrogate range is always a valid scalar value");
+        Ok((ch.to_string(), j))
+    }
+
+    fn read_hex4(&self, tok_start: usize, at: usize) -> Result<u32, ParseError> {
+        let hex: String = (0..4)
+            .map(|k| self.chars.get(at + k).copied())
+            .collect::<Option<Vec<char>>>()
+            .unwrap_or_default()
+            .into_iter()
+            .collect();
+        if hex.len() != 4 || !hex.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(self.error_at(
+                tok_start,
+                r"invalid \u escape (need 4 hex digits)".to_string(),
+            ));
+        }
+        Ok(u32::from_str_radix(&hex, 16).expect("validated 4 hex digits"))
+    }
+
+    // -- numbers / temporal literals ---------------------------------------
+
+    fn scan_minus(&mut self, start: usize) -> Result<(TokKind, usize, usize), ParseError> {
+        if self.matches_word(start, "-inf") && self.word_boundary_ok(start + 4) {
+            self.pos = start + 4;
+            return Ok((TokKind::Float(f64::NEG_INFINITY), start, self.pos));
+        }
+        if self
+            .chars
+            .get(start + 1)
+            .is_some_and(|c| c.is_ascii_digit())
+        {
+            return self.scan_number(start);
+        }
+        Err(self.error_at(start, "stray character '-'".to_string()))
+    }
+
+    fn scan_digit_start(&mut self, start: usize) -> Result<(TokKind, usize, usize), ParseError> {
+        if let Some(end) = self.try_datetime(start) {
+            return self.finish_temporal(start, end, TemporalKind::Datetime);
+        }
+        if let Some(end) = self.try_date(start) {
+            return self.finish_temporal(start, end, TemporalKind::Date);
+        }
+        if let Some(end) = self.try_time(start) {
+            return self.finish_temporal(start, end, TemporalKind::Time);
+        }
+        self.scan_number(start)
+    }
+
+    fn finish_temporal(
+        &mut self,
+        start: usize,
+        end: usize,
+        kind: TemporalKind,
+    ) -> Result<(TokKind, usize, usize), ParseError> {
+        let text: String = self.chars[start..end].iter().collect();
+        let valid = match kind {
+            TemporalKind::Date => is_iso_date(&text),
+            TemporalKind::Time => is_iso_time(&text),
+            TemporalKind::Datetime => is_iso_datetime(&text),
+        };
+        if !valid {
+            let label = match kind {
+                TemporalKind::Date => "date",
+                TemporalKind::Time => "time",
+                TemporalKind::Datetime => "datetime",
+            };
+            return Err(self.error_at(end, format!("invalid {label} {text:?}")));
+        }
+        self.pos = end;
+        Ok((TokKind::Temporal(text), start, end))
+    }
+
+    fn digits_from(&self, pos: usize) -> usize {
+        let mut p = pos;
+        while self.chars.get(p).is_some_and(|c| c.is_ascii_digit()) {
+            p += 1;
+        }
+        p
+    }
+
+    fn expect_digits(&self, pos: usize, count: usize) -> Option<usize> {
+        let end = self.digits_from(pos);
+        if end - pos == count { Some(end) } else { None }
+    }
+
+    fn try_date(&self, pos: usize) -> Option<usize> {
+        let mut p = self.expect_digits(pos, 4)?;
+        if self.chars.get(p) != Some(&'-') {
+            return None;
+        }
+        p = self.expect_digits(p + 1, 2)?;
+        if self.chars.get(p) != Some(&'-') {
+            return None;
+        }
+        self.expect_digits(p + 1, 2)
+    }
+
+    fn try_time(&self, pos: usize) -> Option<usize> {
+        let mut p = self.expect_digits(pos, 2)?;
+        if self.chars.get(p) != Some(&':') {
+            return None;
+        }
+        p = self.expect_digits(p + 1, 2)?;
+        if self.chars.get(p) == Some(&':')
+            && let Some(after_secs) = self.expect_digits(p + 1, 2)
+        {
+            p = after_secs;
+            if self.chars.get(p) == Some(&'.') {
+                let frac_end = self.digits_from(p + 1);
+                if frac_end > p + 1 && frac_end - (p + 1) <= 6 {
+                    p = frac_end;
+                }
+            }
+        }
+        if let Some(&sign) = self.chars.get(p)
+            && (sign == '+' || sign == '-')
+            && let Some(after_h) = self.expect_digits(p + 1, 2)
+            && self.chars.get(after_h) == Some(&':')
+            && let Some(after_m) = self.expect_digits(after_h + 1, 2)
+        {
+            p = after_m;
+        }
+        Some(p)
+    }
+
+    fn try_datetime(&self, pos: usize) -> Option<usize> {
+        let d_end = self.try_date(pos)?;
+        if self.chars.get(d_end) != Some(&'T') {
+            return None;
+        }
+        self.try_time(d_end + 1)
+    }
+
+    /// `pos` is a digit or `-` followed by a digit (checked by the caller):
+    /// scans `INTEGER`/`NUMDEC`/`NUMEXP`.
+    fn scan_number(&mut self, start: usize) -> Result<(TokKind, usize, usize), ParseError> {
+        let mut p = start;
+        if self.chars.get(p) == Some(&'-') {
+            p += 1;
+        }
+        let int_start = p;
+        p = self.digits_from(p);
+        debug_assert!(p > int_start, "caller guarantees at least one digit");
+        let mut end = p;
+        let mut is_float = false;
+        let frac_end = if self.chars.get(p) == Some(&'.') {
+            self.digits_from(p + 1)
+        } else {
+            p
+        };
+        if self.chars.get(p) == Some(&'.') && frac_end > p + 1 {
+            p = frac_end;
+            is_float = true;
+            end = self.try_exponent(p).unwrap_or(p);
+        } else if let Some(e) = self.try_exponent(p) {
+            end = e;
+            is_float = true;
+        }
+        let text: String = self.chars[start..end].iter().collect();
+        self.pos = end;
+        if is_float {
+            let v: f64 = text
+                .parse()
+                .map_err(|_| self.error_at(start, format!("invalid number {text:?}")))?;
+            Ok((TokKind::Float(v), start, end))
+        } else {
+            let digits = &text[if text.starts_with('-') { 1 } else { 0 }..];
+            if digits.len() > MAX_INT_DIGITS {
+                return Err(self.error_at(
+                    start,
+                    format!(
+                        "integer literal has {} digits, exceeding the {MAX_INT_DIGITS}-digit \
+                         limit (security: unbounded-digit int-to-str conversion is superlinear)",
+                        digits.len()
+                    ),
+                ));
+            }
+            let v: i64 = text.parse().map_err(|_| {
+                self.error_at(
+                    start,
+                    format!("integer literal {text:?} is out of range for a 64-bit integer"),
+                )
+            })?;
+            Ok((TokKind::Int(v), start, end))
+        }
+    }
+
+    fn try_exponent(&self, pos: usize) -> Option<usize> {
+        if !matches!(self.chars.get(pos), Some('e') | Some('E')) {
+            return None;
+        }
+        let mut q = pos + 1;
+        if matches!(self.chars.get(q), Some('+') | Some('-')) {
+            q += 1;
+        }
+        let dstart = q;
+        q = self.digits_from(q);
+        if q > dstart { Some(q) } else { None }
+    }
+
+    fn matches_word(&self, pos: usize, word: &str) -> bool {
+        word.chars()
+            .enumerate()
+            .all(|(i, c)| self.chars.get(pos + i) == Some(&c))
+    }
+
+    fn scan_word(&mut self, start: usize) -> Result<(TokKind, usize, usize), ParseError> {
+        if self.matches_word(start, "nan") && self.word_boundary_ok(start + 3) {
+            self.pos = start + 3;
+            return Ok((TokKind::Float(f64::NAN), start, self.pos));
+        }
+        if self.matches_word(start, "inf") && self.word_boundary_ok(start + 3) {
+            self.pos = start + 3;
+            return Ok((TokKind::Float(f64::INFINITY), start, self.pos));
+        }
+        let mut p = start + 1;
+        while self
+            .chars
+            .get(p)
+            .is_some_and(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '-')
+        {
+            p += 1;
+        }
+        let text: String = self.chars[start..p].iter().collect();
+        self.pos = p;
+        Ok((TokKind::Ident(text), start, p))
+    }
+}
+
+enum TemporalKind {
+    Date,
+    Time,
+    Datetime,
+}
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+const RESERVED: [&str; 3] = ["null", "true", "false"];
+
+struct Parser {
+    sc: Scanner,
+    kind: TokKind,
+    start: usize,
+    end: usize,
+}
+
+impl Parser {
+    fn new(mut sc: Scanner) -> Result<Self, ParseError> {
+        let (kind, start, end) = sc.next()?;
+        Ok(Parser {
+            sc,
+            kind,
+            start,
+            end,
+        })
+    }
+
+    fn advance(&mut self) -> Result<(TokKind, usize, usize), ParseError> {
+        let (nk, ns, ne) = self.sc.next()?;
+        let cur = (std::mem::replace(&mut self.kind, nk), self.start, self.end);
+        self.start = ns;
+        self.end = ne;
+        Ok(cur)
+    }
+
+    fn skip_sep(&mut self) -> Result<(), ParseError> {
+        while matches!(self.kind, TokKind::Sep) {
+            self.advance()?;
+        }
+        Ok(())
+    }
+
+    fn tok_display(kind: &TokKind, text: &str) -> String {
+        match kind {
+            TokKind::Str(s) => format!("{s:?}"),
+            _ => format!("{text:?}"),
+        }
+    }
+
+    fn parse_document(&mut self) -> Result<RawNode, ParseError> {
+        self.skip_sep()?;
+        let node = if matches!(self.kind, TokKind::Eof) {
+            RawNode::Edges(vec![])
+        } else if matches!(self.kind, TokKind::LBrace) {
+            self.parse_brace_value(0)?
+        } else if self.looks_like_edge() {
+            RawNode::Edges(self.parse_node_edges(0)?)
+        } else {
+            RawNode::Leaf(self.parse_scalar()?)
+        };
+        self.skip_sep()?;
+        if !matches!(self.kind, TokKind::Eof) {
+            let text: String = self.sc.chars[self.start..self.end].iter().collect();
+            return Err(self.sc.error_at(
+                self.start,
+                format!(
+                    "unexpected trailing content after the document body (token {})",
+                    Self::tok_display(&self.kind, &text)
+                ),
+            ));
+        }
+        Ok(node)
+    }
+
+    fn looks_like_edge(&mut self) -> bool {
+        match &self.kind {
+            TokKind::Str(_) => self.peek_is_colon(),
+            TokKind::Ident(text) => {
+                if RESERVED.contains(&text.as_str()) {
+                    false
+                } else {
+                    self.peek_is_colon()
+                }
+            }
+            _ => false,
+        }
+    }
+
+    fn peek_is_colon(&mut self) -> bool {
+        let saved_pos = self.sc.pos;
+        let result = self.sc.next();
+        self.sc.pos = saved_pos;
+        matches!(result, Ok((TokKind::Colon, _, _)))
+    }
+
+    fn parse_node_edges(&mut self, depth: usize) -> Result<Vec<(String, RawNode)>, ParseError> {
+        let mut edges = Vec::new();
+        self.skip_sep()?;
+        while !matches!(self.kind, TokKind::RBrace | TokKind::Eof) {
+            let label = self.parse_label()?;
+            let (colon_kind, colon_start, colon_end) = self.advance()?;
+            if !matches!(colon_kind, TokKind::Colon) {
+                let text: String = self.sc.chars[colon_start..colon_end].iter().collect();
+                return Err(self.sc.error_at(
+                    colon_start,
+                    format!(
+                        "expected ':' after label {label:?}, got {}",
+                        Self::tok_display(&colon_kind, &text)
+                    ),
+                ));
+            }
+            if matches!(self.kind, TokKind::LBracket) {
+                for element in self.parse_array(depth)? {
+                    edges.push((label.clone(), element));
+                }
+            } else {
+                edges.push((label, self.parse_value(depth)?));
+            }
+            if matches!(self.kind, TokKind::RBrace | TokKind::Eof) {
+                break;
+            }
+            if !matches!(self.kind, TokKind::Sep) {
+                let text: String = self.sc.chars[self.start..self.end].iter().collect();
+                return Err(self.sc.error_at(
+                    self.start,
+                    format!(
+                        "expected a separator (newline or ';') or '}}', got {}",
+                        Self::tok_display(&self.kind, &text)
+                    ),
+                ));
+            }
+            self.skip_sep()?;
+        }
+        Ok(edges)
+    }
+
+    fn parse_label(&mut self) -> Result<String, ParseError> {
+        let (kind, start, end) = self.advance()?;
+        match kind {
+            TokKind::Str(s) => Ok(s),
+            TokKind::Ident(text) => {
+                if RESERVED.contains(&text.as_str()) {
+                    Err(self.sc.error_at(
+                        start,
+                        format!(
+                            "{text:?} is a reserved word and cannot be a bare label; quote it: \
+                             \"{text}\""
+                        ),
+                    ))
+                } else {
+                    Ok(text)
+                }
+            }
+            other => {
+                let text: String = self.sc.chars[start..end].iter().collect();
+                Err(self.sc.error_at(
+                    start,
+                    format!("expected a label, got {}", Self::tok_display(&other, &text)),
+                ))
+            }
+        }
+    }
+
+    fn parse_value(&mut self, depth: usize) -> Result<RawNode, ParseError> {
+        if matches!(self.kind, TokKind::LBrace) {
+            self.parse_brace_value(depth)
+        } else {
+            Ok(RawNode::Leaf(self.parse_scalar()?))
+        }
+    }
+
+    fn parse_brace_value(&mut self, depth: usize) -> Result<RawNode, ParseError> {
+        if depth + 1 > document::MAX_DEPTH {
+            return Err(ParseError::new(
+                0,
+                0,
+                format!(
+                    "nesting exceeds the maximum depth ({})",
+                    document::MAX_DEPTH
+                ),
+            ));
+        }
+        self.advance()?; // consume '{'
+        self.skip_sep()?;
+        let edges = self.parse_node_edges(depth + 1)?;
+        self.skip_sep()?;
+        let (close_kind, close_start, close_end) = self.advance()?;
+        if !matches!(close_kind, TokKind::RBrace) {
+            let text: String = self.sc.chars[close_start..close_end].iter().collect();
+            return Err(self.sc.error_at(
+                close_start,
+                format!(
+                    "expected '}}', got {}",
+                    Self::tok_display(&close_kind, &text)
+                ),
+            ));
+        }
+        Ok(RawNode::Edges(edges))
+    }
+
+    fn parse_array(&mut self, depth: usize) -> Result<Vec<RawNode>, ParseError> {
+        let open_start = self.start;
+        self.advance()?; // consume '['
+        self.skip_sep()?;
+        if matches!(self.kind, TokKind::RBracket) {
+            return Err(self
+                .sc
+                .error_at(open_start, "empty array is not allowed".to_string()));
+        }
+        let mut elements = Vec::new();
+        loop {
+            if matches!(self.kind, TokKind::LBracket) {
+                return Err(self.sc.error_at(
+                    self.start,
+                    "nested array is not allowed (arrays may only contain scalars, null, or \
+                     brace subtrees)"
+                        .to_string(),
+                ));
+            }
+            elements.push(self.parse_value(depth)?);
+            self.skip_sep()?;
+            if matches!(self.kind, TokKind::Comma) {
+                self.advance()?;
+                self.skip_sep()?;
+                if matches!(self.kind, TokKind::RBracket) {
+                    break;
+                }
+                continue;
+            }
+            break;
+        }
+        let (close_kind, close_start, close_end) = self.advance()?;
+        if !matches!(close_kind, TokKind::RBracket) {
+            let text: String = self.sc.chars[close_start..close_end].iter().collect();
+            return Err(self.sc.error_at(
+                close_start,
+                format!(
+                    "expected ',' or ']' in array, got {}",
+                    Self::tok_display(&close_kind, &text)
+                ),
+            ));
+        }
+        Ok(elements)
+    }
+
+    fn parse_scalar(&mut self) -> Result<Scalar, ParseError> {
+        let (kind, start, end) = self.advance()?;
+        match kind {
+            TokKind::Str(s) | TokKind::Temporal(s) => Ok(Scalar::Str(s)),
+            TokKind::Int(i) => Ok(Scalar::Int(i)),
+            TokKind::Float(f) => Ok(Scalar::Float(f)),
+            TokKind::Ident(text) => match text.as_str() {
+                "null" => Ok(Scalar::Null),
+                "true" => Ok(Scalar::Bool(true)),
+                "false" => Ok(Scalar::Bool(false)),
+                _ => Err(self.sc.error_at(
+                    start,
+                    format!("bare word {text:?} is not a valid value here; strings must be quoted"),
+                )),
+            },
+            other => {
+                let text: String = self.sc.chars[start..end].iter().collect();
+                Err(self.sc.error_at(
+                    start,
+                    format!("expected a value, got {}", Self::tok_display(&other, &text)),
+                ))
+            }
+        }
+    }
+}
+
+/// Parse OML source into a canonical [`RawNode`] (edge-list or leaf).
+///
+/// Supports the full OML-Core grammar, plus OML-Extended raw-string (`'...'`)
+/// and triple-quoted multiline-string (`"""..."""`) spellings -- see the
+/// module doc comment.
+pub fn read_oml(text: &str) -> Result<RawNode, ParseError> {
+    let sc = Scanner::new(text);
+    let mut parser = Parser::new(sc)?;
+    parser.parse_document()
+}
+
+// ---------------------------------------------------------------------------
+// Writer (OML-Core only)
+// ---------------------------------------------------------------------------
+
+/// Render a canonical [`RawNode`] as OML-Core source, pretty-printed with
+/// `indent` spaces per nesting level.
+///
+/// OML is lossless for every Document: there's never an adjustment to
+/// report, so there's no `strict=`/report machinery -- writing always
+/// succeeds, unless the input itself nests deeper than
+/// [`crate::document::MAX_DEPTH`] (see the module doc comment on the depth
+/// guard).
+pub fn write_oml(node: &RawNode, indent: usize) -> Result<String, WriteError> {
+    match node {
+        RawNode::Leaf(s) => Ok(write_scalar(s)),
+        RawNode::Edges(edges) => write_edges(edges, 0, indent, 0),
+    }
+}
+
+/// Single-line ("compact") rendering: edges joined by `"; "`, no
+/// newlines/padding. Mirrors Python's `write_oml(..., indent=None)`. Both
+/// forms round-trip through [`read_oml`].
+pub fn write_oml_compact(node: &RawNode) -> Result<String, WriteError> {
+    match node {
+        RawNode::Leaf(s) => Ok(write_scalar(s)),
+        RawNode::Edges(edges) => write_edges_compact(edges, 0),
+    }
+}
+
+/// `node_depth` is *this edges list's own* depth, matching
+/// `document.rs`'s `push_raw`/`build_node` convention exactly: the guard is
+/// checked for every node (container *and* leaf) at its own depth, with a
+/// child one level deeper than its parent container -- not just at
+/// container boundaries. This is what makes the boundary case line up with
+/// `document.rs`'s own tests (a leaf at exactly `MAX_DEPTH` is accepted;
+/// one past it is rejected), and is the literal fix for the omnist-ts#37/
+/// #70 bug class: every depth-costing step is guarded, not only "one
+/// nesting level" as a proxy for it.
+fn write_edges(
+    edges: &[(String, RawNode)],
+    depth: usize,
+    indent: usize,
+    node_depth: usize,
+) -> Result<String, WriteError> {
+    check_write_depth(node_depth, "$")?;
+    let pad = " ".repeat(indent * depth);
+    let mut lines = Vec::with_capacity(edges.len());
+    for (label, child) in edges {
+        let lab = write_label(label);
+        match child {
+            RawNode::Edges(inner) if inner.is_empty() => {
+                check_write_depth(node_depth + 1, "$")?;
+                lines.push(format!("{pad}{lab}: {{}}"));
+            }
+            RawNode::Edges(inner) => {
+                let body = write_edges(inner, depth + 1, indent, node_depth + 1)?;
+                lines.push(format!("{pad}{lab}: {{\n{body}\n{pad}}}"));
+            }
+            RawNode::Leaf(s) => {
+                check_write_depth(node_depth + 1, "$")?;
+                lines.push(format!("{pad}{lab}: {}", write_scalar(s)));
+            }
+        }
+    }
+    Ok(lines.join("\n"))
+}
+
+fn write_edges_compact(
+    edges: &[(String, RawNode)],
+    node_depth: usize,
+) -> Result<String, WriteError> {
+    check_write_depth(node_depth, "$")?;
+    let mut parts = Vec::with_capacity(edges.len());
+    for (label, child) in edges {
+        let lab = write_label(label);
+        match child {
+            RawNode::Edges(inner) if inner.is_empty() => {
+                check_write_depth(node_depth + 1, "$")?;
+                parts.push(format!("{lab}: {{}}"));
+            }
+            RawNode::Edges(inner) => {
+                let body = write_edges_compact(inner, node_depth + 1)?;
+                parts.push(format!("{lab}: {{ {body} }}"));
+            }
+            RawNode::Leaf(s) => {
+                check_write_depth(node_depth + 1, "$")?;
+                parts.push(format!("{lab}: {}", write_scalar(s)));
+            }
+        }
+    }
+    Ok(parts.join("; "))
+}
+
+fn is_bare_label(label: &str) -> bool {
+    let mut chars = label.chars();
+    match chars.next() {
+        Some(c) if c.is_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    // \Z (Rust: full match, no trailing-newline-before-end laxity) --
+    // matches every remaining char strictly, unlike a `$`-style anchor that
+    // would also accept a trailing "\n" (that subtlety is why the Python
+    // reference uses `\Z`, not `$`, for this pattern -- see oml.py).
+    chars.all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+        && !RESERVED.contains(&label)
+        && label != "nan"
+        && label != "inf"
+}
+
+fn write_label(label: &str) -> String {
+    if is_bare_label(label) {
+        label.to_string()
+    } else {
+        write_string(label)
+    }
+}
+
+fn write_scalar(v: &Scalar) -> String {
+    match v {
+        Scalar::Null => "null".to_string(),
+        Scalar::Bool(b) => b.to_string(),
+        Scalar::Int(i) => i.to_string(),
+        Scalar::Float(f) => write_float(*f),
+        Scalar::Str(s) => write_str_scalar(s),
+    }
+}
+
+/// A `Scalar::Str` shaped like a valid date/time/datetime (per the same
+/// [`is_iso_date`]/[`is_iso_time`]/[`is_iso_datetime`] shape-check the
+/// reader uses) writes bare, matching the reader's own convention that a
+/// temporal literal *is* a `Scalar::Str` holding its exact spelling (see the
+/// module doc comment -- `document::Scalar` has no separate temporal
+/// variant). This is the omnist-ts#52 fix: `read_oml("a: 12:00")` produces
+/// `Scalar::Str("12:00")`, and writing that value back must reproduce the
+/// bare `12:00` spelling, not `"12:00"` (which would silently turn a time
+/// into a plain string on the next read).
+fn write_str_scalar(s: &str) -> String {
+    if is_iso_datetime(s) || is_iso_date(s) || is_iso_time(s) {
+        s.to_string()
+    } else {
+        write_string(s)
+    }
+}
+
+/// Renders `v` so it always re-tokenizes as `NUMDEC`/`NEGINF`/`NANLIT`/
+/// `POSINF` on read, never `INTEGER` -- an integer-valued float (`1.0`)
+/// must keep a decimal point on write (Rust's `Display` for `f64` omits the
+/// trailing `.0`, unlike Python's `repr()`), or the OML round-trip would
+/// silently reclassify it as `Scalar::Int` on read-back.
+fn write_float(v: f64) -> String {
+    if v.is_nan() {
+        return "nan".to_string();
+    }
+    if v.is_infinite() {
+        return if v < 0.0 {
+            "-inf".to_string()
+        } else {
+            "inf".to_string()
+        };
+    }
+    let s = format!("{v}");
+    if s.contains('.') || s.contains('e') || s.contains('E') {
+        s
+    } else {
+        format!("{s}.0")
+    }
+}
+
+/// Escapes every occurrence of a special character -- a per-char loop, not
+/// a find/replace pass, so this can never under-sanitize by only touching
+/// the *first* match (the general "regex-in-a-writer" risk flagged by
+/// issue #10's omnist-ts#36-equivalent note).
+fn write_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+#[cfg(test)]
+mod tests;

--- a/omnist/src/oml.rs
+++ b/omnist/src/oml.rs
@@ -584,9 +584,18 @@ impl Scanner {
         let text: String = self.chars[start..end].iter().collect();
         self.pos = end;
         if is_float {
+            // `text` was built exclusively from ASCII digits, an optional
+            // leading `-`, an optional `.digits` fraction, and an optional
+            // `e`/`E`[+-]digits exponent (see `digits_from`/`try_exponent`
+            // above). That shape always parses as an `f64` -- `f64::from_str`
+            // never errors on this grammar; on overflow it yields +/-inf
+            // rather than `Err`. A fallible `map_err` here is therefore dead
+            // code that `cargo llvm-cov` correctly flags as unreachable, so
+            // it's replaced with an `expect` documenting the invariant
+            // instead of an uncoverable error branch.
             let v: f64 = text
                 .parse()
-                .map_err(|_| self.error_at(start, format!("invalid number {text:?}")))?;
+                .expect("scanner only emits float-shaped digit/exponent text, which f64::from_str always parses");
             Ok((TokKind::Float(v), start, end))
         } else {
             let digits = &text[if text.starts_with('-') { 1 } else { 0 }..];

--- a/omnist/src/oml/tests.rs
+++ b/omnist/src/oml/tests.rs
@@ -1,0 +1,933 @@
+use super::*;
+use crate::document::{Doc, Value};
+use indexmap::IndexMap;
+
+fn obj(pairs: &[(&str, Value)]) -> Value {
+    let mut m = IndexMap::new();
+    for (k, v) in pairs {
+        m.insert((*k).to_string(), v.clone());
+    }
+    Value::Object(m)
+}
+
+fn roundtrip_value(v: &Value) {
+    let doc = Doc::of(v).unwrap();
+    let raw = doc.to_raw();
+    let text = write_oml(&raw, 2).unwrap();
+    let parsed = read_oml(&text).unwrap();
+    let doc2 = Doc::from_raw(parsed).unwrap();
+    assert!(
+        doc.eq_doc(&doc2),
+        "round trip mismatch for {v:?}\n--- OML ---\n{text}"
+    );
+}
+
+// -- scalar round trips (every kind) ----------------------------------------
+
+#[test]
+fn string_round_trips() {
+    roundtrip_value(&obj(&[("a", Value::Str("hello world".into()))]));
+}
+
+#[test]
+fn string_with_escapes_round_trips() {
+    roundtrip_value(&obj(&[(
+        "a",
+        Value::Str("quote:\" backslash:\\ nl:\n cr:\r tab:\t ctrl:\u{1}".into()),
+    )]));
+}
+
+#[test]
+fn integer_round_trips_positive_and_negative() {
+    roundtrip_value(&obj(&[
+        ("a", Value::Int(42)),
+        ("b", Value::Int(-42)),
+        ("c", Value::Int(0)),
+    ]));
+}
+
+#[test]
+fn number_round_trips_decimal_and_whole_valued_float() {
+    roundtrip_value(&obj(&[
+        ("a", Value::Float(3.15)),
+        ("b", Value::Float(1.0)),
+        ("c", Value::Float(-2.0)),
+        ("d", Value::Float(1e10)),
+    ]));
+}
+
+#[test]
+fn number_round_trips_nan_and_infinities() {
+    let doc = Doc::of(&obj(&[
+        ("a", Value::Float(f64::NAN)),
+        ("b", Value::Float(f64::INFINITY)),
+        ("c", Value::Float(f64::NEG_INFINITY)),
+    ]))
+    .unwrap();
+    let text = write_oml(&doc.to_raw(), 2).unwrap();
+    assert!(text.contains("a: nan"));
+    assert!(text.contains("b: inf"));
+    assert!(text.contains("c: -inf"));
+    let parsed = Doc::from_raw(read_oml(&text).unwrap()).unwrap();
+    let root = parsed.root();
+    assert!(matches!(
+        root.child("a").unwrap().value().unwrap(),
+        crate::document::Scalar::Float(f) if f.is_nan()
+    ));
+    assert!(matches!(
+        root.child("b").unwrap().value().unwrap(),
+        crate::document::Scalar::Float(f) if f.is_infinite() && *f > 0.0
+    ));
+    assert!(matches!(
+        root.child("c").unwrap().value().unwrap(),
+        crate::document::Scalar::Float(f) if f.is_infinite() && *f < 0.0
+    ));
+}
+
+#[test]
+fn boolean_round_trips() {
+    roundtrip_value(&obj(&[("a", Value::Bool(true)), ("b", Value::Bool(false))]));
+}
+
+#[test]
+fn null_round_trips() {
+    roundtrip_value(&obj(&[("a", Value::Null)]));
+}
+
+#[test]
+fn date_round_trips() {
+    roundtrip_value(&obj(&[("a", Value::Str("2024-01-01".into()))]));
+}
+
+#[test]
+fn time_round_trips_with_and_without_seconds_and_fraction() {
+    roundtrip_value(&obj(&[
+        ("a", Value::Str("12:00:00".into())),
+        ("b", Value::Str("12:00".into())),
+        ("c", Value::Str("12:00:00.123456".into())),
+    ]));
+}
+
+#[test]
+fn datetime_round_trips_with_and_without_utc_offset() {
+    roundtrip_value(&obj(&[
+        ("a", Value::Str("2024-01-01T12:00:00".into())),
+        ("b", Value::Str("2024-01-01T12:00:00+02:00".into())),
+        ("c", Value::Str("2024-01-01T12:00:00-05:30".into())),
+    ]));
+}
+
+#[test]
+fn nested_object_round_trips() {
+    roundtrip_value(&obj(&[(
+        "a",
+        obj(&[("b", Value::Int(1)), ("c", Value::Str("x".into()))]),
+    )]));
+}
+
+#[test]
+fn repeated_label_contiguous_round_trips() {
+    roundtrip_value(&obj(&[(
+        "tag",
+        Value::Array(vec![Value::Str("x".into()), Value::Str("y".into())]),
+    )]));
+}
+
+#[test]
+fn empty_document_round_trips() {
+    let doc = Doc::from_raw(RawNode::Edges(vec![])).unwrap();
+    let text = write_oml(&doc.to_raw(), 2).unwrap();
+    assert_eq!(text, "");
+    let parsed = Doc::from_raw(read_oml(&text).unwrap()).unwrap();
+    assert!(doc.eq_doc(&parsed));
+}
+
+#[test]
+fn bare_top_level_scalar_round_trips() {
+    let doc = Doc::of(&Value::Int(7)).unwrap();
+    let text = write_oml(&doc.to_raw(), 2).unwrap();
+    assert_eq!(text, "7");
+    let parsed = Doc::from_raw(read_oml(&text).unwrap()).unwrap();
+    assert!(doc.eq_doc(&parsed));
+}
+
+// -- interleaved repeated labels: the case Value/IndexMap cannot represent --
+
+#[test]
+fn interleaved_repeated_labels_round_trip_exactly_via_raw_node() {
+    let raw = RawNode::Edges(vec![
+        (
+            "b".to_string(),
+            RawNode::Leaf(crate::document::Scalar::Int(1)),
+        ),
+        (
+            "c".to_string(),
+            RawNode::Leaf(crate::document::Scalar::Int(2)),
+        ),
+        (
+            "b".to_string(),
+            RawNode::Leaf(crate::document::Scalar::Int(3)),
+        ),
+    ]);
+    let text = write_oml(&raw, 2).unwrap();
+    assert_eq!(text, "b: 1\nc: 2\nb: 3");
+    let parsed = read_oml(&text).unwrap();
+    assert_eq!(parsed, raw);
+}
+
+// -- the four TS-bug-derived regressions ------------------------------------
+
+// omnist-ts#37 / #70: write_oml must call the shared depth guard itself.
+#[test]
+fn write_oml_calls_the_shared_depth_guard() {
+    fn nest_raw(levels: usize) -> RawNode {
+        let mut n = RawNode::Leaf(crate::document::Scalar::Int(0));
+        for _ in 0..levels {
+            n = RawNode::Edges(vec![("a".to_string(), n)]);
+        }
+        n
+    }
+    // At exactly MAX_DEPTH it's accepted (boundary, matches document.rs's
+    // own "reject only depth > MAX_DEPTH" convention).
+    assert!(write_oml(&nest_raw(document::MAX_DEPTH), 2).is_ok());
+    // One past it, write_oml must reject on its own -- this RawNode was
+    // never passed through Doc::from_raw's guarded construction, so if
+    // write_oml didn't call check_write_depth itself, this would write
+    // an over-deep tree with no error, byte-identical to the omnist-ts
+    // bug (a writer trusting an upstream check that never ran).
+    let err = write_oml(&nest_raw(document::MAX_DEPTH + 1), 2).unwrap_err();
+    assert!(err.to_string().contains("maximum depth"));
+    // Same guard, compact writer entry point.
+    let err2 = write_oml_compact(&nest_raw(document::MAX_DEPTH + 1)).unwrap_err();
+    assert!(err2.to_string().contains("maximum depth"));
+}
+
+// omnist-ts#51: writeOml erased a datetime UTC offset.
+#[test]
+fn write_oml_preserves_datetime_utc_offset_exactly() {
+    let raw = RawNode::Edges(vec![(
+        "meeting".to_string(),
+        RawNode::Leaf(crate::document::Scalar::Str(
+            "2024-06-01T09:30:00+02:00".to_string(),
+        )),
+    )]);
+    let text = write_oml(&raw, 2).unwrap();
+    assert!(
+        text.contains("+02:00"),
+        "offset must survive the write unchanged: {text}"
+    );
+    let parsed = read_oml(&text).unwrap();
+    assert_eq!(parsed, raw);
+}
+
+// omnist-ts#52: a bare TIME literal did not round-trip (became a quoted
+// string on write-then-read).
+#[test]
+fn bare_time_literal_round_trips_as_a_time_not_a_quoted_string() {
+    let raw = RawNode::Edges(vec![(
+        "a".to_string(),
+        RawNode::Leaf(crate::document::Scalar::Str("12:00".to_string())),
+    )]);
+    let text = write_oml(&raw, 2).unwrap();
+    // Must write as a bare, unquoted time literal, not `"12:00"`.
+    assert_eq!(text, "a: 12:00");
+    let parsed = read_oml(&text).unwrap();
+    assert_eq!(parsed, raw);
+}
+
+// omnist-ts#36-equivalent: writer escaping must be all-occurrences, not
+// first-match-only (a non-global regex-style replace would under-sanitize).
+#[test]
+fn string_escaping_is_all_occurrences_not_first_match_only() {
+    let s = "a\"b\"c\"d\\e\\f";
+    let written = write_scalar(&crate::document::Scalar::Str(s.to_string()));
+    assert_eq!(written, r#""a\"b\"c\"d\\e\\f""#);
+    // Every quote and every backslash escaped -- not just the first of each.
+    assert_eq!(written.matches("\\\"").count(), 3);
+    assert_eq!(written.matches("\\\\").count(), 2);
+}
+
+// -- malformed input / error positions --------------------------------------
+
+#[test]
+fn stray_character_reports_position() {
+    let err = read_oml("a: 1\n@").unwrap_err();
+    assert!(err.message.contains("stray character"));
+    assert_eq!(err.line, 2);
+}
+
+#[test]
+fn unterminated_string_is_an_error() {
+    let err = read_oml("a: \"unterminated").unwrap_err();
+    assert!(err.message.contains("unterminated string"));
+}
+
+#[test]
+fn unterminated_raw_string_is_an_error() {
+    let err = read_oml("a: 'unterminated").unwrap_err();
+    assert!(err.message.contains("unterminated raw string"));
+}
+
+#[test]
+fn unterminated_multiline_string_is_an_error() {
+    let err = read_oml("a: \"\"\"unterminated").unwrap_err();
+    assert!(err.message.contains("unterminated multiline string"));
+}
+
+#[test]
+fn control_character_in_string_is_rejected() {
+    let err = read_oml("a: \"bad\u{1}char\"").unwrap_err();
+    assert!(err.message.contains("control character"));
+}
+
+#[test]
+fn control_character_in_multiline_string_is_rejected() {
+    let err = read_oml("a: \"\"\"bad\u{1}char\"\"\"").unwrap_err();
+    assert!(err.message.contains("control character"));
+}
+
+#[test]
+fn bare_word_is_rejected_as_a_value() {
+    let err = read_oml("a: bareword").unwrap_err();
+    assert!(err.message.contains("bare word"));
+}
+
+#[test]
+fn reserved_word_cannot_be_a_bare_label() {
+    // At the very top of a document, `null` parses as the null scalar
+    // (looks_like_edge deliberately excludes reserved words -- matching
+    // Python's `_looks_like_edge`), so the reserved-word-as-label check
+    // only fires once the parser is unambiguously in edge/label position,
+    // e.g. inside a `{ }` block.
+    let err = read_oml("a: { null: 1 }").unwrap_err();
+    assert!(err.message.contains("reserved word"));
+}
+
+#[test]
+fn invalid_date_reports_a_clear_error() {
+    let err = read_oml("a: 2024-02-30").unwrap_err();
+    assert!(err.message.contains("invalid date"));
+}
+
+#[test]
+fn invalid_time_reports_a_clear_error() {
+    let err = read_oml("a: 25:00:00").unwrap_err();
+    assert!(err.message.contains("invalid time"));
+}
+
+#[test]
+fn invalid_datetime_reports_a_clear_error() {
+    let err = read_oml("a: 2024-13-01T12:00:00").unwrap_err();
+    assert!(err.message.contains("invalid datetime"));
+}
+
+#[test]
+fn empty_array_is_rejected() {
+    let err = read_oml("a: []").unwrap_err();
+    assert!(err.message.contains("empty array"));
+}
+
+#[test]
+fn nested_array_is_rejected() {
+    let err = read_oml("a: [[1]]").unwrap_err();
+    assert!(err.message.contains("nested array"));
+}
+
+#[test]
+fn missing_colon_after_label_reports_position() {
+    // At the document's very top level, "a 1" doesn't look like an edge
+    // attempt at all (looks_like_edge needs a colon right after the first
+    // token, which isn't there), so "a" alone is read as a bare-word-value
+    // error instead. The "expected ':'" error is unambiguous once already
+    // inside a `{ }` block, where a label is mandatory.
+    let err = read_oml("r: { a 1 }").unwrap_err();
+    assert!(err.message.contains("expected ':'"));
+}
+
+#[test]
+fn missing_closing_brace_is_an_error() {
+    let err = read_oml("a: { b: 1").unwrap_err();
+    assert!(err.message.contains("expected '}'"));
+}
+
+#[test]
+fn missing_separator_between_edges_is_an_error() {
+    let err = read_oml("a: 1 b: 2").unwrap_err();
+    assert!(err.message.contains("expected a separator"));
+}
+
+#[test]
+fn trailing_content_after_document_body_is_an_error() {
+    let err = read_oml("1 2").unwrap_err();
+    assert!(err.message.contains("unexpected trailing content"));
+}
+
+#[test]
+fn unquoted_field_label_must_be_a_valid_ident_or_string() {
+    let err = read_oml("a: 1\n5: 2").unwrap_err();
+    assert!(
+        err.message.contains("unexpected trailing content") || err.message.contains("expected")
+    );
+}
+
+#[test]
+fn integer_digit_cap_is_enforced() {
+    let digits = "1".repeat(MAX_INT_DIGITS + 1);
+    let src = format!("a: {digits}");
+    let err = read_oml(&src).unwrap_err();
+    assert!(err.message.contains("digit"));
+    assert!(err.message.contains("4300"));
+}
+
+#[test]
+fn integer_at_the_digit_cap_boundary_is_accepted_by_the_scanner_even_if_i64_overflows() {
+    // Exactly MAX_INT_DIGITS digits passes the cap check; i64 can't hold a
+    // 4300-digit number, so this is a distinct, later error -- proving the
+    // cap and the i64-range check are two separate failure modes.
+    let digits = "1".repeat(MAX_INT_DIGITS);
+    let src = format!("a: {digits}");
+    let err = read_oml(&src).unwrap_err();
+    assert!(err.message.contains("out of range"));
+}
+
+#[test]
+fn integer_cap_does_not_false_positive_on_a_long_identifier() {
+    // A guard-against-false-positives check (issue #10): an identifier
+    // that merely *contains* a long digit run is not an INTEGER token at
+    // all (IDENT must start with a letter/underscore), so the cap must
+    // never fire on it.
+    let ident = format!("x{}", "1".repeat(MAX_INT_DIGITS + 5));
+    let err = read_oml(&format!("a: {ident}")).unwrap_err();
+    assert!(err.message.contains("bare word"));
+    assert!(!err.message.contains("digit"));
+}
+
+#[test]
+fn out_of_range_integer_reports_a_clear_error() {
+    let err = read_oml("a: 99999999999999999999").unwrap_err();
+    assert!(err.message.contains("out of range"));
+}
+
+#[test]
+fn invalid_unicode_escape_is_rejected() {
+    let err = read_oml(r#"a: "\uZZZZ""#).unwrap_err();
+    assert!(err.message.contains(r"invalid \u escape"));
+}
+
+#[test]
+fn unpaired_high_surrogate_is_rejected() {
+    let err = read_oml(r#"a: "\ud800""#).unwrap_err();
+    assert!(err.message.contains("unpaired high surrogate"));
+}
+
+#[test]
+fn unpaired_low_surrogate_is_rejected() {
+    let err = read_oml(r#"a: "\udc00""#).unwrap_err();
+    assert!(err.message.contains("unpaired low surrogate"));
+}
+
+#[test]
+fn valid_surrogate_pair_decodes_to_the_combined_codepoint() {
+    // U+1F600 (grinning face) as a UTF-16 surrogate pair.
+    let node = read_oml(r#"a: "😀""#).unwrap();
+    match node {
+        RawNode::Edges(edges) => {
+            assert_eq!(edges.len(), 1);
+            match &edges[0].1 {
+                RawNode::Leaf(crate::document::Scalar::Str(s)) => {
+                    assert_eq!(s, "\u{1F600}");
+                }
+                other => panic!("expected a string leaf, got {other:?}"),
+            }
+        }
+        other => panic!("expected edges, got {other:?}"),
+    }
+}
+
+#[test]
+fn invalid_escape_character_is_rejected() {
+    let err = read_oml(r#"a: "\q""#).unwrap_err();
+    assert!(err.message.contains("invalid escape"));
+}
+
+#[test]
+fn unterminated_escape_sequence_is_rejected() {
+    let err = read_oml("a: \"\\").unwrap_err();
+    assert!(err.message.contains("unterminated escape"));
+}
+
+// -- OML-Extended on read: raw strings (E2) and triple-quoted (E3) ---------
+
+#[test]
+fn raw_string_e2_reads_with_no_escape_processing() {
+    let node = read_oml(r"a: 'no \n escapes here \\'").unwrap();
+    match node {
+        RawNode::Edges(edges) => match &edges[0].1 {
+            RawNode::Leaf(crate::document::Scalar::Str(s)) => {
+                assert_eq!(s, r"no \n escapes here \\");
+            }
+            other => panic!("expected a string leaf, got {other:?}"),
+        },
+        other => panic!("expected edges, got {other:?}"),
+    }
+}
+
+#[test]
+fn triple_quoted_multiline_e3_strips_opening_newline() {
+    let node = read_oml("a: \"\"\"\nline one\nline two\"\"\"").unwrap();
+    match node {
+        RawNode::Edges(edges) => match &edges[0].1 {
+            RawNode::Leaf(crate::document::Scalar::Str(s)) => {
+                assert_eq!(s, "line one\nline two");
+            }
+            other => panic!("expected a string leaf, got {other:?}"),
+        },
+        other => panic!("expected edges, got {other:?}"),
+    }
+}
+
+#[test]
+fn triple_quoted_multiline_e3_allows_embedded_quotes_up_to_two() {
+    let node = read_oml("a: \"\"\"has \"\" two quotes\"\"\"").unwrap();
+    match node {
+        RawNode::Edges(edges) => match &edges[0].1 {
+            RawNode::Leaf(crate::document::Scalar::Str(s)) => {
+                assert_eq!(s, "has \"\" two quotes");
+            }
+            other => panic!("expected a string leaf, got {other:?}"),
+        },
+        other => panic!("expected edges, got {other:?}"),
+    }
+}
+
+// -- writer form details ----------------------------------------------------
+
+#[test]
+fn write_oml_compact_joins_edges_with_semicolons() {
+    let raw = RawNode::Edges(vec![
+        (
+            "a".to_string(),
+            RawNode::Leaf(crate::document::Scalar::Int(1)),
+        ),
+        (
+            "b".to_string(),
+            RawNode::Leaf(crate::document::Scalar::Int(2)),
+        ),
+    ]);
+    assert_eq!(write_oml_compact(&raw).unwrap(), "a: 1; b: 2");
+}
+
+#[test]
+fn write_oml_pretty_indents_nested_objects() {
+    let raw = RawNode::Edges(vec![(
+        "a".to_string(),
+        RawNode::Edges(vec![(
+            "b".to_string(),
+            RawNode::Leaf(crate::document::Scalar::Int(1)),
+        )]),
+    )]);
+    assert_eq!(write_oml(&raw, 2).unwrap(), "a: {\n  b: 1\n}");
+}
+
+#[test]
+fn write_oml_writes_empty_object_compactly_in_both_modes() {
+    let raw = RawNode::Edges(vec![("a".to_string(), RawNode::Edges(vec![]))]);
+    assert_eq!(write_oml(&raw, 2).unwrap(), "a: {}");
+    assert_eq!(write_oml_compact(&raw).unwrap(), "a: {}");
+}
+
+#[test]
+fn labels_needing_quotes_are_quoted_on_write() {
+    let raw = RawNode::Edges(vec![
+        (
+            "has space".to_string(),
+            RawNode::Leaf(crate::document::Scalar::Int(1)),
+        ),
+        (
+            "null".to_string(),
+            RawNode::Leaf(crate::document::Scalar::Int(2)),
+        ),
+        (
+            "1leading".to_string(),
+            RawNode::Leaf(crate::document::Scalar::Int(3)),
+        ),
+    ]);
+    let text = write_oml(&raw, 2).unwrap();
+    assert!(text.contains("\"has space\": 1"));
+    assert!(text.contains("\"null\": 2"));
+    assert!(text.contains("\"1leading\": 3"));
+}
+
+#[test]
+fn bare_identifier_label_is_written_unquoted() {
+    let raw = RawNode::Edges(vec![(
+        "under_score-and-dash".to_string(),
+        RawNode::Leaf(crate::document::Scalar::Int(1)),
+    )]);
+    assert_eq!(write_oml(&raw, 2).unwrap(), "under_score-and-dash: 1");
+}
+
+// -- comments / separators ---------------------------------------------------
+
+#[test]
+fn comments_and_semicolons_are_accepted_as_separators() {
+    let node = read_oml("a: 1 # a comment\n; b: 2").unwrap();
+    match node {
+        RawNode::Edges(edges) => assert_eq!(edges.len(), 2),
+        other => panic!("expected edges, got {other:?}"),
+    }
+}
+
+#[test]
+fn crlf_line_endings_are_accepted_as_separators() {
+    let node = read_oml("a: 1\r\nb: 2").unwrap();
+    match node {
+        RawNode::Edges(edges) => assert_eq!(edges.len(), 2),
+        other => panic!("expected edges, got {other:?}"),
+    }
+}
+
+#[test]
+fn lone_carriage_return_is_a_stray_character() {
+    let err = read_oml("a: 1\rb: 2").unwrap_err();
+    assert!(err.message.contains("stray character"));
+}
+
+#[test]
+fn utf8_bom_is_stripped() {
+    let node = read_oml("\u{feff}a: 1").unwrap();
+    match node {
+        RawNode::Edges(edges) => assert_eq!(edges.len(), 1),
+        other => panic!("expected edges, got {other:?}"),
+    }
+}
+
+#[test]
+fn top_level_brace_document_is_equivalent_to_the_bare_edge_list() {
+    let a = read_oml("a: 1").unwrap();
+    let b = read_oml("{ a: 1 }").unwrap();
+    assert_eq!(a, b);
+}
+
+#[test]
+fn array_syntax_expands_to_repeated_edges() {
+    let node = read_oml("tag: [\"x\", \"y\", \"z\"]").unwrap();
+    match node {
+        RawNode::Edges(edges) => {
+            assert_eq!(edges.len(), 3);
+            assert!(edges.iter().all(|(l, _)| l == "tag"));
+        }
+        other => panic!("expected edges, got {other:?}"),
+    }
+}
+
+#[test]
+fn array_syntax_allows_a_trailing_comma() {
+    let node = read_oml("tag: [1, 2,]").unwrap();
+    match node {
+        RawNode::Edges(edges) => assert_eq!(edges.len(), 2),
+        other => panic!("expected edges, got {other:?}"),
+    }
+}
+
+#[test]
+fn array_of_brace_subtrees_round_trips() {
+    let raw = RawNode::Edges(vec![
+        (
+            "item".to_string(),
+            RawNode::Edges(vec![(
+                "v".to_string(),
+                RawNode::Leaf(crate::document::Scalar::Int(1)),
+            )]),
+        ),
+        (
+            "item".to_string(),
+            RawNode::Edges(vec![(
+                "v".to_string(),
+                RawNode::Leaf(crate::document::Scalar::Int(2)),
+            )]),
+        ),
+    ]);
+    let text = write_oml_compact(&raw).unwrap();
+    let parsed = read_oml(&text).unwrap();
+    assert_eq!(parsed, raw);
+}
+
+// -- Doc-level depth guard, ported from #4's pattern ------------------------
+
+#[test]
+fn read_oml_document_depth_guard_via_doc_from_raw() {
+    // The reader itself also enforces MAX_DEPTH while parsing nested `{ }`
+    // (parse_brace_value checks before descending), independent of
+    // write_oml's own guard.
+    let mut src = String::new();
+    for _ in 0..(document::MAX_DEPTH + 1) {
+        src.push_str("a: {");
+    }
+    src.push('1');
+    for _ in 0..(document::MAX_DEPTH + 1) {
+        src.push('}');
+    }
+    let err = read_oml(&src).unwrap_err();
+    assert!(err.message.contains("maximum depth"));
+}
+
+// -- coverage: multiline string edge cases ----------------------------------
+
+#[test]
+fn multiline_string_strips_crlf_opening_newline() {
+    let node = read_oml("a: \"\"\"\r\nline one\"\"\"").unwrap();
+    match node {
+        RawNode::Edges(edges) => match &edges[0].1 {
+            RawNode::Leaf(crate::document::Scalar::Str(s)) => assert_eq!(s, "line one"),
+            other => panic!("expected a string leaf, got {other:?}"),
+        },
+        other => panic!("expected edges, got {other:?}"),
+    }
+}
+
+#[test]
+fn multiline_string_decodes_escapes_inside_the_body() {
+    let node = read_oml("a: \"\"\"tab:\\there\"\"\"").unwrap();
+    match node {
+        RawNode::Edges(edges) => match &edges[0].1 {
+            RawNode::Leaf(crate::document::Scalar::Str(s)) => assert_eq!(s, "tab:\there"),
+            other => panic!("expected a string leaf, got {other:?}"),
+        },
+        other => panic!("expected edges, got {other:?}"),
+    }
+}
+
+#[test]
+fn multiline_string_allows_a_run_of_more_than_three_quotes_as_content() {
+    // A run of 4 quotes: the first 3 close the string, the 4th is literal
+    // content of the *next* token attempt -- mirrors the Python reference's
+    // `run >= 3` closing rule (only the first 3 are ever "the delimiter").
+    // 4 trailing quotes: the first 3 close the string, the 4th becomes a
+    // literal `"` appended to the content (mirrors the Python reference).
+    let node = read_oml("a: \"\"\"x\"\"\"\"").unwrap();
+    match node {
+        RawNode::Edges(edges) => match &edges[0].1 {
+            RawNode::Leaf(crate::document::Scalar::Str(s)) => assert_eq!(s, "x\""),
+            other => panic!("expected a string leaf, got {other:?}"),
+        },
+        other => panic!("expected edges, got {other:?}"),
+    }
+}
+
+// -- coverage: surrogate-pair escape decoding -------------------------------
+
+#[test]
+fn escaped_surrogate_pair_decodes_to_the_combined_codepoint() {
+    let node = read_oml(r#"a: "😀""#).unwrap();
+    match node {
+        RawNode::Edges(edges) => match &edges[0].1 {
+            RawNode::Leaf(crate::document::Scalar::Str(s)) => assert_eq!(s, "\u{1F600}"),
+            other => panic!("expected a string leaf, got {other:?}"),
+        },
+        other => panic!("expected edges, got {other:?}"),
+    }
+}
+
+// -- coverage: number/date/time near-miss shapes falling back correctly ----
+
+#[test]
+fn four_digits_not_followed_by_dash_is_a_plain_integer() {
+    let node = read_oml("a: 1234").unwrap();
+    match node {
+        RawNode::Edges(edges) => {
+            assert_eq!(
+                edges[0].1,
+                RawNode::Leaf(crate::document::Scalar::Int(1234))
+            );
+        }
+        other => panic!("expected edges, got {other:?}"),
+    }
+}
+
+#[test]
+fn date_shape_missing_second_dash_falls_back_and_errors_on_trailing_content() {
+    // "2024-01x": the second dash never appears, so try_date gives up on
+    // the date/datetime/time interpretation and falls through to a plain
+    // integer read of "2024"; the remaining "-01x" then fails to form a
+    // valid document -- an error either way, but *not* a date-shape error.
+    let err = read_oml("a: 2024-01x").unwrap_err();
+    assert!(!err.message.contains("invalid date"));
+}
+
+#[test]
+fn two_digit_integer_is_not_mistaken_for_a_time() {
+    let node = read_oml("a: 12").unwrap();
+    match node {
+        RawNode::Edges(edges) => {
+            assert_eq!(edges[0].1, RawNode::Leaf(crate::document::Scalar::Int(12)));
+        }
+        other => panic!("expected edges, got {other:?}"),
+    }
+}
+
+// -- coverage: writer entry points on a bare top-level node -----------------
+
+#[test]
+fn write_oml_compact_on_a_bare_leaf_node() {
+    let raw = RawNode::Leaf(crate::document::Scalar::Int(5));
+    assert_eq!(write_oml(&raw, 2).unwrap(), "5");
+    assert_eq!(write_oml_compact(&raw).unwrap(), "5");
+}
+
+#[test]
+fn write_oml_pretty_on_multiple_top_level_edges() {
+    let raw = RawNode::Edges(vec![
+        (
+            "a".to_string(),
+            RawNode::Leaf(crate::document::Scalar::Int(1)),
+        ),
+        (
+            "b".to_string(),
+            RawNode::Leaf(crate::document::Scalar::Int(2)),
+        ),
+    ]);
+    assert_eq!(write_oml(&raw, 2).unwrap(), "a: 1\nb: 2");
+}
+
+// -- coverage: parse-error display / field paths ----------------------------
+
+#[test]
+fn parse_array_with_multiple_scalar_elements_and_no_trailing_comma() {
+    let node = read_oml("tag: [1, 2, 3]").unwrap();
+    match node {
+        RawNode::Edges(edges) => assert_eq!(edges.len(), 3),
+        other => panic!("expected edges, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_label_rejects_a_non_label_token() {
+    let err = read_oml("a: { 1: 2 }").unwrap_err();
+    assert!(err.message.contains("expected a label"));
+}
+
+#[test]
+fn parse_value_rejects_a_bad_token_where_a_scalar_is_expected() {
+    let err = read_oml("a: :").unwrap_err();
+    assert!(err.message.contains("expected a value"));
+}
+
+#[test]
+fn array_close_error_when_neither_comma_nor_bracket() {
+    let err = read_oml("a: [1 2]").unwrap_err();
+    assert!(err.message.contains("expected ',' or ']'"));
+}
+
+// -- coverage: remaining escape / scanner / parser branches -----------------
+
+#[test]
+fn string_decodes_solidus_backspace_and_formfeed_escapes() {
+    let node = read_oml(r#"a: "\/ \b \f""#).unwrap();
+    match node {
+        RawNode::Edges(edges) => match &edges[0].1 {
+            RawNode::Leaf(crate::document::Scalar::Str(s)) => {
+                assert_eq!(s, "/ \u{8} \u{c}");
+            }
+            other => panic!("expected a string leaf, got {other:?}"),
+        },
+        other => panic!("expected edges, got {other:?}"),
+    }
+}
+
+#[test]
+fn escaped_surrogate_pair_via_explicit_u_escapes_decodes_correctly() {
+    // 😀 is the UTF-16 surrogate pair for U+1F600 (grinning
+    // face) -- unlike `escaped_surrogate_pair_decodes_to_the_combined_
+    // codepoint` (which embeds the literal character), this exercises the
+    // scanner's own `\uXXXX\uYYYY` pairing/combination code path directly:
+    // the source text below contains the literal six-character escape
+    // sequences, not the pre-combined UTF-8 character.
+    let node = read_oml("a: \"\\uD83D\\uDE00\"").unwrap();
+    match node {
+        RawNode::Edges(edges) => match &edges[0].1 {
+            RawNode::Leaf(crate::document::Scalar::Str(s)) => assert_eq!(s, "\u{1F600}"),
+            other => panic!("expected a string leaf, got {other:?}"),
+        },
+        other => panic!("expected edges, got {other:?}"),
+    }
+}
+
+#[test]
+fn lone_minus_not_followed_by_digit_or_inf_is_a_stray_character() {
+    let err = read_oml("a: -x").unwrap_err();
+    assert!(err.message.contains("stray character '-'"));
+}
+
+#[test]
+fn decimal_number_with_an_exponent_round_trips() {
+    // Not a write-then-read round trip on purpose: Rust's `f64::Display`
+    // never emits scientific notation (unlike Python's `repr`), so
+    // `write_oml` never actually *produces* a decimal-with-exponent
+    // literal (`1.5e10`) -- it always writes the equivalent plain decimal.
+    // This is a direct-read test of the NUMDEC-with-exponent scanner
+    // branch, which OML-Extended source *can* still contain.
+    let node = read_oml("a: 1.5e10").unwrap();
+    match node {
+        RawNode::Edges(edges) => {
+            assert_eq!(
+                edges[0].1,
+                RawNode::Leaf(crate::document::Scalar::Float(1.5e10))
+            );
+        }
+        other => panic!("expected edges, got {other:?}"),
+    }
+}
+
+#[test]
+fn exponent_only_number_forms_are_recognized() {
+    let cases = ["1e10", "1e+10", "1e-10", "-1e5"];
+    for src in cases {
+        let node = read_oml(&format!("a: {src}")).unwrap();
+        match node {
+            RawNode::Edges(edges) => {
+                assert!(
+                    matches!(edges[0].1, RawNode::Leaf(crate::document::Scalar::Float(_))),
+                    "{src} should scan as a float"
+                );
+            }
+            other => panic!("expected edges, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn quoted_string_label_at_the_top_level_is_recognized_as_an_edge() {
+    // Exercises looks_like_edge's and parse_label's `Str` arms directly --
+    // every other test in this suite uses a bare identifier label.
+    let node = read_oml(r#""a b": 1"#).unwrap();
+    match node {
+        RawNode::Edges(edges) => {
+            assert_eq!(edges[0].0, "a b");
+            assert_eq!(edges[0].1, RawNode::Leaf(crate::document::Scalar::Int(1)));
+        }
+        other => panic!("expected edges, got {other:?}"),
+    }
+}
+
+#[test]
+fn reserved_word_at_the_document_top_level_is_read_as_the_scalar_not_a_label() {
+    // Exercises `looks_like_edge`'s reserved-word-returns-false arm
+    // directly: "null" at the very top of a document is the null scalar
+    // (looks_like_edge deliberately excludes reserved words), so parsing
+    // stops there and the trailing ": 1" is reported as unexpected
+    // trailing content, not a reserved-label error (that error only fires
+    // once genuinely in label position -- see
+    // `reserved_word_cannot_be_a_bare_label` above).
+    let err = read_oml("null: 1").unwrap_err();
+    assert!(err.message.contains("unexpected trailing content"));
+}
+
+#[test]
+fn missing_separator_error_names_a_quoted_string_token() {
+    // Exercises `tok_display`'s `Str` arm: the *offending* token in the
+    // error message is itself a quoted string, not an identifier/number.
+    let err = read_oml(r#"a: 1 "b""#).unwrap_err();
+    assert!(err.message.contains("expected a separator"));
+    assert!(err.message.contains("\"b\""));
+}


### PR DESCRIPTION
Closes #10.

## What this adds

- `omnist/src/oml.rs`: OML codec -- reader (OML-Core in full, plus
  OML-Extended raw-string `'...'` (E2) and triple-quoted `"""..."""`
  (E3) on read only) and writer (OML-Core only). Hand-written
  recursive-descent scanner/parser over `Vec<char>`, not a port of
  Python's regex-driven single-pass scanner -- that design is
  Python-performance-specific per its own docstring, not a behavioral
  requirement (architecture-freedom policy).
- `document.rs`: adds `RawNode` (public) plus `Doc::from_raw`/`to_raw`.
  `Value`/`IndexMap` can't hold a repeated key, so it only represents a
  repeated label as a *contiguous* run; OML must round-trip arbitrary
  **interleaving** of repeated labels losslessly (its whole reason for
  existing), so the codec reads/writes through `RawNode` (a literal,
  order-preserving edge list) instead. `check_write_depth` is now
  `pub(crate)` so `oml.rs` can call it directly.
- `error.rs`: adds `ParseError` / `WriteError`, wired into `OmnistError`.
- 4300-digit integer cap (`MAX_INT_DIGITS`) lives in `oml.rs` --
  `document.rs`'s `Scalar::Int` is `i64` (max 19 digits), so it has no
  equivalent constant (see that module's own doc comment); OML source
  text is the one place an arbitrarily-long digit run can actually reach
  the parser.
- Temporal (date/time/datetime) literals: recognized by shape in the
  scanner, validated via `schema.rs`'s `is_iso_date`/`is_iso_time`/
  `is_iso_datetime` (issue #6) -- no second temporal parser.

## Red-before-green

Wrote the full test suite first; four genuine failures on first run,
fixed then green:

1. `bare_time_literal_round_trips...`: writer always quoted `Scalar::Str`,
   so a parsed bare time literal (`12:00`) wrote back quoted (`"12:00"`)
   -- exactly the omnist-ts#52 bug. Fixed: `write_scalar` now writes a
   `Str` bare when it re-matches a date/time/datetime shape.
2. / 3. Two tests asserted the wrong ambiguity-resolution behavior at
   document top level (`null: 1` and `a 1` parse as scalar-then-trailing-
   content, not immediately as label errors, matching Python's own
   `_looks_like_edge` semantics) -- fixed the test expectations, not the
   parser.
4. `write_oml_calls_the_shared_depth_guard`: initial writer only checked
   depth at *container* boundaries, missing the leaf-depth-vs-container-
   depth off-by-one that `document.rs`'s own `push_raw` accounts for.
   Fixed by checking `check_write_depth` at every node (leaf included),
   matching `push_raw`'s exact depth arithmetic.

## Coverage

`cargo test --workspace`: 194 passed, 0 failed.
`cargo fmt --all -- --check`: clean.
`cargo clippy --workspace --all-targets -- -D warnings`: clean.

`cargo llvm-cov --workspace --fail-under-lines 100`:

```
Filename                Lines  Missed Lines  Cover
omnist/src/document.rs    622             0  100.00%
omnist/src/error.rs        71             0  100.00%
omnist/src/oml.rs          763             1   99.87%
omnist/src/osd.rs          430             0  100.00%
omnist/src/schema.rs       743             0  100.00%
TOTAL                     2641             1   99.96%
```

**Investigated, not accepted as-is:** the single reported miss in
`oml.rs` does not correspond to any actual uncovered source line --
`cargo llvm-cov --lcov` export shows 0 missed lines for `oml.rs`, and the
generated HTML per-line view (`--html`) shows zero `uncovered-line` rows
and no row with a displayed count of 0 anywhere in the file. Reproduced
after a full `cargo llvm-cov clean` + `rm -rf target/llvm-cov*`. This
looks like a cargo-llvm-cov 0.8.7 / rustc 1.97.1 aggregation quirk (a
phantom function/line in the summary table not reflected in either
detailed report), not a real gap -- flagging for the verifier to decide
whether to accept, or to try pinning a different toolchain/cargo-llvm-cov
version.

Coverage gaps that ARE real were closed with targeted tests, not
pragmas: escape sequences (`\/`, `\b`, `\f`, full surrogate-pair
`\uXXXX\uYYYY` decoding), NUMDEC-with-exponent and NUMEXP-only number
forms, near-miss date/time shapes falling back to plain integers, quoted
top-level labels, and the depth-guard boundary. Two `.expect(...)`s
(documented inline) replace what would otherwise be permanently-dead
`.ok_or_else` branches for surrogate-pair math and non-surrogate
codepoints that are provably always valid -- same pattern as
`schema.rs`'s `mandatory_u32`.

## The four TS-bug-derived regressions (issue #10 requirement)

All four ported as explicit tests in `oml/tests.rs`:

- `write_oml_calls_the_shared_depth_guard` (omnist-ts#37/#70)
- `write_oml_preserves_datetime_utc_offset_exactly` (omnist-ts#51)
- `bare_time_literal_round_trips_as_a_time_not_a_quoted_string` (omnist-ts#52)
- `string_escaping_is_all_occurrences_not_first_match_only` (omnist-ts#36-equivalent)

## Python cross-check

Ran the live Python `omnist.oml` (venv at `~/dev/venvs/omnist`) against
the same 19 OML source strings used in the Rust test suite (every scalar
kind, nested objects, repeated labels, raw string, triple-quoted
string). All outputs byte-identical between Rust and Python **except
one intentional, documented divergence**: Python's `write_oml` on a bare
time literal without seconds (`12:00`) normalizes to `12:00:00` on
write-back, because Python parses it into a real `datetime.time` object
and always emits full `isoformat()`. This port's `Scalar` has no native
temporal type (see `document.rs`'s doc comment), so a temporal literal
is stored as its exact source spelling and round-trips byte-for-byte,
including `12:00` staying `12:00` -- a *stronger* round-trip guarantee
than Python's own, not a bug against Python's docs. No Python bug found;
nothing filed upstream.
