### PR TITLE
Schema algebra: prune, minimize, subschema, extract, lint, isomorphic, signature

### DIFF
--- a/omnist/src/lib.rs
+++ b/omnist/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod document;
 pub mod error;
 pub mod oml;
+pub mod ops;
 pub mod osd;
 pub mod schema;
 

--- a/omnist/src/ops/extract.rs
+++ b/omnist/src/ops/extract.rs
@@ -1,0 +1,143 @@
+//! Subschema extraction (paper Algorithm 5, ExtractSubschema). Ported from
+//! `~/dev/omnist/omnist/ops/extract.py`.
+//!
+//! Given a schema and a set of *permissible labels* `keep` (the paper's
+//! `X'`), produces the minimal subschema that recognizes only documents
+//! built from those labels.
+//!
+//! Algorithm:
+//!
+//! 1. For every record in the env, delete any field whose label is not in
+//!    `keep`.
+//! 2. If a deleted field had `min >= 1` (mandatory), that record is
+//!    *invalidated* -- the paper's "state removed": there is no way to
+//!    build a document at that record's shape without a label that's no
+//!    longer available.
+//! 3. **Propagate.** A record with a *mandatory* field whose type is an
+//!    invalidated record is itself invalidated, and so on transitively -- a
+//!    least-fixpoint closure, same shape as `super::prune`'s satisfiability
+//!    fixpoint.
+//! 4. If the root ends up invalidated, there is no valid subschema for this
+//!    `keep` set at all: [`extract`] returns a [`SchemaError`] naming the
+//!    first offending label and record.
+//! 5. Otherwise, invalidated records (and fields typed to them, along with
+//!    any fields already dropped in step 1) are gone; the result is run
+//!    through [`super::prune::prune`] and [`super::minimize::normalize`]
+//!    (Algorithm 5's own final MakeUseful + Minimize step).
+//!
+//! **Design decision: mandatory deletion is an error, not silently-optional**
+//! -- matching the Python reference. Silently loosening a deleted mandatory
+//! field to optional would mean the result no longer reflects Algorithm 5's
+//! semantics, and would more often hide a mistake in the caller's `keep` set
+//! than express an intentional relaxation.
+
+use indexmap::{IndexMap, IndexSet};
+
+use crate::error::SchemaError;
+use crate::schema::{FieldType, Record, Ref, Schema};
+
+use super::minimize::normalize;
+use super::prune::prune;
+
+/// The minimal subschema of `s` that only recognizes documents built from
+/// labels in `keep`. Returns a [`SchemaError`] if deleting the other labels
+/// would invalidate the root record (see the module doc comment).
+///
+/// Takes a concrete `&[&str]` rather than a generic `IntoIterator` on
+/// purpose: a generic parameter here would monomorphize a separate copy of
+/// `extract` per distinct caller argument type (`Vec<String>`, an array
+/// literal, an empty slice, ...), and `cargo llvm-cov` counts per-
+/// instantiation coverage separately -- so a fully-tested generic version
+/// could still report less than 100% simply because not every
+/// instantiation was independently exercised, without any real gap in
+/// behavior coverage. A single concrete signature sidesteps that entirely.
+pub fn extract(s: &Schema, keep: &[&str]) -> Result<Schema, SchemaError> {
+    let keep_set: IndexSet<String> = keep.iter().map(|s| (*s).to_string()).collect();
+
+    // Step 1+2: per-record field deletion, tracking which records are
+    // directly invalidated by the loss of a mandatory field, and the first
+    // offending (label, record) pair for the error message.
+    let mut trimmed: IndexMap<String, Record> = IndexMap::new();
+    let mut invalidated: IndexSet<String> = IndexSet::new();
+    let mut first_offender: Option<(String, String)> = None;
+
+    for (name, rec) in s.env() {
+        let mut kept_fields = Vec::new();
+        for f in rec.fields() {
+            if keep_set.contains(&f.label) {
+                kept_fields.push(f.clone());
+            } else if f.min >= 1 {
+                if first_offender.is_none() {
+                    first_offender = Some((f.label.clone(), name.clone()));
+                }
+                invalidated.insert(name.clone());
+            }
+        }
+        trimmed.insert(
+            name.clone(),
+            Record::new(kept_fields).expect(
+                "dropping fields from an already-valid Record cannot introduce a duplicate label",
+            ),
+        );
+    }
+
+    // Step 3: propagate invalidation -- a record with a mandatory field
+    // typed to an invalidated record is itself invalidated. Least fixpoint,
+    // same shape as prune's satisfiable_set.
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for (name, rec) in &trimmed {
+            if invalidated.contains(name) {
+                continue;
+            }
+            for f in rec.fields() {
+                if f.min >= 1
+                    && let FieldType::Ref(r) = &f.ty
+                    && invalidated.contains(&r.name)
+                {
+                    invalidated.insert(name.clone());
+                    changed = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    // Step 4: root invalidated -> no valid subschema.
+    if invalidated.contains(&s.root().name) {
+        let (label, record_name) = first_offender.expect(
+            "root invalidated implies step 1 recorded an offender before propagation began",
+        );
+        return Err(SchemaError::new(format!(
+            "no valid subschema: removing label {label:?} deletes a mandatory field of record {record_name:?}"
+        )));
+    }
+
+    // Step 5: drop invalidated records and any fields (mandatory or not)
+    // that still point at one.
+    let mut new_env: IndexMap<String, Record> = IndexMap::new();
+    for (name, rec) in &trimmed {
+        if invalidated.contains(name) {
+            continue;
+        }
+        let fields: Vec<_> = rec
+            .fields()
+            .iter()
+            .filter(|f| !matches!(&f.ty, FieldType::Ref(r) if invalidated.contains(&r.name)))
+            .cloned()
+            .collect();
+        new_env.insert(
+            name.clone(),
+            Record::new(fields).expect(
+                "dropping fields typed to an already-invalidated record cannot introduce a duplicate label",
+            ),
+        );
+    }
+
+    let result = Schema::new(Ref::new(s.root().name.clone()), new_env).expect(
+        "dropping only invalidated records/fields leaves every surviving Ref resolvable within \
+         the surviving env",
+    );
+    Ok(normalize(&prune(&result)))
+}

--- a/omnist/src/ops/isomorphic.rs
+++ b/omnist/src/ops/isomorphic.rs
@@ -1,0 +1,109 @@
+//! Schema isomorphism -- ported from `~/dev/omnist/omnist/ops/isomorphic.py`.
+//!
+//! Two schemas are equivalent iff their minimized (normalized) forms are
+//! isomorphic. That gives a second, algorithm-independent decision procedure
+//! for `equivalent`, structurally unrelated to bidirectional
+//! `subschema::compatible_with`, so the two can be cross-checked against
+//! each other in tests (the "dual-algorithm oracle" -- see `tests.rs`, the
+//! `minimize`/`isomorphic` triple-check strategy from the issue).
+//!
+//! [`is_isomorphic`] is deliberately not part of the crate's public surface
+//! commitment the way `subschema::equivalent` is -- it exists purely as an
+//! independent oracle for tests, matching the Python reference's choice to
+//! keep `_isomorphic` private.
+//!
+//! Algorithm: parallel traversal from both roots, building a bijection
+//! `name_a -> name_b` (and its inverse) between env record names as the
+//! traversal discovers pairs. At each visited record pair, `local_signature`
+//! must match; since it sorts fields by label and ref/scalar shape is part
+//! of the key, fields on the two sides line up one-to-one by label once the
+//! signatures agree. For each ref-typed field, the two targets are
+//! recursively required to be isomorphic, with the bijection enforced
+//! consistently in both directions.
+//!
+//! Both inputs are assumed already normalized (pruned + minimized) by the
+//! caller -- this module does not call `normalize` itself.
+
+use indexmap::IndexMap;
+
+use crate::schema::{FieldType, Schema};
+
+use super::prune::is_empty;
+use super::signature::local_signature;
+
+/// True iff normalized schemas `a` and `b` are isomorphic: there is a
+/// bijection between their env record names under which the two root
+/// records (and everything reachable from them) match exactly.
+///
+/// **Empty-schema convention.** If both `a` and `b` are unsatisfiable, they
+/// are treated as isomorphic (both accept the empty language). If exactly
+/// one is empty, they are *not* isomorphic.
+pub fn is_isomorphic(a: &Schema, b: &Schema) -> bool {
+    let (empty_a, empty_b) = (is_empty(a), is_empty(b));
+    if empty_a || empty_b {
+        return empty_a && empty_b;
+    }
+
+    let mut map_ab: IndexMap<String, String> = IndexMap::new();
+    let mut map_ba: IndexMap<String, String> = IndexMap::new();
+    walk(
+        a,
+        a.root().name.clone(),
+        b,
+        b.root().name.clone(),
+        &mut map_ab,
+        &mut map_ba,
+    )
+}
+
+fn walk(
+    a: &Schema,
+    na: String,
+    b: &Schema,
+    nb: String,
+    map_ab: &mut IndexMap<String, String>,
+    map_ba: &mut IndexMap<String, String>,
+) -> bool {
+    if map_ab.contains_key(&na) || map_ba.contains_key(&nb) {
+        // Already visited on at least one side: the bijection must agree
+        // both ways, or the schemas aren't isomorphic.
+        return map_ab.get(&na) == Some(&nb) && map_ba.get(&nb) == Some(&na);
+    }
+
+    map_ab.insert(na.clone(), nb.clone());
+    map_ba.insert(nb.clone(), na.clone());
+
+    let ra = a
+        .env()
+        .get(&na)
+        .expect("caller only walks names taken from a Schema's own root/Ref graph");
+    let rb = b
+        .env()
+        .get(&nb)
+        .expect("caller only walks names taken from a Schema's own root/Ref graph");
+    if local_signature(ra) != local_signature(rb) {
+        return false;
+    }
+
+    // local_signature sorts fields by label and includes the label in its
+    // key, so two records with equal signatures declare exactly the same
+    // set of labels -- fields on the two sides line up one-to-one by label.
+    for fa in ra.fields() {
+        let fb = rb
+            .field(&fa.label)
+            .expect("equal local_signature guarantees the same label set on both sides");
+        if let (FieldType::Ref(ra_ref), FieldType::Ref(rb_ref)) = (&fa.ty, &fb.ty)
+            && !walk(
+                a,
+                ra_ref.name.clone(),
+                b,
+                rb_ref.name.clone(),
+                map_ab,
+                map_ba,
+            )
+        {
+            return false;
+        }
+    }
+    true
+}

--- a/omnist/src/ops/lint.rs
+++ b/omnist/src/ops/lint.rs
@@ -1,0 +1,147 @@
+//! Non-destructive structural diagnostics for a schema. Ported from
+//! `~/dev/omnist/omnist/ops/lint.py`.
+//!
+//! `Schema::validate` checks a *document* against a schema; `lint` checks
+//! the *schema itself* for structural problems that parse fine but mean
+//! parts of the schema can never do anything. It **reports, never
+//! mutates** -- `prune`/`normalize` are the transforms that fix these
+//! issues; `lint` only diagnoses them.
+//!
+//! Three checks (the Python reference's fourth, `any-field`, has no
+//! counterpart here -- see `super`'s module doc comment on why `AnyType`
+//! is out of scope for this port):
+//!
+//! * `unsatisfiable-record` (`warning`) -- a reachable record no finite
+//!   document can match (e.g. a mandatory ref cycle). Reuses
+//!   [`super::prune::satisfiable_set`] (its complement), intersected with
+//!   reachable.
+//! * `unreachable-record` (`warning`) -- a record defined in the env but not
+//!   reachable from root by following any ref. A plain reachability walk
+//!   (no pruning): every `Ref`-typed field is followed regardless of
+//!   cardinality.
+//! * `duplicate-record` (`warning`) -- two or more structurally identical
+//!   records under different names. Reuses
+//!   [`super::minimize::equivalence_classes`] on the *raw* schema, so
+//!   duplicates are reported as authored.
+
+use indexmap::IndexSet;
+
+use crate::schema::{FieldType, Schema};
+
+use super::minimize::equivalence_classes;
+use super::prune::satisfiable_set;
+
+/// One structural diagnostic. `code` is a stable machine-readable
+/// identifier (`unsatisfiable-record`, `unreachable-record`,
+/// `duplicate-record`); `severity` is `warning` or `info`; `location` is a
+/// record name; `message` is a human-readable, actionable description.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LintFinding {
+    pub code: &'static str,
+    pub severity: &'static str,
+    pub location: String,
+    pub message: String,
+}
+
+/// Record names reachable from `s`'s root by a plain walk following every
+/// `Ref`-typed field -- no pruning, cardinality ignored. A record reachable
+/// only via an optional or unsatisfiable field still counts as referenced.
+fn reachable(s: &Schema) -> IndexSet<String> {
+    let mut seen: IndexSet<String> = IndexSet::new();
+    let mut stack = vec![s.root().name.clone()];
+    while let Some(name) = stack.pop() {
+        if seen.contains(&name) {
+            continue;
+        }
+        // Every name pushed onto `stack` is either `s.root().name` or a
+        // `Ref` target found on an already-visited record's fields --
+        // `Schema::new`'s `check_refs` guarantees both always resolve
+        // within `s.env()`, so `.get` here can never miss. A fallible
+        // `if let ... else { continue }` here would be dead code `cargo
+        // llvm-cov` correctly flags as unreachable (see oml.rs's
+        // `scan_number` for the same pattern), so it's replaced with an
+        // `expect` documenting the invariant instead.
+        let rec = s
+            .env()
+            .get(&name)
+            .expect("Schema's own invariant: every Ref target resolves within its env");
+        seen.insert(name.clone());
+        for f in rec.fields() {
+            if let FieldType::Ref(r) = &f.ty {
+                stack.push(r.name.clone());
+            }
+        }
+    }
+    seen
+}
+
+/// Structural diagnostics for `s` -- see the module doc comment for the
+/// checks. Returns findings sorted deterministically by `(code, location)`.
+/// Never mutates `s`.
+pub fn lint(s: &Schema) -> Vec<LintFinding> {
+    let mut findings: Vec<LintFinding> = Vec::new();
+
+    let reach = reachable(s);
+    let sat = satisfiable_set(s);
+
+    // unsatisfiable-record: reachable but not satisfiable. Iteration order
+    // here doesn't matter for determinism -- the final `.sort_by` below is
+    // what makes the output canonical, matching the Python reference's own
+    // set-difference-then-sort shape.
+    for name in &reach {
+        if !sat.contains(name) {
+            findings.push(LintFinding {
+                code: "unsatisfiable-record",
+                severity: "warning",
+                location: name.clone(),
+                message: format!(
+                    "record {name:?} is reachable but unsatisfiable -- no finite document \
+                     can match it (e.g. a mandatory ref cycle)"
+                ),
+            });
+        }
+    }
+
+    // unreachable-record: defined in env but not reachable from root.
+    for name in s.env().keys() {
+        if !reach.contains(name) {
+            findings.push(LintFinding {
+                code: "unreachable-record",
+                severity: "warning",
+                location: name.clone(),
+                message: format!(
+                    "record {name:?} is defined but never reachable from the root; drop it \
+                     with `schema prune`"
+                ),
+            });
+        }
+    }
+
+    // duplicate-record: structurally identical records under different
+    // names.
+    for block in equivalence_classes(s) {
+        if block.len() > 1 {
+            let mut group = block.clone();
+            group.sort();
+            let location = group.join(", ");
+            let keep = group[0].clone();
+            let others: Vec<String> = group[1..].iter().map(|n| format!("{n:?}")).collect();
+            findings.push(LintFinding {
+                code: "duplicate-record",
+                severity: "warning",
+                location,
+                message: format!(
+                    "records {} are structurally identical to {keep:?}; merge them with \
+                     `schema normalize`",
+                    others.join(", ")
+                ),
+            });
+        }
+    }
+
+    // Canonical ordering -- codepoint (byte-wise) comparison via `str`'s
+    // default `Ord`, never locale-aware. See `tests.rs`'s omnist-ts#56
+    // regression test.
+    findings.sort_by(|a, b| (a.code, &a.location).cmp(&(b.code, &b.location)));
+    findings
+}

--- a/omnist/src/ops/minimize.rs
+++ b/omnist/src/ops/minimize.rs
@@ -1,0 +1,209 @@
+//! Schema minimization: partition-refinement to the canonical minimal form.
+//! Ported from `~/dev/omnist/omnist/ops/minimize.py`.
+//!
+//! `normalize(s)` returns an equivalent schema with the *fewest possible*
+//! env records, unique up to record naming (paper Theorems 3-4).
+//!
+//! Algorithm:
+//!
+//! 1. `s = prune(s)` -- mandatory first step. Two semantically-equal records
+//!    must not be kept apart by never-emittable fields or unreachable
+//!    records; pruning first is what makes the partition canonical.
+//! 2. **Initial partition**: env records grouped by `local_signature` -- a
+//!    target-blind structural key, so records that might turn out
+//!    equivalent via differently-named ref targets still start in the same
+//!    block.
+//! 3. **Refine**: split any block whose members disagree, for some label,
+//!    on which *block* their same-labeled ref-typed field points to. Repeat
+//!    until no block splits (a fixpoint -- always reached on a finite env).
+//! 4. **Merge**: collapse each stable block to a single representative --
+//!    its lexicographically smallest member name (deterministic) -- and
+//!    remap every ref and the root to representatives.
+//!
+//! Special case: an unsatisfiable (empty-language) root. `prune` deliberately
+//! leaves such a root's fields untouched (see its own doc comment), so
+//! partition refinement over the unsatisfiable core isn't meaningful --
+//! `normalize` just returns the pruned schema unchanged in that case.
+
+use std::hash::Hash;
+
+use indexmap::IndexMap;
+
+use crate::schema::{Field, FieldType, Record, Ref, Schema};
+
+use super::prune::{is_empty, prune};
+use super::signature::{LocalSignature, local_signature};
+
+/// Partitions `s.env`'s record names into structural-equivalence classes via
+/// MinimizeSA-style partition refinement (module doc comment, steps 2-3):
+/// an initial `local_signature` grouping refined to a fixpoint by which
+/// *block* each same-labeled ref field points to.
+///
+/// Operates on `s.env` exactly as given -- it does **not** prune first, so
+/// unreachable or unsatisfiable records are still classified. [`normalize`]
+/// calls this after its own prune/is_empty steps; `lint` calls it on the raw
+/// schema so duplicates are reported as authored. Each returned block is a
+/// list of names; a block of length > 1 is a set of records with identical
+/// structure.
+pub fn equivalence_classes(s: &Schema) -> Vec<Vec<String>> {
+    let mut names: Vec<String> = s.env().keys().cloned().collect();
+    names.sort();
+
+    let mut blocks: Vec<Vec<String>> = group_by(&names, |n| {
+        local_signature(s.env().get(n).expect("n comes from s.env's own keys"))
+    });
+    let mut block_of: IndexMap<String, usize> = IndexMap::new();
+    for (i, block) in blocks.iter().enumerate() {
+        for n in block {
+            block_of.insert(n.clone(), i);
+        }
+    }
+
+    loop {
+        let mut new_blocks: Vec<Vec<String>> = Vec::new();
+        let mut new_block_of: IndexMap<String, usize> = IndexMap::new();
+        for block in &blocks {
+            let subs = group_by(block, |n| {
+                refine_key(
+                    s.env().get(n).expect("n comes from s.env's own keys"),
+                    &block_of,
+                )
+            });
+            for sub in subs {
+                let idx = new_blocks.len();
+                for n in &sub {
+                    new_block_of.insert(n.clone(), idx);
+                }
+                new_blocks.push(sub);
+            }
+        }
+        let changed = new_blocks.len() != blocks.len();
+        blocks = new_blocks;
+        block_of = new_block_of;
+        if !changed {
+            return blocks;
+        }
+    }
+}
+
+/// The canonical minimal schema equivalent to `s`: fewest env records,
+/// unique up to record naming. See the module doc comment for the algorithm
+/// (paper's Algorithm 2, MinimizeSA).
+pub fn normalize(s: &Schema) -> Schema {
+    let pruned = prune(s);
+    if is_empty(&pruned) {
+        return pruned;
+    }
+
+    let mut names: Vec<String> = pruned.env().keys().cloned().collect();
+    names.sort();
+    let blocks = equivalence_classes(&pruned);
+
+    let mut rep: IndexMap<String, String> = IndexMap::new();
+    for block in &blocks {
+        let keep = block
+            .iter()
+            .min()
+            .expect("equivalence_classes never returns an empty block")
+            .clone();
+        for n in block {
+            rep.insert(n.clone(), keep.clone());
+        }
+    }
+
+    let mut new_env: IndexMap<String, Record> = IndexMap::new();
+    for name in &names {
+        if rep.get(name) == Some(name) {
+            new_env.insert(
+                name.clone(),
+                remap(
+                    pruned
+                        .env()
+                        .get(name)
+                        .expect("name comes from pruned.env's own keys"),
+                    &rep,
+                ),
+            );
+        }
+    }
+    // `rep` is built from `equivalence_classes(&pruned)`, which partitions
+    // *every* name in `pruned.env()` into exactly one block -- and
+    // `pruned.root().name` is always a key of `pruned.env()` (Schema's own
+    // invariant: the root always resolves). So `rep` always has an entry
+    // for it; a fallback here would be dead code (see `lint::reachable`'s
+    // identical note on this pattern).
+    let new_root_name = rep
+        .get(&pruned.root().name)
+        .cloned()
+        .expect("every env record name, including the root's, is classified into rep");
+    Schema::new(Ref::new(new_root_name), new_env)
+        .expect("normalize only remaps refs to representative names that stay present in new_env")
+}
+
+fn group_by<K, F>(names: &[String], key_fn: F) -> Vec<Vec<String>>
+where
+    K: Eq + Hash,
+    F: Fn(&String) -> K,
+{
+    let mut groups: IndexMap<K, Vec<String>> = IndexMap::new();
+    for n in names {
+        groups.entry(key_fn(n)).or_default().push(n.clone());
+    }
+    groups.into_values().collect()
+}
+
+/// A record's refinement key: its target-blind local signature, plus -- for
+/// each field in label order -- the current block id of its ref target (or
+/// `None` for a scalar field). Two records land in the same refined block
+/// only if they agree on both.
+type RefineKey = (
+    LocalSignature,
+    Vec<(String, usize, Option<usize>, Option<usize>)>,
+);
+
+fn refine_key(rec: &Record, block_of: &IndexMap<String, usize>) -> RefineKey {
+    let mut fields: Vec<(String, usize, Option<usize>, Option<usize>)> = rec
+        .fields()
+        .iter()
+        .map(|f| {
+            let blk = match &f.ty {
+                FieldType::Ref(r) => Some(
+                    *block_of
+                        .get(&r.name)
+                        .expect("every ref target is classified before refine_key runs on it"),
+                ),
+                FieldType::Scalar(_) => None,
+            };
+            (f.label.clone(), f.min, f.max, blk)
+        })
+        .collect();
+    fields.sort_by(|a, b| a.0.cmp(&b.0));
+    (local_signature(rec), fields)
+}
+
+fn remap(rec: &Record, rep: &IndexMap<String, String>) -> Record {
+    let fields: Vec<Field> = rec
+        .fields()
+        .iter()
+        .map(|f| {
+            let ty = match &f.ty {
+                // `remap` is only ever called on a record still present in
+                // `pruned.env()`, and every Ref-typed field on it targets
+                // another name in that same env (Schema's own invariant) --
+                // which `rep` classifies for every name. A fallback here
+                // would be dead code, same reasoning as `new_root_name`
+                // above.
+                FieldType::Ref(r) => FieldType::Ref(Ref::new(
+                    rep.get(&r.name)
+                        .cloned()
+                        .expect("every ref target is classified into rep"),
+                )),
+                FieldType::Scalar(s) => FieldType::Scalar(*s),
+            };
+            Field::new(f.label.clone(), ty, f.min, f.max)
+                .expect("remapping a ref target name changes neither label nor cardinality")
+        })
+        .collect();
+    Record::new(fields)
+        .expect("remap doesn't add/remove/rename fields, so it cannot introduce a duplicate label")
+}

--- a/omnist/src/ops/mod.rs
+++ b/omnist/src/ops/mod.rs
@@ -1,0 +1,47 @@
+//! Schema algebra: `prune`, `minimize`/`normalize`, `subschema`, `extract`,
+//! `lint`, `isomorphic`, `signature` -- ported from `~/dev/omnist/omnist/ops/`
+//! (issue #12), one module per op (matching the Python layout, which is
+//! already a reasonable structure per "architecture freedom").
+//!
+//! ## The `any` type is out of scope here
+//!
+//! The Python reference's `schema.py` has a fourth type kind, `AnyType`
+//! (accepts any value unchecked), threaded through every op in this family.
+//! `omnist-rs`'s [`crate::schema`] (issue #6) does not have an `AnyType`
+//! equivalent -- whether to add one is an explicitly deferred open design
+//! question upstream (not yet decided for this port), so every op below is
+//! written against the two-kind [`crate::schema::FieldType`] (`Scalar` /
+//! `Ref`) that issue #6 actually shipped. `lint`'s Python `any-field` check
+//! has no Rust counterpart for the same reason -- there is nothing to
+//! inventory yet.
+//!
+//! ## Determinism
+//!
+//! Every op here produces a "canonical form" (a pruned/minimized schema, a
+//! sorted lint report, a deterministic equivalence-class partition). None of
+//! this module's code uses `std::collections::HashMap`/`HashSet` --
+//! `indexmap`'s `IndexMap`/`IndexSet` everywhere an ordered structure is
+//! needed, and an explicit `.sort()` everywhere the Python reference itself
+//! sorts for canonical output (see `signature::local_signature`, `lint::lint`,
+//! `minimize::normalize`). See `tests.rs` for the repeated-run determinism
+//! proof and the `omnist-ts#56` ordering-regression tests (codepoint, not
+//! locale, order; `prune`'s declaration-order environment reconstruction).
+
+pub mod extract;
+pub mod isomorphic;
+pub mod lint;
+pub mod minimize;
+pub mod prune;
+pub mod signature;
+pub mod subschema;
+
+pub use extract::extract;
+pub use isomorphic::is_isomorphic;
+pub use lint::{LintFinding, lint};
+pub use minimize::{equivalence_classes, normalize};
+pub use prune::{is_empty, prune, satisfiable_set};
+pub use signature::local_signature;
+pub use subschema::{compatible_with, equivalent};
+
+#[cfg(test)]
+mod tests;

--- a/omnist/src/ops/prune.rs
+++ b/omnist/src/ops/prune.rs
@@ -1,0 +1,154 @@
+//! Satisfiability analysis and schema pruning. Ported from
+//! `~/dev/omnist/omnist/ops/prune.py`.
+//!
+//! A record is *satisfiable* iff it admits at least one finite document, and
+//! [`prune`] returns an equivalent schema with everything that can never
+//! match removed. Satisfiability is a least fixpoint over the env's records:
+//! a record is satisfiable iff every field with `min >= 1` is either a
+//! `Scalar` or a `Ref` to a satisfiable record (fields with `min == 0` never
+//! block satisfiability -- they simply need not be emitted).
+
+use indexmap::{IndexMap, IndexSet};
+
+use crate::schema::{Field, FieldType, Record, Ref, Schema};
+
+/// The set of env record names that admit at least one finite document.
+///
+/// Least fixpoint: start with nothing known-satisfiable and repeatedly add
+/// any record all of whose mandatory (`min >= 1`) fields are already
+/// satisfiable. Monotonic on a finite env, so this always terminates. Only
+/// ever queried by membership (never iterated for its own order), so an
+/// `IndexSet` is used purely for the "no `HashMap`/`HashSet`" house style,
+/// not because iteration order matters here.
+pub fn satisfiable_set(s: &Schema) -> IndexSet<String> {
+    let mut sat: IndexSet<String> = IndexSet::new();
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for (name, rec) in s.env() {
+            if sat.contains(name) {
+                continue;
+            }
+            if record_satisfiable(rec, &sat) {
+                sat.insert(name.clone());
+                changed = true;
+            }
+        }
+    }
+    sat
+}
+
+fn record_satisfiable(rec: &Record, sat: &IndexSet<String>) -> bool {
+    for f in rec.fields() {
+        if f.min < 1 {
+            continue;
+        }
+        if let FieldType::Ref(r) = &f.ty
+            && !sat.contains(&r.name)
+        {
+            return false;
+        }
+    }
+    true
+}
+
+/// True iff `s`'s root record is unsatisfiable -- the schema's language (the
+/// set of documents it accepts) is empty.
+pub fn is_empty(s: &Schema) -> bool {
+    !satisfiable_set(s).contains(&s.root().name)
+}
+
+/// An equivalent schema with everything that can never match removed:
+/// records unreachable from root are dropped; fields with `max == 0` are
+/// dropped; optional (`min == 0`) fields whose type is an unsatisfiable
+/// record are dropped; records left unreachable/unsatisfiable after the
+/// above are dropped from the environment too.
+///
+/// **Root-unsatisfiable case.** If the root record itself is unsatisfiable
+/// (`is_empty` is true), field pruning is *not* applied to the root: its
+/// mandatory fields are exactly what make it unsatisfiable, and stripping
+/// them would silently produce a *different*, satisfiable schema. Instead
+/// the root record is kept as-is and only the rest of the environment is
+/// reduced to what's reachable from it.
+///
+/// **Environment order (omnist-ts#56).** The returned environment iterates
+/// `s.env()` in its own declaration order, filtered to `reachable` -- not
+/// the other way round. `IndexSet::contains` is a membership check only;
+/// iterating the *set* itself instead of the schema's own `IndexMap` is
+/// exactly the bug TS's port had (traversal order leaking into the output
+/// instead of preserving the input's authored order).
+pub fn prune(s: &Schema) -> Schema {
+    let sat = satisfiable_set(s);
+    let root_ok = sat.contains(&s.root().name);
+    let reachable = reachable_from_root(s, &sat, root_ok);
+
+    let mut new_env: IndexMap<String, Record> = IndexMap::new();
+    for (name, rec) in s.env() {
+        if !reachable.contains(name) {
+            continue;
+        }
+        if !root_ok && *name == s.root().name {
+            new_env.insert(name.clone(), rec.clone());
+        } else {
+            new_env.insert(name.clone(), prune_record(rec, &sat));
+        }
+    }
+    Schema::new(Ref::new(s.root().name.clone()), new_env).expect(
+        "prune only drops unreachable records and never-emittable/unsatisfiable-optional \
+         fields; every surviving Ref still resolves within the surviving env",
+    )
+}
+
+fn reachable_from_root(s: &Schema, sat: &IndexSet<String>, root_ok: bool) -> IndexSet<String> {
+    let mut seen: IndexSet<String> = IndexSet::new();
+    let mut stack = vec![s.root().name.clone()];
+    while let Some(name) = stack.pop() {
+        if seen.contains(&name) {
+            continue;
+        }
+        let Some(rec) = s.env().get(&name) else {
+            continue;
+        };
+        seen.insert(name.clone());
+        let is_unpruned_root = name == s.root().name && !root_ok;
+        for f in rec.fields() {
+            if !is_unpruned_root {
+                if f.max == Some(0) {
+                    continue;
+                }
+                if f.min == 0
+                    && let FieldType::Ref(r) = &f.ty
+                    && !sat.contains(&r.name)
+                {
+                    continue;
+                }
+            }
+            if let FieldType::Ref(r) = &f.ty {
+                stack.push(r.name.clone());
+            }
+        }
+    }
+    seen
+}
+
+fn prune_record(rec: &Record, sat: &IndexSet<String>) -> Record {
+    let kept: Vec<Field> = rec
+        .fields()
+        .iter()
+        .filter(|f| {
+            if f.max == Some(0) {
+                return false;
+            }
+            if f.min == 0
+                && let FieldType::Ref(r) = &f.ty
+                && !sat.contains(&r.name)
+            {
+                return false;
+            }
+            true
+        })
+        .cloned()
+        .collect();
+    Record::new(kept)
+        .expect("filtering fields out of an already-valid Record cannot introduce a duplicate label")
+}

--- a/omnist/src/ops/prune.rs
+++ b/omnist/src/ops/prune.rs
@@ -106,9 +106,14 @@ fn reachable_from_root(s: &Schema, sat: &IndexSet<String>, root_ok: bool) -> Ind
         if seen.contains(&name) {
             continue;
         }
-        let Some(rec) = s.env().get(&name) else {
-            continue;
-        };
+        // Every name here is either the root or a Ref target found on an
+        // already-visited record -- `Schema::new`'s `check_refs` guarantees
+        // both always resolve, so a fallible lookup is dead code (see
+        // `lint::reachable`'s identical note).
+        let rec = s
+            .env()
+            .get(&name)
+            .expect("Schema's own invariant: every Ref target resolves within its env");
         seen.insert(name.clone());
         let is_unpruned_root = name == s.root().name && !root_ok;
         for f in rec.fields() {
@@ -149,6 +154,7 @@ fn prune_record(rec: &Record, sat: &IndexSet<String>) -> Record {
         })
         .cloned()
         .collect();
-    Record::new(kept)
-        .expect("filtering fields out of an already-valid Record cannot introduce a duplicate label")
+    Record::new(kept).expect(
+        "filtering fields out of an already-valid Record cannot introduce a duplicate label",
+    )
 }

--- a/omnist/src/ops/signature.rs
+++ b/omnist/src/ops/signature.rs
@@ -1,0 +1,58 @@
+//! Field-signature helpers for schema minimization (and isomorphism).
+//! Ported from `~/dev/omnist/omnist/ops/signature.py`.
+//!
+//! [`local_signature`] is the target-blind structural key used as the
+//! *initial* partition for `minimize`'s partition refinement: a key
+//! including ref target names would be too strong a starting point --
+//! records that turn out to be equivalent because their ref targets are
+//! themselves equivalent-but-differently-named would never even land in
+//! the same starting block. It captures a field's label, cardinality, and
+//! scalar-or-ref *shape*, but excludes ref target names (those are compared
+//! by evolving block id during `minimize`'s refinement instead).
+
+use crate::schema::{FieldType, Record, ScalarKind};
+
+/// A field's target-blind shape: `Scalar(kind, nullable)` or `Ref` (the
+/// target record's name is deliberately excluded -- see the module doc
+/// comment).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ShapeKey {
+    Scalar(ScalarKind, bool),
+    Ref,
+}
+
+/// One field's signature entry: `(label, min, max, shape)`.
+pub type FieldKey = (String, usize, Option<usize>, ShapeKey);
+
+/// A record's target-blind structural key: every field's [`FieldKey`],
+/// sorted by label.
+pub type LocalSignature = Vec<FieldKey>;
+
+/// Target-blind structural key for a record: fields sorted by label, each
+/// keyed by `(label, min, max, shape)`.
+///
+/// Fields are sorted by label rather than kept in declaration order:
+/// validation ignores field order (a `Record` is a *set* of labeled fields),
+/// so two records that declare the same fields in a different order accept
+/// exactly the same documents and MUST land in the same initial partition
+/// block -- keying by declaration order would incorrectly split them.
+pub fn local_signature(rec: &Record) -> LocalSignature {
+    let mut fields: LocalSignature = rec
+        .fields()
+        .iter()
+        .map(|f| {
+            let shape = match &f.ty {
+                FieldType::Scalar(s) => ShapeKey::Scalar(s.kind(), s.is_nullable()),
+                FieldType::Ref(_) => ShapeKey::Ref,
+            };
+            (f.label.clone(), f.min, f.max, shape)
+        })
+        .collect();
+    // `Record::new` already rejects duplicate labels, so this sort can never
+    // need a tie-breaker -- codepoint order via `String`'s default `Ord`
+    // (byte-wise on valid UTF-8, which coincides with codepoint order),
+    // never a locale-aware comparison (see the omnist-ts#56 regression test
+    // in `tests.rs`).
+    fields.sort_by(|a, b| a.0.cmp(&b.0));
+    fields
+}

--- a/omnist/src/ops/subschema.rs
+++ b/omnist/src/ops/subschema.rs
@@ -1,0 +1,146 @@
+//! Subschema compatibility and equivalence. Ported from
+//! `~/dev/omnist/omnist/ops/subschema.py`.
+//!
+//! Implements the paper's Algorithm 4 (SubschemaSA) restricted to omnist's
+//! counting cardinality languages; [`equivalent`] is bidirectional
+//! inclusion.
+//!
+//! Algorithm 4 assumes its precondition MakeUsefulSA (useless-state removal,
+//! `super::prune`) has already run: the coinductive cycle rule below only
+//! coincides with true (finite-document) language inclusion once every
+//! A-side record is known satisfiable. Rather than requiring callers to
+//! pre-prune, [`compatible_with`] computes `a`'s satisfiable set once up
+//! front and consults it directly -- an unsatisfiable A-side record is
+//! vacuously a subschema of anything (it emits no documents at all), and an
+//! optional A-field whose type is unsatisfiable is skipped (it can never
+//! actually be emitted, so it imposes no obligation on B).
+
+use indexmap::{IndexMap, IndexSet};
+
+use crate::schema::{FieldType, Record, Scalar, ScalarKind, Schema};
+
+use super::prune::satisfiable_set;
+
+/// True if every document `a` accepts is also accepted by `b` (`a` is a
+/// subschema / `b` is backward-compatible).
+pub fn compatible_with(a: &Schema, b: &Schema) -> bool {
+    let sat_a = satisfiable_set(a);
+    let mut memo: IndexMap<(String, String), bool> = IndexMap::new();
+    sub(
+        a,
+        &FieldType::Ref(a.root().clone()),
+        b,
+        &FieldType::Ref(b.root().clone()),
+        &sat_a,
+        &mut memo,
+    )
+}
+
+/// True if both schemas accept exactly the same documents.
+pub fn equivalent(a: &Schema, b: &Schema) -> bool {
+    compatible_with(a, b) && compatible_with(b, a)
+}
+
+/// The memo key is `(a-ref-name, b-ref-name)`, guarding only the ref/ref
+/// case -- the only one that can cycle. Scalar comparisons never recurse,
+/// so they need no memoization to terminate.
+fn sub(
+    sa: &Schema,
+    ta: &FieldType,
+    sb: &Schema,
+    tb: &FieldType,
+    sat_a: &IndexSet<String>,
+    memo: &mut IndexMap<(String, String), bool>,
+) -> bool {
+    match (ta, tb) {
+        (FieldType::Ref(ra), _) if !sat_a.contains(&ra.name) => true,
+        (FieldType::Scalar(a), FieldType::Scalar(b)) => scalar_sub(*a, *b),
+        (FieldType::Ref(ra), FieldType::Ref(rb)) => {
+            let key = (ra.name.clone(), rb.name.clone());
+            if let Some(&v) = memo.get(&key) {
+                return v;
+            }
+            // Coinductive assumption while descending, mirroring the Python
+            // reference: a cycle that never disagrees is compatible.
+            memo.insert(key.clone(), true);
+            let reca = sa
+                .env()
+                .get(&ra.name)
+                .expect("Schema's own invariant: every Ref resolves within its env");
+            let recb = sb
+                .env()
+                .get(&rb.name)
+                .expect("Schema's own invariant: every Ref resolves within its env");
+            let result = record_sub(sa, reca, sb, recb, sat_a, memo);
+            memo.insert(key, result);
+            result
+        }
+        // A value type vs. an object type (or vice versa) is never
+        // compatible.
+        _ => false,
+    }
+}
+
+fn record_sub(
+    sa: &Schema,
+    a: &Record,
+    sb: &Schema,
+    b: &Record,
+    sat_a: &IndexSet<String>,
+    memo: &mut IndexMap<(String, String), bool>,
+) -> bool {
+    // Every label A may emit must be allowed by B, with a cardinality range
+    // B's covers and a type B accepts.
+    for fa in a.fields() {
+        if fa.max == Some(0) {
+            continue; // A never emits this label
+        }
+        if fa.min == 0
+            && let FieldType::Ref(r) = &fa.ty
+            && !sat_a.contains(&r.name)
+        {
+            continue; // A never actually emits this label either
+        }
+        let Some(fb) = b.field(&fa.label) else {
+            return false; // B is closed and has no such field
+        };
+        if !(fb.min <= fa.min && le(fa.max, fb.max)) {
+            return false; // [fa.min,fa.max] not a subset of B's range
+        }
+        if !sub(sa, &fa.ty, sb, &fb.ty, sat_a, memo) {
+            return false;
+        }
+    }
+    // Every label B *requires* must be guaranteed by A.
+    for fb in b.fields() {
+        if fb.min >= 1 {
+            match a.field(&fb.label) {
+                None => return false,
+                Some(fa) if fa.min < fb.min => return false,
+                _ => {}
+            }
+        }
+    }
+    true
+}
+
+/// `x <= y`, treating `None` as `+infinity` (unbounded max).
+fn le(x: Option<usize>, y: Option<usize>) -> bool {
+    match y {
+        None => true,
+        Some(y) => match x {
+            None => false,
+            Some(x) => x <= y,
+        },
+    }
+}
+
+fn scalar_sub(a: Scalar, b: Scalar) -> bool {
+    if a.is_nullable() && !b.is_nullable() {
+        return false;
+    }
+    if a.kind() == b.kind() {
+        return true;
+    }
+    a.kind() == ScalarKind::Integer && b.kind() == ScalarKind::Number
+}

--- a/omnist/src/ops/tests.rs
+++ b/omnist/src/ops/tests.rs
@@ -1,0 +1,831 @@
+//! Tests for the schema-algebra ops (issue #12).
+
+use indexmap::IndexMap;
+
+use crate::schema::{
+    BOOLEAN, Field, FieldType, INTEGER, NUMBER, Record, Ref, STRING, Schema, nullable,
+};
+
+use super::*;
+
+// ---------------------------------------------------------------------------
+// Schema-building helpers
+// ---------------------------------------------------------------------------
+
+fn env(pairs: Vec<(&str, Record)>) -> IndexMap<String, Record> {
+    pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect()
+}
+
+fn rec(fields: Vec<Field>) -> Record {
+    Record::new(fields).unwrap()
+}
+
+fn f(label: &str, ty: impl Into<FieldType>, min: usize, max: Option<usize>) -> Field {
+    Field::new(label, ty, min, max).unwrap()
+}
+
+fn req(label: &str, ty: impl Into<FieldType>) -> Field {
+    Field::required(label, ty).unwrap()
+}
+
+fn opt(label: &str, ty: impl Into<FieldType>) -> Field {
+    Field::new(label, ty, 0, Some(1)).unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// signature
+// ---------------------------------------------------------------------------
+
+#[test]
+fn local_signature_sorts_by_label_and_excludes_ref_target_names() {
+    let a = rec(vec![req("z", Ref::new("Other")), req("a", STRING)]);
+    let b = rec(vec![req("z", Ref::new("Different")), req("a", STRING)]);
+    assert_eq!(
+        signature::local_signature(&a),
+        signature::local_signature(&b)
+    );
+}
+
+#[test]
+fn local_signature_distinguishes_scalar_kind_and_nullability() {
+    let a = rec(vec![req("x", STRING)]);
+    let b = rec(vec![req("x", INTEGER)]);
+    let c = rec(vec![req("x", nullable(STRING))]);
+    assert_ne!(
+        signature::local_signature(&a),
+        signature::local_signature(&b)
+    );
+    assert_ne!(
+        signature::local_signature(&a),
+        signature::local_signature(&c)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// prune
+// ---------------------------------------------------------------------------
+
+#[test]
+fn prune_drops_unreachable_records() {
+    let e = env(vec![
+        ("Root", rec(vec![req("x", STRING)])),
+        ("Unreachable", rec(vec![req("y", STRING)])),
+    ]);
+    let s = Schema::new(Ref::new("Root"), e).unwrap();
+    let pruned = prune::prune(&s);
+    assert!(pruned.env().contains_key("Root"));
+    assert!(!pruned.env().contains_key("Unreachable"));
+}
+
+#[test]
+fn prune_drops_never_emittable_fields() {
+    let e = env(vec![(
+        "Root",
+        rec(vec![f("dead", STRING, 0, Some(0)), req("x", STRING)]),
+    )]);
+    let s = Schema::new(Ref::new("Root"), e).unwrap();
+    let pruned = prune::prune(&s);
+    assert!(pruned.env().get("Root").unwrap().field("dead").is_none());
+    assert!(pruned.env().get("Root").unwrap().field("x").is_some());
+}
+
+#[test]
+fn prune_drops_optional_field_to_unsatisfiable_record() {
+    // Cyclic, all-mandatory record: never satisfiable.
+    let e = env(vec![
+        (
+            "Root",
+            rec(vec![opt("child", Ref::new("Bad")), req("x", STRING)]),
+        ),
+        ("Bad", rec(vec![req("self", Ref::new("Bad"))])),
+    ]);
+    let s = Schema::new(Ref::new("Root"), e).unwrap();
+    let pruned = prune::prune(&s);
+    assert!(pruned.env().get("Root").unwrap().field("child").is_none());
+    assert!(!pruned.env().contains_key("Bad"));
+}
+
+#[test]
+fn prune_keeps_unsatisfiable_root_fields_intact() {
+    let e = env(vec![("Root", rec(vec![req("self", Ref::new("Root"))]))]);
+    let s = Schema::new(Ref::new("Root"), e).unwrap();
+    assert!(prune::is_empty(&s));
+    let pruned = prune::prune(&s);
+    assert!(prune::is_empty(&pruned));
+    assert!(pruned.env().get("Root").unwrap().field("self").is_some());
+}
+
+/// omnist-ts#56 regression: prune's environment reconstruction must follow
+/// the *schema's own* declaration order, not the satisfiable/reachable
+/// set's iteration order.
+#[test]
+fn prune_environment_order_matches_declaration_order() {
+    let e = env(vec![
+        ("Zeta", rec(vec![req("x", STRING)])),
+        ("Alpha", rec(vec![req("x", STRING)])),
+        (
+            "Root",
+            rec(vec![
+                req("z", Ref::new("Zeta")),
+                req("a", Ref::new("Alpha")),
+            ]),
+        ),
+    ]);
+    let s = Schema::new(Ref::new("Root"), e).unwrap();
+    let pruned = prune::prune(&s);
+    let names: Vec<&String> = pruned.env().keys().collect();
+    assert_eq!(names, vec!["Zeta", "Alpha", "Root"]);
+}
+
+// ---------------------------------------------------------------------------
+// isomorphic
+// ---------------------------------------------------------------------------
+
+#[test]
+fn isomorphic_schemas_with_renamed_records() {
+    let e_a = env(vec![("A", rec(vec![req("x", STRING)]))]);
+    let e_b = env(vec![("B", rec(vec![req("x", STRING)]))]);
+    let a = Schema::new(Ref::new("A"), e_a).unwrap();
+    let b = Schema::new(Ref::new("B"), e_b).unwrap();
+    assert!(isomorphic::is_isomorphic(&a, &b));
+}
+
+#[test]
+fn non_isomorphic_schemas_differ_in_field_shape() {
+    let e_a = env(vec![("A", rec(vec![req("x", STRING)]))]);
+    let e_b = env(vec![("B", rec(vec![req("x", INTEGER)]))]);
+    let a = Schema::new(Ref::new("A"), e_a).unwrap();
+    let b = Schema::new(Ref::new("B"), e_b).unwrap();
+    assert!(!isomorphic::is_isomorphic(&a, &b));
+}
+
+#[test]
+fn both_empty_schemas_are_isomorphic() {
+    let e_a = env(vec![("A", rec(vec![req("self", Ref::new("A"))]))]);
+    let e_b = env(vec![(
+        "B",
+        rec(vec![req("x", Ref::new("B")), req("self", Ref::new("B"))]),
+    )]);
+    let a = Schema::new(Ref::new("A"), e_a).unwrap();
+    let b = Schema::new(Ref::new("B"), e_b).unwrap();
+    assert!(prune::is_empty(&a) && prune::is_empty(&b));
+    assert!(isomorphic::is_isomorphic(&a, &b));
+}
+
+#[test]
+fn only_one_empty_schema_is_not_isomorphic() {
+    let e_a = env(vec![("A", rec(vec![req("self", Ref::new("A"))]))]);
+    let e_b = env(vec![("B", rec(vec![req("x", STRING)]))]);
+    let a = Schema::new(Ref::new("A"), e_a).unwrap();
+    let b = Schema::new(Ref::new("B"), e_b).unwrap();
+    assert!(!isomorphic::is_isomorphic(&a, &b));
+}
+
+#[test]
+fn isomorphic_handles_ref_cycles_via_bijection() {
+    let e_a = env(vec![(
+        "A",
+        rec(vec![opt("next", Ref::new("A")), req("v", STRING)]),
+    )]);
+    let e_b = env(vec![(
+        "Node",
+        rec(vec![opt("next", Ref::new("Node")), req("v", STRING)]),
+    )]);
+    let a = Schema::new(Ref::new("A"), e_a).unwrap();
+    let b = Schema::new(Ref::new("Node"), e_b).unwrap();
+    assert!(isomorphic::is_isomorphic(&a, &b));
+}
+
+/// A mismatch that's only visible after recursing into a ref target -- the
+/// two roots' own `local_signature`s match (same single ref-typed field),
+/// so the walk must actually descend to `P1`/`P2` to find the disagreement.
+#[test]
+fn isomorphic_false_when_mismatch_found_only_by_recursing_into_a_ref() {
+    let e_a = env(vec![
+        ("RootA", rec(vec![req("p", Ref::new("P1"))])),
+        ("P1", rec(vec![req("v", STRING)])),
+    ]);
+    let e_b = env(vec![
+        ("RootB", rec(vec![req("p", Ref::new("P2"))])),
+        ("P2", rec(vec![req("v", INTEGER)])),
+    ]);
+    let a = Schema::new(Ref::new("RootA"), e_a).unwrap();
+    let b = Schema::new(Ref::new("RootB"), e_b).unwrap();
+    assert!(!isomorphic::is_isomorphic(&a, &b));
+}
+
+// ---------------------------------------------------------------------------
+// minimize / isomorphic joint (triple-check strategy)
+// ---------------------------------------------------------------------------
+
+/// The triple-check oracle: minimize's result must (a) accept exactly the
+/// same documents as the input, verified via the *independent*
+/// `subschema::equivalent` algorithm (bidirectional inclusion, unrelated to
+/// partition refinement), and (b) already be a fixpoint of minimization --
+/// `is_isomorphic` (also independent of both) must find it isomorphic to
+/// re-minimizing it. A literal `is_isomorphic(s, minimize(s))` is *not* the
+/// right check when `s` itself has redundant structurally-identical
+/// records: minimize legitimately shrinks the record count then, so the two
+/// env graphs are no longer size-equal (never isomorphic in the strict
+/// name-bijection sense), even though they remain semantically equivalent
+/// -- exactly DFA minimization vs. the original, unminimized DFA. This
+/// mirrors the Python reference's own test suite, which always calls
+/// `_isomorphic(s.normalize(), t.normalize())`, never on a raw schema.
+fn assert_minimize_preserves_semantics_and_reaches_a_fixpoint(s: &Schema) {
+    let m = minimize::normalize(s);
+    assert!(
+        subschema::equivalent(s, &m),
+        "minimize(s) must accept exactly the same documents as s"
+    );
+    let m2 = minimize::normalize(&m);
+    assert!(
+        isomorphic::is_isomorphic(&m, &m2),
+        "re-minimizing an already-minimal schema must reach the same (isomorphic) fixpoint"
+    );
+}
+
+#[test]
+fn minimize_merges_structurally_identical_records() {
+    let e = env(vec![
+        (
+            "Root",
+            rec(vec![req("a", Ref::new("A")), req("b", Ref::new("B"))]),
+        ),
+        ("A", rec(vec![req("x", STRING)])),
+        ("B", rec(vec![req("x", STRING)])),
+    ]);
+    let s = Schema::new(Ref::new("Root"), e).unwrap();
+    let m = minimize::normalize(&s);
+    // A and B are structurally identical -> collapse to one record.
+    assert_eq!(m.env().len(), 2);
+    assert_minimize_preserves_semantics_and_reaches_a_fixpoint(&s);
+}
+
+#[test]
+fn minimize_is_a_no_op_on_an_already_minimal_schema() {
+    let e = env(vec![("Root", rec(vec![req("x", STRING)]))]);
+    let s = Schema::new(Ref::new("Root"), e).unwrap();
+    let m = minimize::normalize(&s);
+    assert_eq!(m.env().len(), 1);
+    assert_minimize_preserves_semantics_and_reaches_a_fixpoint(&s);
+}
+
+#[test]
+fn minimize_on_unsatisfiable_root_returns_pruned_schema_unchanged() {
+    let e = env(vec![("Root", rec(vec![req("self", Ref::new("Root"))]))]);
+    let s = Schema::new(Ref::new("Root"), e).unwrap();
+    let m = minimize::normalize(&s);
+    assert!(prune::is_empty(&m));
+    assert_minimize_preserves_semantics_and_reaches_a_fixpoint(&s);
+}
+
+#[test]
+fn minimize_handles_ref_cycles() {
+    // Two isomorphic-but-differently-named cyclic linked lists sharing the
+    // same shape; each should minimize down to a single self-referential
+    // record.
+    let e_a = env(vec![
+        (
+            "Root",
+            rec(vec![opt("next", Ref::new("Mid")), req("v", STRING)]),
+        ),
+        (
+            "Mid",
+            rec(vec![opt("next", Ref::new("Root")), req("v", STRING)]),
+        ),
+    ]);
+    let a = Schema::new(Ref::new("Root"), e_a).unwrap();
+    let m = minimize::normalize(&a);
+    assert_eq!(m.env().len(), 1);
+    assert_minimize_preserves_semantics_and_reaches_a_fixpoint(&a);
+}
+
+#[test]
+fn minimize_equivalence_classes_groups_duplicates() {
+    let e = env(vec![
+        (
+            "Root",
+            rec(vec![
+                req("a", Ref::new("A")),
+                req("b", Ref::new("B")),
+                req("c", Ref::new("C")),
+            ]),
+        ),
+        ("A", rec(vec![req("x", STRING)])),
+        ("B", rec(vec![req("x", STRING)])),
+        ("C", rec(vec![req("x", INTEGER)])),
+    ]);
+    let s = Schema::new(Ref::new("Root"), e).unwrap();
+    let blocks = minimize::equivalence_classes(&s);
+    let dup_block: Vec<&Vec<String>> = blocks.iter().filter(|b| b.len() > 1).collect();
+    assert_eq!(dup_block.len(), 1);
+    let mut names = dup_block[0].clone();
+    names.sort();
+    assert_eq!(names, vec!["A".to_string(), "B".to_string()]);
+}
+
+/// Forces `equivalence_classes`'s refine loop through more than one
+/// iteration: `X` and `Y` share a `local_signature` initially (both have a
+/// single ref-typed field `p`), so they start in the same block, and are
+/// only split once refinement notices their `p` targets (`P`/`Q`) land in
+/// different blocks -- which itself only happened because `P`/`Q` already
+/// differ by scalar kind at the *initial* partition. Without this test the
+/// refine loop's "still changing, keep looping" branch was never exercised.
+#[test]
+fn minimize_equivalence_classes_needs_more_than_one_refine_pass() {
+    let e = env(vec![
+        (
+            "Root",
+            rec(vec![req("x", Ref::new("X")), req("y", Ref::new("Y"))]),
+        ),
+        ("X", rec(vec![req("p", Ref::new("P"))])),
+        ("Y", rec(vec![req("p", Ref::new("Q"))])),
+        ("P", rec(vec![req("v", STRING)])),
+        ("Q", rec(vec![req("v", INTEGER)])),
+    ]);
+    let s = Schema::new(Ref::new("Root"), e).unwrap();
+    let blocks = minimize::equivalence_classes(&s);
+    // Every one of the 5 records is structurally distinct -- X and Y must
+    // NOT collapse together despite sharing an initial local_signature.
+    assert_eq!(blocks.len(), 5);
+    let m = minimize::normalize(&s);
+    assert_eq!(m.env().len(), 5);
+    assert_minimize_preserves_semantics_and_reaches_a_fixpoint(&s);
+}
+
+// ---------------------------------------------------------------------------
+// subschema
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compatible_with_widening_cardinality_and_integer_to_number() {
+    let e_a = env(vec![("A", rec(vec![req("x", INTEGER)]))]);
+    let e_b = env(vec![("B", rec(vec![f("x", NUMBER, 0, Some(3))]))]);
+    let a = Schema::new(Ref::new("A"), e_a).unwrap();
+    let b = Schema::new(Ref::new("B"), e_b).unwrap();
+    assert!(subschema::compatible_with(&a, &b));
+    assert!(!subschema::compatible_with(&b, &a));
+}
+
+#[test]
+fn compatible_with_rejects_missing_required_field_in_b() {
+    let e_a = env(vec![("A", rec(vec![req("x", STRING)]))]);
+    let e_b = env(vec![("B", rec(vec![req("x", STRING), req("y", STRING)]))]);
+    let a = Schema::new(Ref::new("A"), e_a).unwrap();
+    let b = Schema::new(Ref::new("B"), e_b).unwrap();
+    // a has no "y" that b requires.
+    assert!(!subschema::compatible_with(&a, &b));
+}
+
+#[test]
+fn compatible_with_rejects_narrower_nullability() {
+    let e_a = env(vec![("A", rec(vec![req("x", nullable(STRING))]))]);
+    let e_b = env(vec![("B", rec(vec![req("x", STRING)]))]);
+    let a = Schema::new(Ref::new("A"), e_a).unwrap();
+    let b = Schema::new(Ref::new("B"), e_b).unwrap();
+    assert!(!subschema::compatible_with(&a, &b));
+    assert!(subschema::compatible_with(&b, &a));
+}
+
+#[test]
+fn compatible_with_vacuously_true_for_unsatisfiable_a() {
+    let e_a = env(vec![("A", rec(vec![req("self", Ref::new("A"))]))]);
+    let e_b = env(vec![("B", rec(vec![req("x", STRING)]))]);
+    let a = Schema::new(Ref::new("A"), e_a).unwrap();
+    let b = Schema::new(Ref::new("B"), e_b).unwrap();
+    assert!(subschema::compatible_with(&a, &b));
+}
+
+#[test]
+fn compatible_with_a_scalar_field_is_never_compatible_with_a_record_field() {
+    let e_a = env(vec![("A", rec(vec![req("x", STRING)]))]);
+    let e_b = env(vec![
+        ("B", rec(vec![req("x", Ref::new("X"))])),
+        ("X", rec(vec![req("v", STRING)])),
+    ]);
+    let a = Schema::new(Ref::new("A"), e_a).unwrap();
+    let b = Schema::new(Ref::new("B"), e_b).unwrap();
+    assert!(!subschema::compatible_with(&a, &b));
+}
+
+#[test]
+fn compatible_with_skips_a_never_emitted_field_in_a() {
+    // "z" has max == 0 in A -- A never emits it, so B needn't declare it at
+    // all.
+    let e_a = env(vec![(
+        "A",
+        rec(vec![req("x", STRING), f("z", STRING, 0, Some(0))]),
+    )]);
+    let e_b = env(vec![("B", rec(vec![req("x", STRING)]))]);
+    let a = Schema::new(Ref::new("A"), e_a).unwrap();
+    let b = Schema::new(Ref::new("B"), e_b).unwrap();
+    assert!(subschema::compatible_with(&a, &b));
+}
+
+#[test]
+fn compatible_with_skips_an_optional_field_typed_to_an_unsatisfiable_a_record() {
+    // "bad" is optional in A and typed to an unsatisfiable (cyclic
+    // mandatory) A-side record -- A can never actually emit it, so B
+    // needn't declare it either.
+    let e_a = env(vec![
+        (
+            "A",
+            rec(vec![req("x", STRING), opt("bad", Ref::new("Cycle"))]),
+        ),
+        ("Cycle", rec(vec![req("self", Ref::new("Cycle"))])),
+    ]);
+    let e_b = env(vec![("B", rec(vec![req("x", STRING)]))]);
+    let a = Schema::new(Ref::new("A"), e_a).unwrap();
+    let b = Schema::new(Ref::new("B"), e_b).unwrap();
+    assert!(subschema::compatible_with(&a, &b));
+}
+
+#[test]
+fn compatible_with_rejects_a_field_b_does_not_declare_at_all() {
+    let e_a = env(vec![(
+        "A",
+        rec(vec![req("x", STRING), req("extra", STRING)]),
+    )]);
+    let e_b = env(vec![("B", rec(vec![req("x", STRING)]))]);
+    let a = Schema::new(Ref::new("A"), e_a).unwrap();
+    let b = Schema::new(Ref::new("B"), e_b).unwrap();
+    // B is closed and has no "extra" field.
+    assert!(!subschema::compatible_with(&a, &b));
+}
+
+#[test]
+fn compatible_with_unbounded_b_max_accepts_a_bounded_a_max() {
+    let e_a = env(vec![("A", rec(vec![f("x", STRING, 0, Some(2))]))]);
+    let e_b = env(vec![("B", rec(vec![f("x", STRING, 0, None)]))]);
+    let a = Schema::new(Ref::new("A"), e_a).unwrap();
+    let b = Schema::new(Ref::new("B"), e_b).unwrap();
+    assert!(subschema::compatible_with(&a, &b));
+}
+
+#[test]
+fn compatible_with_unbounded_a_max_is_incompatible_with_a_bounded_b_max() {
+    let e_a = env(vec![("A", rec(vec![f("x", STRING, 0, None)]))]);
+    let e_b = env(vec![("B", rec(vec![f("x", STRING, 0, Some(2))]))]);
+    let a = Schema::new(Ref::new("A"), e_a).unwrap();
+    let b = Schema::new(Ref::new("B"), e_b).unwrap();
+    assert!(!subschema::compatible_with(&a, &b));
+}
+
+#[test]
+fn equivalent_matches_isomorphic_oracle_across_random_pairs() {
+    // Dual-algorithm oracle: equivalent(a, b) must agree with
+    // is_isomorphic(normalize(a), normalize(b)) across a handful of
+    // schema pairs, including a cyclic one.
+    let cases: Vec<(Schema, Schema, bool)> = vec![
+        {
+            let e_a = env(vec![("A", rec(vec![req("x", STRING)]))]);
+            let e_b = env(vec![("B", rec(vec![req("x", STRING)]))]);
+            (
+                Schema::new(Ref::new("A"), e_a).unwrap(),
+                Schema::new(Ref::new("B"), e_b).unwrap(),
+                true,
+            )
+        },
+        {
+            let e_a = env(vec![("A", rec(vec![req("x", STRING)]))]);
+            let e_b = env(vec![("B", rec(vec![req("x", INTEGER)]))]);
+            (
+                Schema::new(Ref::new("A"), e_a).unwrap(),
+                Schema::new(Ref::new("B"), e_b).unwrap(),
+                false,
+            )
+        },
+        {
+            let e_a = env(vec![
+                (
+                    "Root",
+                    rec(vec![opt("next", Ref::new("Mid")), req("v", STRING)]),
+                ),
+                (
+                    "Mid",
+                    rec(vec![opt("next", Ref::new("Root")), req("v", STRING)]),
+                ),
+            ]);
+            let e_b = env(vec![(
+                "N",
+                rec(vec![opt("next", Ref::new("N")), req("v", STRING)]),
+            )]);
+            (
+                Schema::new(Ref::new("Root"), e_a).unwrap(),
+                Schema::new(Ref::new("N"), e_b).unwrap(),
+                true,
+            )
+        },
+    ];
+    for (a, b, expected) in cases {
+        let via_subschema = subschema::equivalent(&a, &b);
+        let via_isomorphic =
+            isomorphic::is_isomorphic(&minimize::normalize(&a), &minimize::normalize(&b));
+        assert_eq!(via_subschema, expected);
+        assert_eq!(via_isomorphic, expected);
+        assert_eq!(via_subschema, via_isomorphic);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// extract
+// ---------------------------------------------------------------------------
+
+#[test]
+fn extract_keeps_only_requested_labels() {
+    let e = env(vec![(
+        "Root",
+        rec(vec![req("keep", STRING), opt("drop", STRING)]),
+    )]);
+    let s = Schema::new(Ref::new("Root"), e).unwrap();
+    let out = extract::extract(&s, &["keep"]).unwrap();
+    let root = out.env().get(out.root().name.as_str()).unwrap();
+    assert!(root.field("keep").is_some());
+    assert!(root.field("drop").is_none());
+}
+
+#[test]
+fn extract_errors_when_root_mandatory_field_is_dropped() {
+    let e = env(vec![("Root", rec(vec![req("mandatory", STRING)]))]);
+    let s = Schema::new(Ref::new("Root"), e).unwrap();
+    let err = extract::extract(&s, &[]).unwrap_err();
+    assert!(err.to_string().contains("no valid subschema"));
+    assert!(err.to_string().contains("mandatory"));
+}
+
+#[test]
+fn extract_propagates_invalidation_through_a_chain() {
+    // "child" is kept (so Root's mandatory ref field to Child survives step
+    // 1 untouched), but Child's own mandatory field "gone" is not kept --
+    // Child is invalidated directly in step 1, then that invalidation must
+    // *propagate* to Root in step 3 (Root's field to Child is itself
+    // mandatory), not be caught by step 1 alone.
+    let e = env(vec![
+        ("Root", rec(vec![req("child", Ref::new("Child"))])),
+        ("Child", rec(vec![req("gone", STRING)])),
+    ]);
+    let s = Schema::new(Ref::new("Root"), e).unwrap();
+    let err = extract::extract(&s, &["child"]).unwrap_err();
+    assert!(err.to_string().contains("no valid subschema"));
+    assert!(err.to_string().contains("gone"));
+}
+
+/// A record invalidated only via a field that's *optional* in its parent:
+/// the parent survives (it never actually requires that field), so
+/// `extract` must succeed while still dropping the invalidated record and
+/// the now-dangling optional ref field that pointed to it (step 5's
+/// per-record skip for an already-invalidated name).
+#[test]
+fn extract_drops_an_invalidated_record_reached_only_optionally() {
+    let e = env(vec![
+        (
+            "Root",
+            rec(vec![req("keep", STRING), opt("child", Ref::new("Child"))]),
+        ),
+        ("Child", rec(vec![req("gone", STRING)])),
+    ]);
+    let s = Schema::new(Ref::new("Root"), e).unwrap();
+    let out = extract::extract(&s, &["keep", "child"]).unwrap();
+    assert!(!out.env().contains_key("Child"));
+    let root = out.env().get(out.root().name.as_str()).unwrap();
+    assert!(root.field("child").is_none());
+}
+
+/// Two independent step-1 drops (one per unreachable-but-still-in-env
+/// record): `first_offender` must be recorded once, on the first one seen,
+/// and left alone on the second -- the error message names the first
+/// offender specifically, not whichever happened to be found last.
+#[test]
+fn extract_first_offender_is_recorded_only_once_across_multiple_invalidations() {
+    let e = env(vec![
+        ("Root", rec(vec![req("child", Ref::new("Child"))])),
+        ("Child", rec(vec![req("gone", STRING)])),
+        ("AlsoBad", rec(vec![req("also_gone", STRING)])),
+    ]);
+    let s = Schema::new(Ref::new("Root"), e).unwrap();
+    let err = extract::extract(&s, &["child"]).unwrap_err();
+    // "gone" (Child) is declared before "also_gone" (AlsoBad) in the env,
+    // so it must be the one named, even though AlsoBad is also invalidated.
+    assert!(err.to_string().contains("gone"));
+    assert!(!err.to_string().contains("also_gone"));
+}
+
+#[test]
+fn extract_result_is_pruned_and_normalized() {
+    let e = env(vec![
+        (
+            "Root",
+            rec(vec![
+                req("keep", STRING),
+                req("a", Ref::new("A")),
+                req("b", Ref::new("B")),
+            ]),
+        ),
+        ("A", rec(vec![req("x", STRING)])),
+        ("B", rec(vec![req("x", STRING)])),
+    ]);
+    let s = Schema::new(Ref::new("Root"), e).unwrap();
+    let out = extract::extract(&s, &["keep", "a", "b", "x"]).unwrap();
+    // A and B are structurally identical -- normalize should have merged
+    // them.
+    assert_eq!(out.env().len(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// lint
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lint_flags_unreachable_and_unsatisfiable_and_duplicate_records() {
+    let e = env(vec![
+        (
+            "Root",
+            rec(vec![req("a", Ref::new("A")), req("bad", Ref::new("Bad"))]),
+        ),
+        ("A", rec(vec![req("x", STRING)])),
+        ("Dup", rec(vec![req("x", STRING)])),
+        ("Bad", rec(vec![req("self", Ref::new("Bad"))])),
+        ("Orphan", rec(vec![req("x", STRING)])),
+    ]);
+    let s = Schema::new(Ref::new("Root"), e).unwrap();
+    let findings = lint::lint(&s);
+    let codes: Vec<&str> = findings.iter().map(|f| f.code).collect();
+    assert!(codes.contains(&"unsatisfiable-record"));
+    assert!(codes.contains(&"unreachable-record"));
+    assert!(codes.contains(&"duplicate-record"));
+    assert!(findings.iter().any(|f| f.location == "Bad"));
+    assert!(findings.iter().any(|f| f.location == "Orphan"));
+}
+
+#[test]
+fn lint_is_sorted_by_code_then_location() {
+    let e = env(vec![
+        ("Root", rec(vec![req("x", STRING)])),
+        ("Zeta", rec(vec![req("x", STRING)])),
+        ("Alpha", rec(vec![req("x", STRING)])),
+    ]);
+    let s = Schema::new(Ref::new("Root"), e).unwrap();
+    let findings = lint::lint(&s);
+    let mut sorted = findings.clone();
+    sorted.sort_by(|a, b| (a.code, &a.location).cmp(&(b.code, &b.location)));
+    assert_eq!(findings, sorted);
+}
+
+/// omnist-ts#56 regression: lint's ordering must be codepoint order (byte-
+/// wise on UTF-8), not locale-aware (`localeCompare`-style) order, which
+/// would sort e.g. accented/mixed-case labels differently. This mixes case
+/// and a non-ASCII (accented) record name where codepoint and locale order
+/// diverge for common locales.
+#[test]
+fn lint_ordering_is_codepoint_not_locale_non_ascii_mixed_case() {
+    let e = env(vec![
+        (
+            "Root",
+            rec(vec![
+                req("a", Ref::new("aardvark")),
+                req("b", Ref::new("Zebra")),
+                req("c", Ref::new("\u{e9}clair")), // "éclair" -- unreachable/unsatisfiable-record location
+            ]),
+        ),
+        ("aardvark", rec(vec![req("self", Ref::new("aardvark"))])), // unsatisfiable
+        ("Zebra", rec(vec![req("self", Ref::new("Zebra"))])),       // unsatisfiable
+        (
+            "\u{e9}clair",
+            rec(vec![req("self", Ref::new("\u{e9}clair"))]),
+        ), // unsatisfiable
+        ("Orphan", rec(vec![req("x", STRING)])),
+        ("aOrphan", rec(vec![req("x", STRING)])),
+    ]);
+    let s = Schema::new(Ref::new("Root"), e).unwrap();
+    let findings = lint::lint(&s);
+    let unsat_locations: Vec<&str> = findings
+        .iter()
+        .filter(|f| f.code == "unsatisfiable-record")
+        .map(|f| f.location.as_str())
+        .collect();
+    // Codepoint order: 'R' (0x52) < 'Z' (0x5A) < 'a' (0x61) < 'é' (0xE9) --
+    // "Root" itself is unsatisfiable too (its mandatory fields all point at
+    // unsatisfiable records) and sorts first; a locale-aware sort would
+    // instead place "Zebra" after "aardvark" (case-insensitive) and
+    // "éclair" among the "e"s.
+    assert_eq!(
+        unsat_locations,
+        vec!["Root", "Zebra", "aardvark", "\u{e9}clair"]
+    );
+
+    let unreachable_locations: Vec<&str> = findings
+        .iter()
+        .filter(|f| f.code == "unreachable-record")
+        .map(|f| f.location.as_str())
+        .collect();
+    // "Orphan" (0x4F) sorts before "aOrphan" (0x61) in codepoint order.
+    assert_eq!(unreachable_locations, vec!["Orphan", "aOrphan"]);
+}
+
+#[test]
+fn lint_never_mutates_the_schema() {
+    let e = env(vec![("Root", rec(vec![req("x", STRING)]))]);
+    let s = Schema::new(Ref::new("Root"), e).unwrap();
+    let before = s.clone();
+    let _ = lint::lint(&s);
+    assert_eq!(s, before);
+}
+
+// ---------------------------------------------------------------------------
+// Determinism audit
+// ---------------------------------------------------------------------------
+
+/// A schema large enough that hash-based (HashMap/HashSet) iteration would
+/// visibly reorder output across repeated runs, if any op leaked it.
+fn large_schema() -> Schema {
+    let mut e: IndexMap<String, Record> = IndexMap::new();
+    // 40 leaf records with varying shapes, plus a root referencing all of
+    // them, plus a chain of duplicate-shaped records to exercise minimize's
+    // equivalence classes and lint's duplicate-record check at scale.
+    let mut root_fields = Vec::new();
+    for i in 0..40 {
+        let name = format!("Leaf{i:02}");
+        let ty = if i % 3 == 0 {
+            INTEGER
+        } else if i % 3 == 1 {
+            STRING
+        } else {
+            BOOLEAN
+        };
+        e.insert(name.clone(), rec(vec![req("v", ty)]));
+        root_fields.push(opt(&format!("f{i:02}"), Ref::new(name)));
+    }
+    e.insert("Root".to_string(), rec(root_fields));
+    Schema::new(Ref::new("Root"), e).unwrap()
+}
+
+#[test]
+fn determinism_repeated_runs_produce_identical_output_for_every_op() {
+    let s = large_schema();
+
+    let first_prune = prune::prune(&s);
+    let first_normalize = minimize::normalize(&s);
+    let first_lint = lint::lint(&s);
+    let first_classes = minimize::equivalence_classes(&s);
+
+    for _ in 0..25 {
+        assert_eq!(prune::prune(&s), first_prune);
+        assert_eq!(minimize::normalize(&s), first_normalize);
+        assert_eq!(lint::lint(&s), first_lint);
+        assert_eq!(minimize::equivalence_classes(&s), first_classes);
+    }
+
+    // Env key order specifically (not just set-equality) must be stable.
+    let prune_order: Vec<String> = first_prune.env().keys().cloned().collect();
+    for _ in 0..25 {
+        let again_schema = prune::prune(&s);
+        let again: Vec<String> = again_schema.env().keys().cloned().collect();
+        assert_eq!(again, prune_order);
+    }
+}
+
+#[test]
+fn no_hashmap_or_hashset_in_ops_source() {
+    // Static grep-style guard: the ops module must never reach for
+    // std::collections::HashMap/HashSet (nondeterministic iteration order).
+    // This is a coarse text check on the crate's own source, run as part of
+    // the test suite so a future regression fails CI, not just an audit.
+    let src_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/src/ops");
+    // Only the non-test source modules -- this file itself legitimately
+    // mentions "HashMap"/"HashSet" in prose (this very check, and doc
+    // comments explaining what NOT to use).
+    // mod.rs is excluded: it's pure doc-comments and re-exports (no logic
+    // of its own), and its module doc comment explicitly *names*
+    // `std::collections::HashMap` in prose to explain why the module
+    // avoids it -- a legitimate mention, not a usage.
+    let source_files = [
+        "signature.rs",
+        "isomorphic.rs",
+        "prune.rs",
+        "minimize.rs",
+        "subschema.rs",
+        "extract.rs",
+        "lint.rs",
+    ];
+    for name in source_files {
+        let path = std::path::Path::new(src_dir).join(name);
+        let contents = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("failed to read {path:?}: {e}"));
+        // Look for actual type usage (`HashMap<`/`HashSet<` or the
+        // `std::collections::` path), not mere prose mentions in doc
+        // comments explaining what NOT to use (e.g. this module's own
+        // module-level doc comment).
+        for needle in [
+            "HashMap<",
+            "HashSet<",
+            "collections::HashMap",
+            "collections::HashSet",
+        ] {
+            assert!(
+                !contents.contains(needle),
+                "{path:?} must not use HashMap/HashSet -- use IndexMap/IndexSet instead \
+                 (found {needle:?})"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes #12

## Summary

Completes the schema-algebra port. The prior WIP commit (83cb992) drafted
`signature`/`isomorphic`/`prune` but never wired `ops` into `lib.rs` -- the
whole module was uncompiled, untested dead code. This PR:

- Adds the four missing ops: `minimize` (partition-refinement to canonical
  minimal form), `subschema` (bidirectional inclusion / compatibility),
  `extract` (subschema extraction with mandatory-field invalidation
  propagation), `lint` (structural diagnostics: unsatisfiable/unreachable/
  duplicate records).
- Wires `pub mod ops;` into `lib.rs` (this alone is why the WIP had zero
  runnable tests -- red state #1, see below).
- Fixes two real bugs found reviewing the WIP draft against the Python
  reference and issue spec (both are unreachable-dead-code fixes, not
  behavior changes -- see "Bugs found" below).
- Brings the whole module to 100% line coverage, a determinism audit, and
  the omnist-ts#56 ordering regression tests.

## What was kept vs. fixed vs. rewritten from the WIP

**Kept as-is** (reviewed, matches Python reference and issue spec):
`signature::local_signature`, `isomorphic::is_isomorphic`,
`prune::{satisfiable_set, is_empty, prune}` (algorithm logic).

**Fixed** (unreachable dead code, confirmed via `cargo llvm-cov`, same
pattern as `oml.rs`'s `scan_number` precedent from PR #11):
- `prune::reachable_from_root` had `let Some(rec) = s.env().get(&name) else
  { continue }` -- `Schema::new`'s `check_refs` guarantees every visited
  name resolves, so the `else` arm is unreachable. Replaced with a
  documented `.expect()`.
- `lint::reachable` had the identical pattern; same fix.
- `minimize::normalize`'s `new_root_name` and `remap`'s ref-target lookup
  each had a `.unwrap_or_else(|| name.clone())` fallback -- `rep` is built
  from `equivalence_classes` over every name in `pruned.env()`, so the
  fallback can never fire. Replaced with documented `.expect()`s.

**Added new** (the four ops the WIP was missing), plus `lib.rs`'s `pub mod
ops;` line and the full `tests.rs`.

## Red-before-green evidence

**Red #1** -- the WIP itself was never compiled/tested:
```
$ cargo test --workspace ops::
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 192 filtered out
```
(`ops` wasn't declared in `lib.rs` at all.)

**Red #2** -- after wiring `ops` in and writing `tests.rs` against the WIP +
new ops, before fixing bugs found along the way:
```
test ops::tests::lint_ordering_is_codepoint_not_locale_non_ascii_mixed_case ... FAILED
test ops::tests::minimize_handles_ref_cycles ... FAILED
test ops::tests::minimize_merges_structurally_identical_records ... FAILED
test ops::tests::no_hashmap_or_hashset_in_ops_source ... FAILED
test result: FAILED. 28 passed; 4 failed
```
Root causes: (a) a bad test premise -- literal `is_isomorphic(s, minimize(s))`
is wrong when `s` has redundant records (minimize legitimately shrinks
record count, so the env graphs aren't size-equal / never isomorphic in the
strict sense -- exactly DFA minimization vs. the original DFA); fixed by
testing `subschema::equivalent(s, minimize(s))` plus idempotence instead.
(b) my own test's expected lint order omitted "Root" (which is itself
unsatisfiable in that fixture). (c) my own "no HashMap" test's substring
grep tripped on its own prose. All three were test bugs, not implementation
bugs.

**Green** -- final state:
```
$ cargo test --workspace
test result: ok. 234 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Coverage-driven follow-up: `cargo llvm-cov` flagged 4 more unreachable
regions (the two bugs listed above) and one real test gap (the refine
loop's "still changing, keep looping" branch was never exercised) -- added
`minimize_equivalence_classes_needs_more_than_one_refine_pass` to force a
genuine two-iteration refinement (X/Y sharing an initial signature, split
only once P/Q's already-different block ids are visible).

## Coverage

```
$ cargo llvm-cov --workspace --fail-under-lines 100
...
TOTAL    5748    54    99.06%   345   0   100.00%   3160   0   100.00%   0   0   -
```
Exit 0. Every `ops/*.rs` file is at 100% lines (extract.rs needed one
signature change to get there -- see below).

One coverage/design note: `extract` originally took a generic
`impl IntoIterator<Item: Into<String>>` (matching the doc-comment plan).
`cargo llvm-cov` counts per-monomorphization coverage separately, and my
tests called it with several different concrete argument types (array
literals of different lengths, `Vec::<String>::new()`), which meant the
aggregate "lines" stat sat at 98.5% despite every source line executing
under *some* instantiation -- not a real behavior gap. Switched `extract`
to a concrete `&[&str]` parameter, which is also plainly simpler for
callers and sidesteps the issue entirely.

## Determinism audit

- `grep`-style test (`no_hashmap_or_hashset_in_ops_source`) asserts none of
  `signature.rs`/`isomorphic.rs`/`prune.rs`/`minimize.rs`/`subschema.rs`/
  `extract.rs`/`lint.rs` reference `HashMap`/`HashSet` as a type (`mod.rs`
  is prose-only and legitimately *names* `HashMap` to explain why it's
  avoided).
- `determinism_repeated_runs_produce_identical_output_for_every_op`: 25
  repeated calls to `prune`/`normalize`/`lint`/`equivalence_classes` on a
  41-record schema assert byte-identical output every time, including
  `prune`'s env key **order** specifically (not just set-equality).

## omnist-ts#56 regression tests

- `prune_environment_order_matches_declaration_order`: pruned env
  iterates in the schema's own declaration order, not the
  satisfiable/reachable set's iteration order.
- `lint_ordering_is_codepoint_not_locale_non_ascii_mixed_case`: mixes case
  (`"Zebra"` vs. `"aardvark"`) and a non-ASCII label (`"éclair"`) where
  codepoint order and common-locale `localeCompare` order diverge; asserts
  the codepoint order Rust's default `Ord` on `String` already gives.

## Python cross-check

Live Python `omnist.ops.*` (venv at `~/dev/venvs/omnist`, `omnist` 0.7.9,
installed editable from `~/dev/omnist`), run against the exact schemas used
in the Rust tests:

| Check | Python output | Rust output |
|---|---|---|
| `prune` env order | `['Zeta', 'Alpha', 'Root']` | same |
| `minimize` merge (A≡B) | env len 2, keeps `A` | same |
| multi-pass refine blocks | 5 singleton blocks | same |
| `lint` unsatisfiable order | `['Root', 'Zebra', 'aardvark', 'éclair']` | same |
| `lint` unreachable order | `['Orphan', 'aOrphan']` | same |
| `compatible_with` unbounded B | `True` | same |
| `compatible_with` unbounded A vs. bounded B | `False` | same |
| `extract` chain-invalidation error | `"...deletes a mandatory field of record 'Child'"` | same message shape |

No discrepancy found -- clean pass, nothing filed upstream.

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (234 passed)
- [x] `cargo llvm-cov --workspace --fail-under-lines 100` (100.00% lines,
      exit 0)
- [x] Determinism proven by repeated-run test
- [x] omnist-ts#56 regressions covered
- [x] Cross-checked against live Python `omnist.ops.*`
