### PR TITLE
Add XML codec (issue #22)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,7 @@ name = "omnist"
 version = "0.0.1-alpha"
 dependencies = [
  "indexmap",
+ "quick-xml",
  "regex",
  "thiserror",
  "toml_edit",
@@ -94,6 +95,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/omnist/Cargo.toml
+++ b/omnist/Cargo.toml
@@ -13,3 +13,4 @@ thiserror = "2"
 regex = "1"
 yaml-rust2 = { version = "0.11.0", default-features = false }
 toml_edit = { version = "0.25.13", default-features = false, features = ["parse", "display"] }
+quick-xml = "0.41.0"

--- a/omnist/src/formats/mod.rs
+++ b/omnist/src/formats/mod.rs
@@ -10,8 +10,10 @@
 //! [`crate::report`].
 //!
 //! This issue (#16) added the first of the four: [`json`]. Issue #18 added
-//! [`yaml`]; issue #20 adds [`toml`].
+//! [`yaml`]; issue #20 added [`toml`]; issue #22 adds [`xml`], the last and
+//! structurally different one -- see `xml.rs`'s own doc comment.
 
 pub mod json;
 pub mod toml;
+pub mod xml;
 pub mod yaml;

--- a/omnist/src/formats/xml.rs
+++ b/omnist/src/formats/xml.rs
@@ -1,0 +1,713 @@
+//! XML codec. Ported from `~/dev/omnist/omnist/formats.py`'s
+//! `read_xml`/`write_xml`/`check_xml`.
+//!
+//! ## Structural difference from `json.rs`/`yaml.rs`/`toml.rs`
+//!
+//! Per the Python module's own top docstring: "XML uses repeated elements
+//! directly, so it preserves interleaving on read and needs a single
+//! document element on write." Unlike the other three codecs, which all
+//! project through [`crate::document::Doc::to_grouped`] (the JSON-shaped
+//! "same-label edges become an array" representation), this module goes
+//! through [`crate::document::Doc::from_raw`]/[`Doc::to_raw`] and
+//! [`crate::document::RawNode`] instead -- the same interleaving-preserving
+//! path `crate::oml` uses, and for the same reason: XML element order can
+//! interleave distinct labels arbitrarily (`<b/><c/><b/>`), which a
+//! `Value::Object`'s `IndexMap` cannot represent (see `RawNode`'s own doc
+//! comment in `document.rs`). Read builds a `RawNode` directly from the
+//! parsed element tree; write walks `Doc::to_raw()` directly, never
+//! `to_grouped()`.
+//!
+//! ## Crate choice: `quick-xml`, advisory-checked
+//!
+//! [`quick_xml`] is used for read-side tokenization only (default features,
+//! no `serde`); the omnist-specific layer -- interleaving/repetition
+//! preservation, the depth guard, scalar coercion, all-occurrences
+//! sanitization -- is hand-written, mirroring `yaml.rs`/`toml.rs`'s
+//! crate-for-tokenization-plus-hand-written-logic pattern.
+//!
+//! Checked per the omnist-ts#38 concern (an unfixable `fast-xml-parser`
+//! GHSA advisory the TS port could not shed): `cargo audit` against this
+//! crate's full dependency tree (29 crates, including `quick-xml` 0.41.0)
+//! on 2026-07-26 against the RustSec advisory database (1169 advisories
+//! loaded) found **zero** matches -- `quick-xml` has no open advisory at
+//! this version, unlike TS's situation. Additionally, `quick-xml` has no
+//! DTD/external-entity expansion support at all (only the five predefined
+//! XML entities `&lt; &gt; &amp; &apos; &quot;` are recognized; an
+//! undefined entity reference is a parse error, not silently resolved) --
+//! so, unlike Python's `read_xml` (which specifically requires
+//! `defusedxml` instead of the stdlib `xml.etree.ElementTree`, precisely to
+//! shut off XXE/entity-expansion attacks), this port has no equivalent
+//! opt-in needed: the crate is XXE-safe by construction, not by
+//! configuration.
+//!
+//! ## Namespace handling: a disclosed simplification
+//!
+//! Python's `read_xml` uses `ElementTree`, which resolves a namespaced tag
+//! into Clark notation (`{uri}local`) and `_local()` strips the `{uri}`
+//! prefix to get the bare local name. `quick_xml` (used here in
+//! non-namespace-aware mode) does not perform namespace URI resolution;
+//! [`local_name`] instead strips a lexical `prefix:` (up to the last `:`)
+//! from a tag, which coincides with Python's behavior for the common case
+//! (a declared, in-scope prefix) but does not resolve prefixes through
+//! `xmlns` declarations the way real namespace-aware processing would.
+//! Namespaces are outside this issue's spec (the Python docstring never
+//! mentions them), so this is a deliberate, disclosed simplification, not
+//! a claimed parity guarantee.
+//!
+//! ## Scalar coercion, confirmed against live Python (omnist-ts#53 lesson)
+//!
+//! `omnist-ts#53` found TS's XML scalar coercion narrower than Python's,
+//! undocumented. This module's [`coerce`] was checked against a live
+//! `~/dev/venvs/omnist` interpreter's `omnist.formats._coerce`, not
+//! assumed. Confirmed rules (see this module's tests for the exact
+//! input/output pairs exercised):
+//!
+//! * Empty string reads as the empty string `""` -- never coerced.
+//! * A **case-insensitive, whole-string** match against `"true"`/`"false"`
+//!   reads as a bool -- **without trimming** first: live-confirmed
+//!   `_coerce(" true ")` stays the *string* `" true "` (surrounding
+//!   whitespace defeats the bool match, since Python compares
+//!   `text.lower()` against the literal text, not a trimmed copy).
+//! * Otherwise, Python tries `int(text)`, then `float(text)`, keeping the
+//!   **original, untrimmed** text if neither succeeds. Both of Python's
+//!   conversions themselves trim surrounding whitespace and accept a
+//!   single underscore between two digits as a digit-group separator
+//!   (`"1_0"` -> `10`, live-confirmed) -- this module's [`try_parse_int`]/
+//!   [`try_parse_float`] replicate exactly that (trim, then validate that
+//!   every `_` sits strictly between two ASCII digits before stripping
+//!   them and delegating to Rust's own `i64`/`f64` parsers).
+//! * `float(text)` also accepts the words `inf`/`infinity`/`nan` (any
+//!   ASCII case, optionally signed) -- live-confirmed `_coerce('Infinity')
+//!   -> inf`, `_coerce('nan') -> nan`. Rust's `f64::from_str` accepts the
+//!   same vocabulary (see this module's `parses_inf_and_nan_words` test),
+//!   so no special-casing was needed beyond the shared trim/underscore
+//!   step.
+//! * **Disclosed representational gap** (same shape as `json.rs`'s/
+//!   `toml.rs`'s i64-only `Scalar::Int`): live-confirmed
+//!   `_coerce('9'*19)` is a Python `int` and `_coerce('9'*20)` is *also*
+//!   still a Python `int` (arbitrary precision, no cap until 4300 digits,
+//!   where CPython's `int(str)` digit-limit guard makes `int()` raise and
+//!   `_coerce` falls back to `float()`, which overflows silently to
+//!   `inf` for `'9'*4301` -- live-confirmed). This port's `Scalar::Int` is
+//!   `i64`-backed (19-digit range), so anything from 20 digits up through
+//!   4300 digits that Python holds as an exact `int` instead falls
+//!   through to this module's own `try_parse_float`, which is *always*
+//!   attempted after `try_parse_int` fails (unlike `json.rs`/`toml.rs`,
+//!   which reject an over-`i64` integer *literal* outright as a
+//!   `ParseError`, because JSON/TOML's grammar lexically commits to
+//!   "this token is an integer" before parsing it). XML's `_coerce` has no
+//!   such lexical commitment -- it is textual coercion, tries int then
+//!   float unconditionally -- so falling back to a `Scalar::Float`
+//!   instead of erroring is the more faithful match to Python's actual
+//!   (int-then-float-fallback) control flow, not a new divergence
+//!   invented for this port.
+//! * **Not replicated**: Python's `int()`/`float()` accept any Unicode
+//!   decimal digit (e.g. U+0663 ARABIC-INDIC DIGIT THREE), live-confirmed
+//!   `_coerce('٣') == 3`. This module's parsers are ASCII-digit-only
+//!   (`char::is_ascii_digit`) -- a disclosed, narrower-than-Python
+//!   simplification in the same spirit as `omnist-ts#53`'s own
+//!   already-accepted narrowing, not silently assumed.
+//!
+//! ## All-occurrences sanitization (omnist-ts#36 regression)
+//!
+//! `omnist-ts#36`: `writeXml`'s `xmlSanitize` used a **non-global** regex,
+//! so only the *first* XML-illegal character in a string was replaced,
+//! emitting malformed XML for any string with more than one. This module's
+//! [`xml_sanitize`] does not use a substitution regex at all -- it maps
+//! every `char` of the input through [`is_xml_illegal_char`] individually
+//! (`str::chars().map(...).collect()`), so there is no "first occurrence
+//! only" bug class available in the first place. See
+//! `sanitizes_every_illegal_character_not_just_the_first` for the
+//! regression test with multiple illegal characters in one string.
+//!
+//! ## Depth guard reuse
+//!
+//! [`read_xml`] checks nesting depth itself, inline, during the
+//! recursive-descent walk of `quick_xml`'s pull events (mirroring Python's
+//! own `_xml_to_node`, which inlines the identical check against the
+//! shared `_MAX_DEPTH` constant rather than routing through
+//! `document.py`'s write-side guard) -- this is necessary because,
+//! without it, an adversarially deep input could blow the native Rust call
+//! stack in [`parse_content`]'s own recursion *before* [`Doc::from_raw`]
+//! ever gets a chance to reject it via
+//! [`crate::document::check_write_depth`]. [`Doc::from_raw`] then applies
+//! its own guard a second time when building the final `Doc` -- a harmless,
+//! redundant confirmation of the same limit, not a second copy of the
+//! guard's logic (it calls the crate's one shared [`check_write_depth`]).
+//! [`write_xml`]/[`check_xml`] do not re-guard on the way out, matching
+//! `json.rs`'s reasoning: they walk an already-`Doc`-validated
+//! [`RawNode`], so there is nothing left to guard.
+//!
+//! ## Single document element (write-side)
+//!
+//! [`write_xml`] requires `doc.to_raw()` to be a [`RawNode::Edges`] with
+//! **exactly one** edge -- any other shape (a bare leaf-rooted `Doc`, zero
+//! edges, or more than one top-level edge) is a [`crate::error::WriteError`],
+//! matching Python's `write_xml` check
+//! (`if not (isinstance(node, list) and len(node) == 1): raise WriteError(...)`)
+//! exactly, including that it fires *outside* [`crate::report::finish_write`]
+//! -- unconditionally, even under `strict=false`, and with no
+//! [`crate::report::WriteReport`] attached (mirrors `toml.rs`'s identical
+//! "non-table root" precedent).
+
+use crate::WriteError;
+use crate::document::{Doc, MAX_DEPTH, RawNode, Scalar};
+use crate::error::{DocumentError, OmnistError, ParseError};
+use crate::report::{Severity, WriteReport};
+use quick_xml::Reader;
+use quick_xml::events::Event;
+use std::collections::HashMap;
+
+// ============================================================== Reader
+
+/// Parse XML text into a [`Doc`], preserving element order/interleaving
+/// exactly (see this module's doc comment).
+pub fn read_xml(text: &str) -> Result<Doc, OmnistError> {
+    let normalized = normalize_line_endings(text);
+    let mut reader = Reader::from_str(&normalized);
+    reader.config_mut().trim_text(false);
+    let mut buf = Vec::new();
+    loop {
+        buf.clear();
+        let ev = reader
+            .read_event_into(&mut buf)
+            .map_err(|e| xml_parse_error(&reader, &normalized, &e))?;
+        match ev {
+            Event::Start(e) => {
+                let tag = local_name(e.name());
+                let content = parse_content(&mut reader, &normalized, 1)?;
+                let doc = Doc::from_raw(RawNode::Edges(vec![(tag, content)]))?;
+                return Ok(doc);
+            }
+            Event::Empty(e) => {
+                let tag = local_name(e.name());
+                let doc = Doc::from_raw(RawNode::Edges(vec![(tag, RawNode::Leaf(coerce("")))]))?;
+                return Ok(doc);
+            }
+            Event::Eof => {
+                return Err(located_error(
+                    &reader,
+                    &normalized,
+                    "invalid XML: no root element found",
+                ));
+            }
+            // Decl/Comment/PI/DocType/whitespace-only prolog text: skip.
+            _ => continue,
+        }
+    }
+}
+
+/// Reads the content of an already-opened element (the matching `Start`
+/// event has already been consumed by the caller) up to and including its
+/// `End` event, returning either an internal node ([`RawNode::Edges`], if
+/// it has child elements) or a leaf ([`RawNode::Leaf`], coerced from its
+/// text), mirroring Python's `_xml_to_node`.
+fn parse_content(
+    reader: &mut Reader<&[u8]>,
+    source: &str,
+    depth: usize,
+) -> Result<RawNode, OmnistError> {
+    if depth > MAX_DEPTH {
+        return Err(DocumentError::new(
+            "$",
+            format!("nesting exceeds the maximum depth ({MAX_DEPTH})"),
+        )
+        .into());
+    }
+    let mut text = String::new();
+    let mut children: Vec<(String, RawNode)> = Vec::new();
+    let mut buf = Vec::new();
+    loop {
+        buf.clear();
+        let ev = reader
+            .read_event_into(&mut buf)
+            .map_err(|e| xml_parse_error(reader, source, &e))?;
+        match ev {
+            Event::Start(e) => {
+                let tag = local_name(e.name());
+                let child = parse_content(reader, source, depth + 1)?;
+                children.push((tag, child));
+            }
+            Event::Empty(e) => {
+                let tag = local_name(e.name());
+                children.push((tag, RawNode::Leaf(coerce(""))));
+            }
+            Event::End(_) => break,
+            Event::Text(e) => {
+                // `quick_xml` splits entity/character references out into
+                // their own `GeneralRef` events (see the arm below) --
+                // a `Text` event's content never itself contains an
+                // unresolved `&...;` sequence, so only charset decoding
+                // (never entity unescaping) is needed here. `decode()`
+                // cannot fail for a `Reader::from_str`-backed reader (the
+                // crate's own source notes the decoder is fixed to UTF-8
+                // automatically in that case -- there is no declared-
+                // encoding-vs-actual-bytes mismatch possible when the
+                // input was already a Rust `&str`), so this is an
+                // `.expect()`, not a propagated error path.
+                let decoded = e
+                    .decode()
+                    .expect("Reader::from_str fixes the decoder to UTF-8; decode() cannot fail");
+                text.push_str(&decoded);
+            }
+            Event::GeneralRef(e) => {
+                text.push(resolve_general_ref(reader, source, &e)?);
+            }
+            Event::CData(e) => {
+                text.push_str(&String::from_utf8_lossy(e.as_ref()));
+            }
+            Event::Eof => {
+                return Err(located_error(
+                    reader,
+                    source,
+                    "invalid XML: unexpected end of document",
+                ));
+            }
+            // Comments/PIs inside an element body: skip.
+            _ => {}
+        }
+    }
+    if !children.is_empty() {
+        if !text.trim().is_empty() {
+            return Err(located_error(
+                reader,
+                source,
+                "invalid XML: mixed content (text alongside child elements) is outside the \
+                 data-XML profile",
+            ));
+        }
+        Ok(RawNode::Edges(children))
+    } else {
+        Ok(RawNode::Leaf(coerce(&text)))
+    }
+}
+
+/// Builds a [`ParseError`] located at the reader's current byte position
+/// (converted to a 1-based line/column via [`line_col`]), for the error
+/// conditions this module detects itself rather than receiving from
+/// `quick_xml` (unexpected EOF, mixed content).
+fn located_error(reader: &Reader<&[u8]>, source: &str, message: &str) -> OmnistError {
+    let pos = (reader.buffer_position() as usize).min(source.len());
+    let (line, col) = line_col(source, pos);
+    ParseError::new(line, col, message).into()
+}
+
+/// The local (unprefixed) part of a tag name -- see this module's doc
+/// comment on namespace handling.
+fn local_name(name: quick_xml::name::QName) -> String {
+    let raw = std::str::from_utf8(name.as_ref()).unwrap_or_default();
+    match raw.rsplit_once(':') {
+        Some((_, local)) => local.to_string(),
+        None => raw.to_string(),
+    }
+}
+
+/// XML mandates line-ending normalization on parse (any of `"\r\n"`,
+/// a lone `"\r"`) to a bare `"\n"` -- live-confirmed against
+/// `defusedxml.ElementTree` (see this module's tests).
+fn normalize_line_endings(s: &str) -> String {
+    s.replace("\r\n", "\n").replace('\r', "\n")
+}
+
+fn xml_parse_error(reader: &Reader<&[u8]>, source: &str, e: &quick_xml::Error) -> OmnistError {
+    let pos = (reader.buffer_position() as usize).min(source.len());
+    let (line, col) = line_col(source, pos);
+    ParseError::new(line, col, format!("invalid XML: {e}")).into()
+}
+
+/// Resolves an `Event::GeneralRef` (a `&...;` entity or character
+/// reference `quick_xml` tokenizes as its own event, separate from
+/// `Text`) to the single `char` it denotes. Handles a numeric character
+/// reference (`&#65;`/`&#x41;`) via the crate's own [`quick_xml::events::BytesRef::resolve_char_ref`],
+/// and the five predefined XML entities by name -- `quick_xml` has no
+/// DTD support, so no other named entity can ever legitimately appear
+/// (see this module's doc comment on why that's a security feature, not
+/// a gap).
+fn resolve_general_ref(
+    reader: &Reader<&[u8]>,
+    source: &str,
+    e: &quick_xml::events::BytesRef<'_>,
+) -> Result<char, OmnistError> {
+    if let Some(ch) = e
+        .resolve_char_ref()
+        .map_err(|err| xml_parse_error(reader, source, &err))?
+    {
+        return Ok(ch);
+    }
+    let name = e
+        .decode()
+        .expect("Reader::from_str fixes the decoder to UTF-8; decode() cannot fail");
+    match name.as_ref() {
+        "lt" => Ok('<'),
+        "gt" => Ok('>'),
+        "amp" => Ok('&'),
+        "apos" => Ok('\''),
+        "quot" => Ok('"'),
+        other => {
+            let pos = (reader.buffer_position() as usize).min(source.len());
+            let (line, col) = line_col(source, pos);
+            Err(ParseError::new(
+                line,
+                col,
+                format!(
+                    "invalid XML: unrecognized entity reference '&{other};' (only the five \
+                     predefined XML entities are supported; quick_xml has no DTD support)"
+                ),
+            )
+            .into())
+        }
+    }
+}
+
+/// 1-based (line, column) of byte offset `pos` in `text` -- same shape as
+/// `toml.rs`'s identical helper.
+fn line_col(text: &str, pos: usize) -> (usize, usize) {
+    let mut line = 1usize;
+    let mut last_nl: Option<usize> = None;
+    for (i, b) in text.as_bytes()[..pos.min(text.len())].iter().enumerate() {
+        if *b == b'\n' {
+            line += 1;
+            last_nl = Some(i);
+        }
+    }
+    let col = match last_nl {
+        Some(i) => pos - i,
+        None => pos + 1,
+    };
+    (line, col)
+}
+
+/// Turns element text into a [`Scalar`] -- see this module's doc comment
+/// for the confirmed-against-live-Python coercion rules.
+fn coerce(text: &str) -> Scalar {
+    if text.is_empty() {
+        return Scalar::Str(String::new());
+    }
+    let low = text.to_lowercase();
+    if low == "true" {
+        return Scalar::Bool(true);
+    }
+    if low == "false" {
+        return Scalar::Bool(false);
+    }
+    if let Some(i) = try_parse_int(text) {
+        return Scalar::Int(i);
+    }
+    if let Some(f) = try_parse_float(text) {
+        return Scalar::Float(f);
+    }
+    Scalar::Str(text.to_string())
+}
+
+/// `None` if `s` contains an underscore that isn't strictly between two
+/// ASCII digits (Python's digit-group-separator rule for `int()`/
+/// `float()`); otherwise `Some` of `s` with every underscore removed.
+fn strip_underscores_if_valid(s: &str) -> Option<String> {
+    let chars: Vec<char> = s.chars().collect();
+    for (i, &c) in chars.iter().enumerate() {
+        if c == '_' {
+            let prev_ok = i > 0 && chars[i - 1].is_ascii_digit();
+            let next_ok = i + 1 < chars.len() && chars[i + 1].is_ascii_digit();
+            if !(prev_ok && next_ok) {
+                return None;
+            }
+        }
+    }
+    Some(chars.into_iter().filter(|&c| c != '_').collect())
+}
+
+/// Python's `int(text)`: trims whitespace, allows a `+`/`-` sign and
+/// underscore digit-group separators, ASCII digits only (see this
+/// module's doc comment on the Unicode-digit divergence).
+fn try_parse_int(text: &str) -> Option<i64> {
+    let t = text.trim();
+    if t.is_empty() {
+        return None;
+    }
+    let cleaned = strip_underscores_if_valid(t)?;
+    cleaned.parse::<i64>().ok()
+}
+
+/// Python's `float(text)`: trims whitespace, allows a sign, underscore
+/// digit-group separators, and the `inf`/`infinity`/`nan` words (any
+/// case) -- see this module's doc comment.
+fn try_parse_float(text: &str) -> Option<f64> {
+    let t = text.trim();
+    if t.is_empty() {
+        return None;
+    }
+    let cleaned = strip_underscores_if_valid(t)?;
+    cleaned.parse::<f64>().ok()
+}
+
+// ============================================================== Writer
+
+/// Project a [`Doc`] to XML text. See this module's doc comment for the
+/// single-document-element requirement, sanitization, and depth-guard
+/// decisions.
+pub fn write_xml(
+    doc: &Doc,
+    strict: bool,
+    report: Option<&mut WriteReport>,
+) -> Result<String, WriteError> {
+    let raw = doc.to_raw();
+    let RawNode::Edges(edges) = &raw else {
+        return Err(single_root_error());
+    };
+    if edges.len() != 1 {
+        return Err(single_root_error());
+    }
+    let mut rep = WriteReport::new();
+    scan_xml_into(&raw, "$", &mut rep);
+    let (tag, content) = &edges[0];
+    let mut out = String::new();
+    write_element(tag, content, 0, &mut out);
+    if !matches!(content, RawNode::Edges(e) if !e.is_empty()) && out.ends_with('\n') {
+        out.pop();
+    }
+    crate::report::finish_write(out, rep, strict, report)
+}
+
+fn single_root_error() -> WriteError {
+    WriteError::new(
+        "XML needs exactly one document element; the root node must have a single top-level \
+         edge (a single-rooted Document)",
+    )
+}
+
+/// Report what writing XML would adjust, without producing output. Unlike
+/// [`write_xml`], this does not enforce the single-document-element shape
+/// (mirrors Python's `check_xml`, which is just `_scan_xml(node, "$", rep)`
+/// with no root-shape guard of its own).
+pub fn check_xml(doc: &Doc) -> WriteReport {
+    let mut rep = WriteReport::new();
+    scan_xml_into(&doc.to_raw(), "$", &mut rep);
+    rep
+}
+
+fn scan_xml_into(node: &RawNode, path: &str, rep: &mut WriteReport) {
+    match node {
+        RawNode::Edges(edges) => {
+            if edges.is_empty() {
+                rep.add(
+                    path,
+                    "shape.empty_ambiguous",
+                    "empty internal node (no edges) written as <tag /> and reads back as the \
+                     empty-string leaf '', not []",
+                    Severity::Warning,
+                );
+                return;
+            }
+            let mut counts: HashMap<String, usize> = HashMap::new();
+            for (label, child) in edges {
+                let i = *counts.get(label).unwrap_or(&0);
+                counts.insert(label.clone(), i + 1);
+                let p = if i == 0 {
+                    format!("{path}.{label}")
+                } else {
+                    format!("{path}.{label}[{i}]")
+                };
+                if !is_valid_xml_name(label) {
+                    rep.add(
+                        p.clone(),
+                        "key.sanitized",
+                        format!("label {label:?} isn't a valid XML name; written sanitized"),
+                        Severity::Warning,
+                    );
+                }
+                scan_xml_into(child, &p, rep);
+            }
+        }
+        RawNode::Leaf(scalar) => scan_leaf(scalar, path, rep),
+    }
+}
+
+fn scan_leaf(scalar: &Scalar, path: &str, rep: &mut WriteReport) {
+    match scalar {
+        Scalar::Null => rep.add(
+            path,
+            "null.omitted",
+            "null written as an empty element",
+            Severity::Warning,
+        ),
+        Scalar::Str(v) => {
+            if !matches!(coerce(v), Scalar::Str(_)) {
+                rep.add(
+                    path,
+                    "string.ambiguous",
+                    format!("string {v:?} looks like another type and reads back as that type"),
+                    Severity::Warning,
+                );
+            }
+        }
+        Scalar::Bool(_) | Scalar::Int(_) | Scalar::Float(_) => {}
+    }
+    if let Scalar::Str(v) = scalar {
+        if v.chars().any(is_xml_illegal_char) {
+            rep.add(
+                path,
+                "string.illegal_xml_char",
+                "string contains a character XML 1.0 cannot represent (e.g. a C0 control other \
+                 than tab/LF/CR); it is replaced with U+FFFD on write so the output stays \
+                 well-formed",
+                Severity::Error,
+            );
+        }
+        if v.contains('\r') {
+            rep.add(
+                path,
+                "string.cr_normalized",
+                "string contains a carriage return ('\\r'); XML mandates line-ending \
+                 normalization on parse, so '\\r' (and '\\r\\n') read back as '\\n'",
+                Severity::Warning,
+            );
+        }
+    }
+}
+
+fn write_element(tag: &str, content: &RawNode, level: usize, out: &mut String) {
+    let indent = "  ".repeat(level);
+    out.push_str(&indent);
+    out.push('<');
+    out.push_str(&xml_name(tag));
+    match content {
+        RawNode::Edges(edges) if !edges.is_empty() => {
+            out.push_str(">\n");
+            for (label, child) in edges {
+                write_element(label, child, level + 1, out);
+            }
+            out.push_str(&indent);
+            out.push_str("</");
+            out.push_str(&xml_name(tag));
+            out.push_str(">\n");
+        }
+        RawNode::Edges(_) => out.push_str(" />\n"),
+        RawNode::Leaf(scalar) => {
+            let text = xml_sanitize(&xml_text(scalar));
+            if text.is_empty() {
+                out.push_str(" />\n");
+            } else {
+                out.push('>');
+                out.push_str(&xml_escape_text(&text));
+                out.push_str("</");
+                out.push_str(&xml_name(tag));
+                out.push_str(">\n");
+            }
+        }
+    }
+}
+
+/// A valid XML 1.0 `Name`, simplified to the ASCII-friendly subset Python's
+/// own `_XML_NAME` regex accepts (`^[A-Za-z_][A-Za-z0-9_.\-]*$`).
+fn is_valid_xml_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.' || c == '-')
+}
+
+/// A label as a legal XML element name -- sanitized if it isn't already
+/// one, matching Python's `_xml_name`.
+fn xml_name(name: &str) -> String {
+    if is_valid_xml_name(name) {
+        return name.to_string();
+    }
+    let safe: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '.' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if safe.is_empty() || !is_valid_xml_name(&safe) {
+        format!("_{safe}")
+    } else {
+        safe
+    }
+}
+
+fn xml_text(scalar: &Scalar) -> String {
+    match scalar {
+        Scalar::Null => String::new(),
+        Scalar::Bool(b) => {
+            if *b {
+                "true".to_string()
+            } else {
+                "false".to_string()
+            }
+        }
+        Scalar::Int(i) => i.to_string(),
+        Scalar::Float(x) => write_float_text(*x),
+        Scalar::Str(s) => s.clone(),
+    }
+}
+
+/// Same float-formatting convention as `toml.rs`'s `write_float`: `nan`/
+/// `inf`/`-inf` lowercase for special values, an explicit `.0` for an
+/// integral finite value (matching Python's `str(float)`, which Rust's
+/// bare `{}` formatter does not add on its own), default `Display`
+/// otherwise.
+fn write_float_text(x: f64) -> String {
+    if x.is_nan() {
+        "nan".to_string()
+    } else if x.is_infinite() {
+        if x > 0.0 { "inf" } else { "-inf" }.to_string()
+    } else if x == x.trunc() && x.is_finite() && x.abs() < 1e17 {
+        format!("{x:.1}")
+    } else {
+        x.to_string()
+    }
+}
+
+/// Replaces every character XML 1.0 cannot represent with U+FFFD --
+/// see this module's doc comment on the omnist-ts#36 all-occurrences fix.
+fn xml_sanitize(text: &str) -> String {
+    text.chars()
+        .map(|c| {
+            if is_xml_illegal_char(c) {
+                '\u{FFFD}'
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
+/// XML 1.0's character-data legality rule (tab/LF/CR plus U+0020-U+D7FF,
+/// U+E000-U+FFFD, U+10000-U+10FFFF are legal; everything else, including
+/// the C0 controls other than tab/LF/CR and the BMP noncharacters
+/// U+FFFE/U+FFFF, is not) -- a Rust `char` can never be a UTF-16 surrogate,
+/// so that illegal range from Python's version is unreachable here and
+/// intentionally omitted.
+fn is_xml_illegal_char(c: char) -> bool {
+    let cp = c as u32;
+    (0x00..=0x08).contains(&cp)
+        || (0x0B..=0x0C).contains(&cp)
+        || (0x0E..=0x1F).contains(&cp)
+        || (0xFFFE..=0xFFFF).contains(&cp)
+}
+
+/// Escapes the three characters XML text content requires escaped
+/// (`&`, `<`, `>`) -- matching `ElementTree.tostring`'s text-escaping
+/// (quotes are left literal; they only need escaping in attribute values,
+/// which this module never writes).
+fn xml_escape_text(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for c in text.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests;

--- a/omnist/src/formats/xml/tests.rs
+++ b/omnist/src/formats/xml/tests.rs
@@ -1,0 +1,701 @@
+use super::*;
+use crate::document::{RawNode, Scalar};
+
+fn edges(pairs: Vec<(&str, RawNode)>) -> RawNode {
+    RawNode::Edges(pairs.into_iter().map(|(l, v)| (l.to_string(), v)).collect())
+}
+
+fn leaf_str(s: &str) -> RawNode {
+    RawNode::Leaf(Scalar::Str(s.to_string()))
+}
+
+fn leaf_int(i: i64) -> RawNode {
+    RawNode::Leaf(Scalar::Int(i))
+}
+
+// ------------------------------------------------------------ reader: basics
+
+#[test]
+fn reads_a_leaf_root_element() {
+    let doc = read_xml("<root>hello</root>").unwrap();
+    let raw = doc.to_raw();
+    assert_eq!(raw, edges(vec![("root", leaf_str("hello"))]));
+}
+
+#[test]
+fn reads_an_empty_element_as_empty_string_leaf() {
+    let doc = read_xml("<root />").unwrap();
+    assert_eq!(doc.to_raw(), edges(vec![("root", leaf_str(""))]));
+    let doc2 = read_xml("<root></root>").unwrap();
+    assert_eq!(doc2.to_raw(), edges(vec![("root", leaf_str(""))]));
+}
+
+#[test]
+fn reads_nested_elements() {
+    let doc = read_xml("<root><a>1</a></root>").unwrap();
+    assert_eq!(
+        doc.to_raw(),
+        edges(vec![("root", edges(vec![("a", leaf_int(1))]))])
+    );
+}
+
+#[test]
+fn invalid_xml_is_a_parse_error() {
+    let err = read_xml("<root><a></root>").unwrap_err();
+    assert!(matches!(err, OmnistError::Parse(_)));
+}
+
+#[test]
+fn empty_document_is_a_parse_error() {
+    let err = read_xml("   ").unwrap_err();
+    assert!(matches!(err, OmnistError::Parse(ref e) if e.message.contains("no root element")));
+}
+
+// -------------------------------------------------- interleaving / repetition
+
+#[test]
+fn preserves_repeated_sibling_elements_as_repeated_edges() {
+    let doc = read_xml("<root><x>1</x><x>2</x></root>").unwrap();
+    let RawNode::Edges(root_edges) = doc.to_raw() else {
+        panic!("expected edges")
+    };
+    let (tag, content) = &root_edges[0];
+    assert_eq!(tag, "root");
+    assert_eq!(
+        *content,
+        edges(vec![("x", leaf_int(1)), ("x", leaf_int(2))])
+    );
+}
+
+#[test]
+fn preserves_interleaved_distinct_labels_exactly() {
+    // <b/><c/><b/> -- interleaved, not a contiguous run of "b". This is
+    // exactly the shape a `Value::Object`/`IndexMap` can't represent,
+    // which is why this module goes through `RawNode` instead of
+    // `to_grouped` (see this module's doc comment).
+    let doc = read_xml("<root><b>1</b><c>2</c><b>3</b></root>").unwrap();
+    let RawNode::Edges(root_edges) = doc.to_raw() else {
+        panic!("expected edges")
+    };
+    let (_, content) = &root_edges[0];
+    let RawNode::Edges(inner) = content else {
+        panic!("expected edges")
+    };
+    let labels: Vec<&str> = inner.iter().map(|(l, _)| l.as_str()).collect();
+    assert_eq!(labels, vec!["b", "c", "b"]);
+    assert_eq!(inner[0].1, leaf_int(1));
+    assert_eq!(inner[1].1, leaf_int(2));
+    assert_eq!(inner[2].1, leaf_int(3));
+}
+
+#[test]
+fn round_trips_interleaved_repeated_elements() {
+    let text = "<root>\n  <b>1</b>\n  <c>2</c>\n  <b>3</b>\n</root>\n";
+    let doc = read_xml(text).unwrap();
+    let out = write_xml(&doc, false, None).unwrap();
+    assert_eq!(out, text);
+    let doc2 = read_xml(&out).unwrap();
+    assert!(doc.eq_doc(&doc2));
+}
+
+// ---------------------------------------------------------------- mixed content
+
+#[test]
+fn mixed_content_text_alongside_children_is_a_parse_error() {
+    let err = read_xml("<root>text<a>1</a></root>").unwrap_err();
+    assert!(matches!(err, OmnistError::Parse(ref e) if e.message.contains("mixed content")));
+}
+
+#[test]
+fn whitespace_only_text_alongside_children_is_not_mixed_content() {
+    let doc = read_xml("<root>\n  <a>1</a>\n</root>").unwrap();
+    assert_eq!(
+        doc.to_raw(),
+        edges(vec![("root", edges(vec![("a", leaf_int(1))]))])
+    );
+}
+
+// --------------------------------------------------------------------- coercion
+
+#[test]
+fn coerces_booleans_case_insensitively() {
+    for (text, expected) in [
+        ("true", true),
+        ("True", true),
+        ("TRUE", true),
+        ("false", false),
+        ("FALSE", false),
+    ] {
+        let doc = read_xml(&format!("<r>{text}</r>")).unwrap();
+        assert_eq!(
+            doc.to_raw(),
+            edges(vec![("r", RawNode::Leaf(Scalar::Bool(expected)))])
+        );
+    }
+}
+
+#[test]
+fn bool_match_does_not_trim_surrounding_whitespace() {
+    // Live-confirmed against Python: `_coerce(' true ')` stays the string
+    // `' true '` -- the bool comparison uses the raw text, not a trimmed
+    // copy (omnist-ts#53-style undocumented-narrowing lesson: verify, don't
+    // assume).
+    let doc = read_xml("<r> true </r>").unwrap();
+    assert_eq!(doc.to_raw(), edges(vec![("r", leaf_str(" true "))]));
+}
+
+#[test]
+fn coerces_plain_integers() {
+    let doc = read_xml("<r>42</r>").unwrap();
+    assert_eq!(doc.to_raw(), edges(vec![("r", leaf_int(42))]));
+    let doc2 = read_xml("<r>-7</r>").unwrap();
+    assert_eq!(doc2.to_raw(), edges(vec![("r", leaf_int(-7))]));
+}
+
+#[test]
+fn coerces_underscore_grouped_integer_literal() {
+    // Live-confirmed: Python's int("1_0") == 10.
+    let doc = read_xml("<r>1_0</r>").unwrap();
+    assert_eq!(doc.to_raw(), edges(vec![("r", leaf_int(10))]));
+}
+
+#[test]
+fn coerces_leading_zero_integer() {
+    // Live-confirmed: Python's int("007") == 7 (int() has no octal
+    // interpretation of a leading zero, unlike a Python integer literal).
+    let doc = read_xml("<r>007</r>").unwrap();
+    assert_eq!(doc.to_raw(), edges(vec![("r", leaf_int(7))]));
+}
+
+#[test]
+fn coerces_plain_floats() {
+    let doc = read_xml("<r>1.5</r>").unwrap();
+    assert_eq!(
+        doc.to_raw(),
+        edges(vec![("r", RawNode::Leaf(Scalar::Float(1.5)))])
+    );
+}
+
+#[test]
+fn coerces_leading_and_trailing_dot_floats() {
+    // Live-confirmed: float(".5") == 0.5, float("5.") == 5.0.
+    let doc = read_xml("<a>.5</a>").unwrap();
+    assert_eq!(
+        doc.to_raw(),
+        edges(vec![("a", RawNode::Leaf(Scalar::Float(0.5)))])
+    );
+    let doc2 = read_xml("<a>5.</a>").unwrap();
+    assert_eq!(
+        doc2.to_raw(),
+        edges(vec![("a", RawNode::Leaf(Scalar::Float(5.0)))])
+    );
+}
+
+#[test]
+fn parses_inf_and_nan_words() {
+    // Live-confirmed: float("inf") == inf, float("Infinity") == inf,
+    // float("nan") == nan (any ASCII case, optionally signed).
+    for text in ["inf", "Infinity", "INFINITY", "-inf", "+inf"] {
+        let doc = read_xml(&format!("<r>{text}</r>")).unwrap();
+        let RawNode::Edges(e) = doc.to_raw() else {
+            panic!()
+        };
+        let RawNode::Leaf(Scalar::Float(f)) = &e[0].1 else {
+            panic!("expected float leaf for {text:?}")
+        };
+        assert!(f.is_infinite(), "{text} should be infinite, got {f}");
+    }
+    let doc = read_xml("<r>nan</r>").unwrap();
+    let RawNode::Edges(e) = doc.to_raw() else {
+        panic!()
+    };
+    let RawNode::Leaf(Scalar::Float(f)) = &e[0].1 else {
+        panic!("expected float leaf")
+    };
+    assert!(f.is_nan());
+}
+
+#[test]
+fn underscore_grouped_float_coerces() {
+    // Live-confirmed: float("1_0.5") == 10.5.
+    let doc = read_xml("<r>1_0.5</r>").unwrap();
+    assert_eq!(
+        doc.to_raw(),
+        edges(vec![("r", RawNode::Leaf(Scalar::Float(10.5)))])
+    );
+}
+
+#[test]
+fn malformed_underscore_grouping_stays_a_string() {
+    // Live-confirmed: Python's int()/float() reject a leading, trailing,
+    // or doubled underscore -- "_1", "1_", "1__0" all stay strings.
+    for text in ["_1", "1_", "1__0"] {
+        let doc = read_xml(&format!("<r>{text}</r>")).unwrap();
+        assert_eq!(
+            doc.to_raw(),
+            edges(vec![("r", leaf_str(text))]),
+            "input {text:?}"
+        );
+    }
+}
+
+#[test]
+fn non_numeric_text_stays_a_string() {
+    let doc = read_xml("<r>hello world</r>").unwrap();
+    assert_eq!(doc.to_raw(), edges(vec![("r", leaf_str("hello world"))]));
+}
+
+#[test]
+fn hex_literal_text_stays_a_string() {
+    // Live-confirmed: Python's int("0x1A")/float("0x1A") both raise
+    // (no implicit base without base=0), so it stays a string.
+    let doc = read_xml("<r>0x1A</r>").unwrap();
+    assert_eq!(doc.to_raw(), edges(vec![("r", leaf_str("0x1A"))]));
+}
+
+#[test]
+fn whitespace_only_text_with_no_digits_stays_unchanged() {
+    // Live-confirmed: Python's int("  ")/float("  ") both raise (no
+    // digits at all), so _coerce falls through to the *original*,
+    // unstripped text.
+    let doc = read_xml("<r>  </r>").unwrap();
+    assert_eq!(doc.to_raw(), edges(vec![("r", leaf_str("  "))]));
+}
+
+#[test]
+fn oversized_integer_falls_back_to_float_not_a_parse_error() {
+    // Live-confirmed divergence: Python's _coerce("9"*20) is still an
+    // exact Python int (arbitrary precision) -- this port's Scalar::Int
+    // is i64-backed (19-digit range), so it falls through to
+    // try_parse_float instead of erroring, matching _coerce's actual
+    // int-then-float control flow (see this module's doc comment).
+    let text = "9".repeat(20);
+    let doc = read_xml(&format!("<r>{text}</r>")).unwrap();
+    let RawNode::Edges(e) = doc.to_raw() else {
+        panic!()
+    };
+    assert!(matches!(&e[0].1, RawNode::Leaf(Scalar::Float(_))));
+}
+
+// ------------------------------------------------------------------ CR normalization
+
+#[test]
+fn carriage_returns_normalize_to_newline_on_read() {
+    // Live-confirmed against defusedxml: "line\r\ncr\ronly" reads as
+    // "line\ncr\nonly".
+    let doc = read_xml("<a>line\r\ncr\ronly</a>").unwrap();
+    assert_eq!(doc.to_raw(), edges(vec![("a", leaf_str("line\ncr\nonly"))]));
+}
+
+// ------------------------------------------------------------------------ depth guard
+
+#[test]
+fn depth_guard_rejects_deeply_nested_xml() {
+    let mut text = String::from("<a>");
+    for _ in 0..MAX_DEPTH + 5 {
+        text.push_str("<a>");
+    }
+    text.push('1');
+    for _ in 0..MAX_DEPTH + 6 {
+        text.push_str("</a>");
+    }
+    let err = read_xml(&text).unwrap_err();
+    assert!(
+        matches!(err, OmnistError::Document(ref e) if e.message.contains("maximum depth")),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn depth_at_the_boundary_is_accepted() {
+    // MAX_DEPTH levels of nesting is the accept boundary (root itself is
+    // depth 0, its content is depth 1, ...).
+    let mut text = String::from("<a>");
+    for _ in 0..MAX_DEPTH - 1 {
+        text.push_str("<a>");
+    }
+    text.push('1');
+    for _ in 0..MAX_DEPTH {
+        text.push_str("</a>");
+    }
+    assert!(read_xml(&text).is_ok());
+}
+
+// --------------------------------------------------------------------- write: shape
+
+#[test]
+fn write_requires_exactly_one_top_level_edge() {
+    let doc = Doc::of(&crate::document::Value::Int(5)).unwrap();
+    let err = write_xml(&doc, false, None).unwrap_err();
+    assert!(err.to_string().contains("exactly one document element"));
+    assert!(err.report().is_none());
+}
+
+#[test]
+fn write_rejects_a_multi_edge_root() {
+    let raw = edges(vec![("a", leaf_int(1)), ("b", leaf_int(2))]);
+    let doc = Doc::from_raw(raw).unwrap();
+    let err = write_xml(&doc, false, None).unwrap_err();
+    assert!(err.to_string().contains("exactly one document element"));
+}
+
+// ---------------------------------------------------------------------- write: shapes
+
+#[test]
+fn writes_a_leaf_root_on_one_line_no_trailing_newline() {
+    let doc = Doc::from_raw(edges(vec![("root", leaf_str("hello"))])).unwrap();
+    let text = write_xml(&doc, false, None).unwrap();
+    assert_eq!(text, "<root>hello</root>");
+}
+
+#[test]
+fn writes_an_empty_root_self_closed_no_trailing_newline() {
+    let doc = Doc::from_raw(edges(vec![("root", edges(vec![]))])).unwrap();
+    let text = write_xml(&doc, false, None).unwrap();
+    assert_eq!(text, "<root />");
+}
+
+#[test]
+fn writes_nested_elements_indented_with_trailing_newline() {
+    let doc = Doc::from_raw(edges(vec![(
+        "root",
+        edges(vec![
+            ("a", leaf_int(1)),
+            ("b", edges(vec![("x", leaf_str("1")), ("x", leaf_str("2"))])),
+            ("c", edges(vec![])),
+        ]),
+    )]))
+    .unwrap();
+    let text = write_xml(&doc, false, None).unwrap();
+    assert_eq!(
+        text,
+        "<root>\n  <a>1</a>\n  <b>\n    <x>1</x>\n    <x>2</x>\n  </b>\n  <c />\n</root>\n"
+    );
+}
+
+#[test]
+fn writes_deeply_nested_single_child_chain() {
+    let doc = Doc::from_raw(edges(vec![(
+        "root",
+        edges(vec![(
+            "a",
+            edges(vec![("b", edges(vec![("c", leaf_int(1))]))]),
+        )]),
+    )]))
+    .unwrap();
+    let text = write_xml(&doc, false, None).unwrap();
+    assert_eq!(
+        text,
+        "<root>\n  <a>\n    <b>\n      <c>1</c>\n    </b>\n  </a>\n</root>\n"
+    );
+}
+
+// --------------------------------------------------------------- write: escaping
+
+#[test]
+fn escapes_ampersand_lt_gt_in_text_but_not_quotes() {
+    let doc = Doc::from_raw(edges(vec![(
+        "root",
+        edges(vec![("a", leaf_str("x < y & z > w \"quote\" 'apos'"))]),
+    )]))
+    .unwrap();
+    let text = write_xml(&doc, false, None).unwrap();
+    assert!(text.contains("x &lt; y &amp; z &gt; w \"quote\" 'apos'"));
+}
+
+// ------------------------------------------------------- all-occurrences sanitization
+
+#[test]
+fn sanitizes_every_illegal_character_not_just_the_first() {
+    // Regression test for omnist-ts#36: writeXml's xmlSanitize used a
+    // non-global regex, replacing only the *first* XML-illegal character.
+    // Three illegal C0 controls (\x01, \x02, \x03) in one string -- all
+    // three must become U+FFFD, not just the first.
+    let illegal = "a\u{01}b\u{02}c\u{03}d";
+    let doc = Doc::from_raw(edges(vec![("root", leaf_str(illegal))])).unwrap();
+    let text = write_xml(&doc, false, None).unwrap();
+    assert_eq!(text, "<root>a\u{FFFD}b\u{FFFD}c\u{FFFD}d</root>");
+    assert_eq!(
+        text.matches('\u{FFFD}').count(),
+        3,
+        "all three must be replaced"
+    );
+}
+
+#[test]
+fn check_xml_reports_illegal_char_as_error_and_cr_as_warning() {
+    let doc = Doc::from_raw(edges(vec![("root", leaf_str("bad\u{01}\rtext"))])).unwrap();
+    let rep = check_xml(&doc);
+    assert!(
+        rep.adjustments()
+            .iter()
+            .any(|a| a.code == "string.illegal_xml_char" && a.severity == Severity::Error)
+    );
+    assert!(
+        rep.adjustments()
+            .iter()
+            .any(|a| a.code == "string.cr_normalized" && a.severity == Severity::Warning)
+    );
+}
+
+#[test]
+fn strict_write_raises_on_illegal_char_error() {
+    let doc = Doc::from_raw(edges(vec![("root", leaf_str("bad\u{01}"))])).unwrap();
+    let err = write_xml(&doc, true, None).unwrap_err();
+    assert!(err.report().is_some());
+}
+
+// ----------------------------------------------------------------- key sanitization
+
+#[test]
+fn sanitizes_an_invalid_label_and_records_adjustment() {
+    let doc = Doc::from_raw(edges(vec![(
+        "root",
+        edges(vec![("1bad label", leaf_int(1))]),
+    )]))
+    .unwrap();
+    let mut rep = WriteReport::new();
+    let text = write_xml(&doc, false, Some(&mut rep)).unwrap();
+    assert!(text.contains("<_1bad_label>1</_1bad_label>"));
+    assert!(rep.adjustments().iter().any(|a| a.code == "key.sanitized"));
+}
+
+#[test]
+fn xml_name_prefixes_underscore_when_sanitized_result_still_invalid() {
+    // A label made of only illegal characters sanitizes to an
+    // all-underscore string, which IS a valid XML name on its own
+    // (starts with `_`) -- but a label that sanitizes to something
+    // starting with a digit still needs the extra leading underscore.
+    assert_eq!(xml_name("123"), "_123");
+    assert_eq!(xml_name("a b"), "a_b");
+    assert_eq!(xml_name("valid_name"), "valid_name");
+}
+
+// --------------------------------------------------------------------- empty shape
+
+#[test]
+fn empty_internal_node_reports_shape_empty_ambiguous() {
+    let doc = Doc::from_raw(edges(vec![("root", edges(vec![("empty", edges(vec![]))]))])).unwrap();
+    let rep = check_xml(&doc);
+    assert!(
+        rep.adjustments()
+            .iter()
+            .any(|a| a.code == "shape.empty_ambiguous")
+    );
+}
+
+// --------------------------------------------------------------- ambiguous string
+
+#[test]
+fn string_that_looks_like_another_type_is_flagged_ambiguous() {
+    let doc = Doc::from_raw(edges(vec![("root", leaf_str("42"))])).unwrap();
+    let rep = check_xml(&doc);
+    assert!(
+        rep.adjustments()
+            .iter()
+            .any(|a| a.code == "string.ambiguous"),
+        "{rep:?}"
+    );
+}
+
+#[test]
+fn ordinary_string_is_not_flagged_ambiguous() {
+    let doc = Doc::from_raw(edges(vec![("root", leaf_str("hello"))])).unwrap();
+    let rep = check_xml(&doc);
+    assert!(
+        !rep.adjustments()
+            .iter()
+            .any(|a| a.code == "string.ambiguous")
+    );
+}
+
+// --------------------------------------------------------------------- null leaf
+
+#[test]
+fn null_leaf_writes_as_empty_element_and_is_reported() {
+    let doc = Doc::from_raw(edges(vec![("root", RawNode::Leaf(Scalar::Null))])).unwrap();
+    let mut rep = WriteReport::new();
+    let text = write_xml(&doc, false, Some(&mut rep)).unwrap();
+    assert_eq!(text, "<root />");
+    assert!(rep.adjustments().iter().any(|a| a.code == "null.omitted"));
+}
+
+// ------------------------------------------------------------------------ round trip
+
+#[test]
+fn round_trips_every_scalar_kind() {
+    let doc = Doc::from_raw(edges(vec![(
+        "root",
+        edges(vec![
+            ("i", leaf_int(42)),
+            ("s", leaf_str("hello")),
+            ("b", RawNode::Leaf(Scalar::Bool(true))),
+            ("f", RawNode::Leaf(Scalar::Float(1.5))),
+        ]),
+    )]))
+    .unwrap();
+    let text = write_xml(&doc, false, None).unwrap();
+    let doc2 = read_xml(&text).unwrap();
+    assert!(doc.eq_doc(&doc2));
+}
+
+#[test]
+fn float_integral_value_gets_a_decimal_point() {
+    let doc = Doc::from_raw(edges(vec![("root", RawNode::Leaf(Scalar::Float(1.0)))])).unwrap();
+    let text = write_xml(&doc, false, None).unwrap();
+    assert_eq!(text, "<root>1.0</root>");
+}
+
+#[test]
+fn nan_and_infinity_round_trip() {
+    let doc = Doc::from_raw(edges(vec![(
+        "root",
+        edges(vec![
+            ("a", RawNode::Leaf(Scalar::Float(f64::NAN))),
+            ("b", RawNode::Leaf(Scalar::Float(f64::INFINITY))),
+            ("c", RawNode::Leaf(Scalar::Float(f64::NEG_INFINITY))),
+        ]),
+    )]))
+    .unwrap();
+    let text = write_xml(&doc, false, None).unwrap();
+    assert!(text.contains("<a>nan</a>"));
+    assert!(text.contains("<b>inf</b>"));
+    assert!(text.contains("<c>-inf</c>"));
+    let doc2 = read_xml(&text).unwrap();
+    let RawNode::Edges(e) = doc2.to_raw() else {
+        panic!()
+    };
+    let RawNode::Edges(inner) = &e[0].1 else {
+        panic!()
+    };
+    assert!(matches!(&inner[0].1, RawNode::Leaf(Scalar::Float(f)) if f.is_nan()));
+    assert!(matches!(&inner[1].1, RawNode::Leaf(Scalar::Float(f)) if f.is_infinite() && *f > 0.0));
+    assert!(matches!(&inner[2].1, RawNode::Leaf(Scalar::Float(f)) if f.is_infinite() && *f < 0.0));
+}
+
+// ------------------------------------------------------------------ namespaces
+
+#[test]
+fn a_prefixed_tag_reads_as_its_local_name() {
+    // See this module's doc comment on the disclosed namespace
+    // simplification -- the prefix is stripped lexically, not resolved
+    // through an xmlns declaration.
+    let doc = read_xml("<ns:root xmlns:ns=\"urn:example\">1</ns:root>").unwrap();
+    let RawNode::Edges(e) = doc.to_raw() else {
+        panic!()
+    };
+    assert_eq!(e[0].0, "root");
+}
+
+// ---------------------------------------------------------------- white-box coverage
+
+#[test]
+fn xml_sanitize_leaves_legal_characters_untouched() {
+    assert_eq!(xml_sanitize("hello\tworld\n"), "hello\tworld\n");
+}
+
+#[test]
+fn is_xml_illegal_char_boundary_values() {
+    assert!(is_xml_illegal_char('\u{00}'));
+    assert!(!is_xml_illegal_char('\t'));
+    assert!(!is_xml_illegal_char('\n'));
+    assert!(!is_xml_illegal_char('\r'));
+    assert!(is_xml_illegal_char('\u{0B}'));
+    assert!(is_xml_illegal_char('\u{1F}'));
+    assert!(!is_xml_illegal_char(' '));
+    assert!(is_xml_illegal_char('\u{FFFE}'));
+    assert!(is_xml_illegal_char('\u{FFFF}'));
+    assert!(!is_xml_illegal_char('\u{FFFD}'));
+}
+
+#[test]
+fn xml_text_covers_bool_false() {
+    assert_eq!(xml_text(&Scalar::Bool(false)), "false");
+}
+
+// -------------------------------------------------------------- reader: extra event kinds
+
+#[test]
+fn nested_self_closed_child_is_an_empty_string_leaf() {
+    // Exercises the `Event::Empty` arm inside `parse_content` (the
+    // top-level `read_xml` loop has its own separate `Empty` arm for a
+    // self-closed *root*; this covers the nested case).
+    let doc = read_xml("<root><a/></root>").unwrap();
+    assert_eq!(
+        doc.to_raw(),
+        edges(vec![("root", edges(vec![("a", leaf_str(""))]))])
+    );
+}
+
+#[test]
+fn comments_and_pis_inside_an_element_body_are_skipped() {
+    // Exercises `parse_content`'s catch-all arm (comments/PIs interleaved
+    // with real content are ignored, not treated as text or an error).
+    let doc = read_xml("<root><!-- a comment --><a>1</a><?pi data?></root>").unwrap();
+    assert_eq!(
+        doc.to_raw(),
+        edges(vec![("root", edges(vec![("a", leaf_int(1))]))])
+    );
+}
+
+#[test]
+fn cdata_section_contributes_to_leaf_text() {
+    let doc = read_xml("<root><![CDATA[hello <world>]]></root>").unwrap();
+    assert_eq!(
+        doc.to_raw(),
+        edges(vec![("root", leaf_str("hello <world>"))])
+    );
+}
+
+#[test]
+fn truncated_document_inside_a_nested_element_is_a_parse_error() {
+    // Unclosed at EOF while *inside* `parse_content`'s own loop (not the
+    // top-level `read_xml` loop) -- exercises `parse_content`'s own
+    // `Event::Eof` arm.
+    let err = read_xml("<root><a>").unwrap_err();
+    assert!(matches!(err, OmnistError::Parse(ref e) if e.message.contains("unexpected end")));
+}
+
+#[test]
+fn malformed_numeric_character_reference_is_a_parse_error() {
+    // "&#zzz;" is not a valid numeric character reference -- `quick_xml`
+    // tokenizes it as its own `GeneralRef` event (distinct from `Text`),
+    // and `resolve_general_ref`'s `resolve_char_ref()` call surfaces the
+    // invalid-digit failure as a `ParseError`.
+    let err = read_xml("<root>&#zzz;</root>").unwrap_err();
+    assert!(matches!(err, OmnistError::Parse(_)), "got {err:?}");
+}
+
+#[test]
+fn parse_error_on_line_two_reports_line_two() {
+    // Exercises `line_col`'s newline-counting branch for an XML parse
+    // error (the same branch `toml.rs`'s identical helper already covers
+    // for TOML), via a truncated document whose failure is only detected
+    // after a line break.
+    let err = read_xml("<root>\n<a>").unwrap_err();
+    assert!(
+        matches!(err, OmnistError::Parse(ref e) if e.line == 2),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn numeric_and_named_character_references_resolve_correctly() {
+    // "&#65;" (decimal) and "&#x41;" (hex) are both "A"; the five
+    // predefined named entities resolve by name via `resolve_general_ref`.
+    let doc = read_xml("<r>&#65;&#x41;&lt;&gt;&amp;&apos;&quot;</r>").unwrap();
+    assert_eq!(doc.to_raw(), edges(vec![("r", leaf_str("AA<>&'\""))]));
+}
+
+#[test]
+fn unrecognized_named_entity_is_a_parse_error() {
+    // `quick_xml` has no DTD support, so only the five predefined
+    // entities can ever resolve -- anything else is a parse error
+    // (see this module's doc comment on why that's the crate's XXE-safe
+    // behavior, not a gap).
+    let err = read_xml("<root>&undefinedentity;</root>").unwrap_err();
+    assert!(
+        matches!(err, OmnistError::Parse(ref e) if e.message.contains("unrecognized entity")),
+        "got {err:?}"
+    );
+}

--- a/omnist/src/formats/xml/tests.rs
+++ b/omnist/src/formats/xml/tests.rs
@@ -51,6 +51,19 @@ fn empty_document_is_a_parse_error() {
     assert!(matches!(err, OmnistError::Parse(ref e) if e.message.contains("no root element")));
 }
 
+#[test]
+fn malformed_syntax_before_any_root_element_is_a_parse_error() {
+    // A stray closing tag with no matching opening tag fails on the very
+    // first `read_event_into` call in `read_xml`'s top-level loop, before
+    // any `Start`/`Empty`/`Eof` event has been returned -- this exercises
+    // that loop's own `map_err(..)` mapping, distinct from the identical
+    // mapping inside `parse_content` (exercised by
+    // `invalid_xml_is_a_parse_error` and friends, whose malformed syntax
+    // occurs only after a valid root `Start` event has already opened).
+    let err = read_xml("</root>").unwrap_err();
+    assert!(matches!(err, OmnistError::Parse(_)));
+}
+
 // -------------------------------------------------- interleaving / repetition
 
 #[test]


### PR DESCRIPTION
Closes #22.

## Summary

Adds the XML codec, the last of the four format codecs (JSON -> YAML -> TOML -> XML, easiest-to-hardest per docs/workflow-playbook.md).

- **Structural difference from json.rs/yaml.rs/toml.rs**: per the Python reference's own docstring, XML preserves element interleaving/repetition directly rather than going through the shared JSON-style "grouped" representation. This module goes through `Doc::from_raw`/`Doc::to_raw` and `RawNode` (the same interleaving-preserving path `oml.rs` uses) instead of `Doc::to_grouped`.
- **Crate choice**: `quick-xml` 0.41.0 for tokenization only, no `serde` feature. `cargo audit` against the full 29-crate dependency tree found zero advisories. `quick-xml` also has no DTD/external-entity expansion support at all, so it is XXE-safe by construction (unlike Python's `read_xml`, which specifically requires `defusedxml` instead of the stdlib `ElementTree` for the same protection).
- **omnist-ts#36 regression** (non-global sanitize regex): `xml_sanitize` maps every `char` through a predicate instead of using a substitution regex, so there's no "first occurrence only" bug class available at all. Regression test: `sanitizes_every_illegal_character_not_just_the_first`.
- **omnist-ts#53 lesson** (undocumented scalar-coercion narrowing): `coerce`'s rules were checked against a live `~/dev/venvs/omnist` Python interpreter's `omnist.formats._coerce`, not assumed -- documented in the module's doc comment, including a disclosed representational gap (this port's `Scalar::Int` is `i64`; a 20-4300-digit numeral that Python holds as an exact `int` falls through to `Scalar::Float` here instead, matching `_coerce`'s actual int-then-float control flow rather than erroring) and a disclosed narrowing (Unicode decimal digits, e.g. Arabic-indic digits, are not recognized -- ASCII-digit-only).
- Depth guard reused via `crate::document::check_write_depth` (inline during the recursive-descent read, matching Python's own approach, plus `Doc::from_raw`'s own guard on construction).
- Single-document-element write requirement, matching Python's `write_xml` check exactly (including firing outside `finish_write`, unconditionally, with no report attached).

## Cross-checked against live Python

Scalar coercion, CR normalization, and entity/character-reference resolution were all verified against a live `~/dev/omnist` interpreter (venv at `~/dev/venvs/omnist`, with `defusedxml` installed). No genuine Python bugs found -- this port's cross-checks continue the clean run (only issue #4 found a real bug so far, omnist-dev/omnist#255).

## Coverage correction

An earlier version of this PR claimed `cargo llvm-cov --workspace --fail-under-lines 100` passed. That claim was false: independent review reproduced the actual result as exit 1, workspace at 99.99% (6728/6729 lines), with the single missed line inside `xml.rs`'s own `read_xml` function.

Root cause: `read_xml`'s top-level event loop has its own `.map_err(|e| xml_parse_error(&reader, &normalized, &e))?` around the *first* `read_event_into` call (before any `Start`/`Empty`/`Eof` event has been returned). All existing malformed-XML tests exercised the identically-shaped `map_err` inside `parse_content` instead (reached only *after* a valid root `Start` event), so `read_xml`'s own copy of this mapping was never called. This is a genuine, reachable gap, not dead code -- confirmed experimentally against `quick-xml` directly: input like `</root>` (a stray closing tag with no matching open, i.e. malformed syntax before any root element) fails on that very first `read_event_into` call with `IllFormed(UnmatchedEndTag(..))`.

Fix: added `malformed_syntax_before_any_root_element_is_a_parse_error` (in `formats/xml/tests.rs`), which calls `read_xml("</root>")` and asserts it returns `OmnistError::Parse`, directly exercising that branch.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (526 tests total, 58 in `formats::xml`)
- [x] `cargo llvm-cov --workspace --fail-under-lines 100` -- genuinely passes now: exit 0, 100.00% lines/functions workspace-wide (previously falsely claimed passing; see Coverage correction above for the real gap that was found and fixed)
- [x] `cargo audit` against the full dependency tree: zero advisories

Generated with Claude Code
