### PR TITLE
omnist-cli: full command surface (issue #24)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,106 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "clap"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "equivalent"
@@ -54,6 +150,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +164,18 @@ dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "memchr"
@@ -85,8 +199,17 @@ dependencies = [
 name = "omnist-cli"
 version = "0.0.1-alpha"
 dependencies = [
+ "clap",
+ "indexmap",
  "omnist",
+ "serde_json",
 ]
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "proc-macro2"
@@ -145,6 +268,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +295,26 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -239,6 +391,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,3 +429,9 @@ dependencies = [
  "arraydeque",
  "hashlink",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/omnist-cli/Cargo.toml
+++ b/omnist-cli/Cargo.toml
@@ -13,3 +13,6 @@ path = "src/main.rs"
 
 [dependencies]
 omnist = { path = "../omnist" }
+clap = { version = "4", features = ["derive"] }
+serde_json = { version = "1", features = ["preserve_order"] }
+indexmap = "2"

--- a/omnist-cli/src/lib.rs
+++ b/omnist-cli/src/lib.rs
@@ -1,3 +1,941 @@
+//! The `omnist` command-line interface.
+//!
+//! Ported from `~/dev/omnist/omnist/cli.py` (issue #24) into a `clap`-based
+//! command tree over the existing `omnist` library crate. Per issue #1's
+//! "architecture freedom" policy, `clap`'s derive-based subcommand tree is
+//! not required to mirror Python's `argparse` structure line-for-line --
+//! only the resulting CLI surface (flags, subcommands, exit codes, output
+//! shapes) has to match. See `docs/design/cli-spec.md` (in the Python
+//! reference repo) for the authoritative command-surface spec this module
+//! is checked against.
+//!
+//! ## Known scope gaps (library limitations, not CLI bugs)
+//!
+//! - **`--arrays`**: the Python reference's `write_oml` supports an
+//!   `arrays=True` mode that collapses runs of same-label edges into
+//!   `[...]` array syntax. This port's [`omnist::oml::write_oml`] has no
+//!   `arrays` parameter yet (separate, not-yet-ported library work).
+//!   Passing `--arrays` where it would apply to OML output (`format`,
+//!   `convert --to oml`) is accepted by the argument parser (matching the
+//!   Python surface) but reported as a clear, non-panicking "not supported
+//!   yet" error (exit 2) rather than silently ignored or faked -- the same
+//!   scoping pattern `infer.rs`'s `allow_any` gap and `ops`'s `any`-type
+//!   gap already established in this port. Wherever `--arrays` has no
+//!   effect per spec (OSD output, or a `--to` other than `oml`), it is
+//!   accepted and silently ignored, matching Python exactly.
+//! - **schema-directed `--schema` on `convert`**: implemented via
+//!   [`omnist::materialize::materialize`] on the raw node after a
+//!   schema-less read, exactly mirroring Python's `_materialize(node,
+//!   schema)` call inside each reader.
+
+use std::io::{self, Read, Write};
+
+use clap::{Parser, Subcommand, ValueEnum};
+use omnist::document::{Doc, Value};
+use omnist::schema::Schema;
+use omnist::{OmnistError, WriteError, WriteReport};
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "omnist",
+    version = omnist::VERSION,
+    about = "One canonical data model for JSON, YAML, TOML, XML, and OML -- \
+             read, validate, and write any of them."
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Canonicalize an OML document (the only format with no other tool for this).
+    Format(FormatArgs),
+    /// Convert a document between formats (one in, one out).
+    Convert(ConvertArgs),
+    /// Report what writing as --to would adjust, without ever writing.
+    Check(CheckArgs),
+    /// Check a document against a schema (no schema-directed upgrading).
+    Validate(ValidateArgs),
+    /// Draft a schema from example documents (all the same format).
+    Infer(InferArgs),
+    /// Operate on a Schema (OSD).
+    #[command(subcommand)]
+    Schema(SchemaCommand),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub enum Fmt {
+    Json,
+    Yaml,
+    Toml,
+    Xml,
+    Oml,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum, Default)]
+pub enum ResultFormat {
+    #[default]
+    Text,
+    Json,
+    Oml,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum, Default)]
+pub enum LintSeverity {
+    #[default]
+    Info,
+    Warning,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct FormatArgs {
+    /// OML file, or - for stdin
+    pub input: String,
+    #[arg(long)]
+    pub compact: bool,
+    #[arg(long)]
+    pub arrays: bool,
+    #[arg(short, long)]
+    pub output: Option<String>,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct ConvertArgs {
+    pub input: String,
+    #[arg(long = "from", value_enum)]
+    pub from: Fmt,
+    #[arg(long = "to", value_enum)]
+    pub to: Fmt,
+    #[arg(long)]
+    pub schema: Option<String>,
+    #[arg(long)]
+    pub strict: bool,
+    #[arg(long)]
+    pub report: bool,
+    #[arg(long = "result-format", value_enum, default_value_t = ResultFormat::Text)]
+    pub result_format: ResultFormat,
+    #[arg(long)]
+    pub compact: bool,
+    #[arg(long)]
+    pub arrays: bool,
+    #[arg(short, long)]
+    pub output: Option<String>,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct CheckArgs {
+    pub input: String,
+    #[arg(long = "from", value_enum)]
+    pub from: Fmt,
+    #[arg(long = "to", value_enum)]
+    pub to: Fmt,
+    #[arg(long)]
+    pub strict: bool,
+    #[arg(long = "result-format", value_enum, default_value_t = ResultFormat::Text)]
+    pub result_format: ResultFormat,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct ValidateArgs {
+    pub input: String,
+    #[arg(long = "from", value_enum)]
+    pub from: Fmt,
+    #[arg(long)]
+    pub schema: String,
+    #[arg(long = "result-format", value_enum, default_value_t = ResultFormat::Text)]
+    pub result_format: ResultFormat,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct InferArgs {
+    #[arg(required = true)]
+    pub input: Vec<String>,
+    #[arg(long = "from", value_enum)]
+    pub from: Fmt,
+    #[arg(long)]
+    pub compact: bool,
+    #[arg(long)]
+    pub arrays: bool,
+    #[arg(long = "allow-any")]
+    pub allow_any: bool,
+    #[arg(short, long)]
+    pub output: Option<String>,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SchemaCommand {
+    Format(SchemaFormatArgs),
+    Normalize(SchemaFormatArgs),
+    Prune(SchemaPruneArgs),
+    #[command(name = "is-empty")]
+    IsEmpty(SchemaResultArgs),
+    Extract(SchemaExtractArgs),
+    Lint(SchemaLintArgs),
+    #[command(name = "compatible-with")]
+    CompatibleWith(SchemaPairArgs),
+    Equivalent(SchemaPairArgs),
+}
+
+#[derive(clap::Args, Debug)]
+pub struct SchemaFormatArgs {
+    pub schema_file: String,
+    #[arg(long)]
+    pub compact: bool,
+    #[arg(long)]
+    pub arrays: bool,
+    #[arg(short, long)]
+    pub output: Option<String>,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct SchemaPruneArgs {
+    pub schema_file: String,
+    #[arg(long)]
+    pub compact: bool,
+    #[arg(short, long)]
+    pub output: Option<String>,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct SchemaResultArgs {
+    pub schema_file: String,
+    #[arg(long = "result-format", value_enum, default_value_t = ResultFormat::Text)]
+    pub result_format: ResultFormat,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct SchemaExtractArgs {
+    pub schema_file: String,
+    #[arg(long)]
+    pub keep: String,
+    #[arg(long)]
+    pub compact: bool,
+    #[arg(short, long)]
+    pub output: Option<String>,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct SchemaLintArgs {
+    pub schema_file: String,
+    #[arg(long, value_enum, default_value_t = LintSeverity::Info)]
+    pub severity: LintSeverity,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct SchemaPairArgs {
+    pub a: String,
+    pub b: String,
+    #[arg(long = "result-format", value_enum, default_value_t = ResultFormat::Text)]
+    pub result_format: ResultFormat,
+    #[arg(long)]
+    pub json: bool,
+}
+
+// ---------------------------------------------------------------------------
+// I/O plumbing
+// ---------------------------------------------------------------------------
+
+/// Read `path` (or stdin for `-`). On failure, the message names the path
+/// (mirroring Python's `OSError` string, which embeds the filename) rather
+/// than a bare OS message with no context.
+fn read_input(path: &str) -> Result<String, String> {
+    if path == "-" {
+        let mut s = String::new();
+        io::stdin()
+            .read_to_string(&mut s)
+            .map_err(|e| format!("{e} (reading stdin)"))?;
+        Ok(s)
+    } else {
+        std::fs::read_to_string(path).map_err(|e| format!("{path}: {e}"))
+    }
+}
+
+fn write_output(path: Option<&str>, mut text: String) -> Result<(), String> {
+    if !text.ends_with('\n') {
+        text.push('\n');
+    }
+    match path {
+        None | Some("-") => {
+            print!("{text}");
+            io::stdout().flush().map_err(|e| e.to_string())
+        }
+        Some(p) => std::fs::write(p, text).map_err(|e| format!("{p}: {e}")),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Uniform error shape
+// ---------------------------------------------------------------------------
+
+/// One structured error entry, shared by every `--json` failure payload.
+/// Mirrors Python's `ParseError.errors`: only schema-conformance failures
+/// via [`omnist::materialize::materialize`] ever populate this --
+/// format-syntax failures always report `[]`.
+fn extract_errors(e: &OmnistError) -> Vec<(String, String, String)> {
+    match e {
+        OmnistError::Materialize(me) => me
+            .errors()
+            .iter()
+            .map(|ve| {
+                (
+                    ve.path.clone(),
+                    ve.code.as_str().to_string(),
+                    ve.message.clone(),
+                )
+            })
+            .collect(),
+        _ => vec![],
+    }
+}
+
+/// Serialize a [`serde_json::Value`] using Python `json.dumps`'s default
+/// separators (`", "`/`": "`) rather than serde_json's default compact
+/// (no-space) style, so `--json`/`--result-format json` output matches
+/// Python's byte-for-byte (the CLI's own JSON payloads are always small,
+/// hand-built shapes -- this is not a general-purpose formatter). Key
+/// order is preserved by `serde_json`'s `preserve_order` feature, matching
+/// the insertion order Python's dict literals give `json.dumps`.
+fn py_json(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::Object(m) => {
+            let items: Vec<String> = m
+                .iter()
+                .map(|(k, v)| format!("{}: {}", serde_json::to_string(k).unwrap(), py_json(v)))
+                .collect();
+            format!("{{{}}}", items.join(", "))
+        }
+        serde_json::Value::Array(a) => {
+            let items: Vec<String> = a.iter().map(py_json).collect();
+            format!("[{}]", items.join(", "))
+        }
+        other => serde_json::to_string(other).unwrap(),
+    }
+}
+
+fn json_error_payload(message: &str, errors: &[(String, String, String)]) -> String {
+    let errs: Vec<serde_json::Value> = errors
+        .iter()
+        .map(|(p, c, m)| serde_json::json!({"path": p, "code": c, "message": m}))
+        .collect();
+    py_json(&serde_json::json!({"ok": false, "message": message, "errors": errs}))
+}
+
+/// Uniform in-command error emission, mirroring Python's `_fail`. Under
+/// `--json`, prints a machine-readable error object to stdout; otherwise
+/// the free-text `error: ...` to stderr. Returns `code` unchanged either
+/// way.
+fn fail(json: bool, message: &str, errors: &[(String, String, String)], code: i32) -> i32 {
+    if json {
+        println!("{}", json_error_payload(message, errors));
+    } else {
+        eprintln!("error: {message}");
+    }
+    code
+}
+
+/// The generic uncaught-error path, mirroring Python `main()`'s top-level
+/// exception handler: exit 2 always.
+fn generic_fail(json: bool, e: &OmnistError) -> i32 {
+    fail(json, &e.to_string(), &extract_errors(e), 2)
+}
+
+fn io_fail(json: bool, message: &str) -> i32 {
+    fail(json, message, &[], 2)
+}
+
+// ---------------------------------------------------------------------------
+// Format dispatch helpers
+// ---------------------------------------------------------------------------
+
+fn read_by_fmt(fmt: Fmt, text: &str) -> Result<Doc, OmnistError> {
+    match fmt {
+        Fmt::Json => omnist::formats::json::read_json(text),
+        Fmt::Yaml => omnist::formats::yaml::read_yaml(text),
+        Fmt::Toml => omnist::formats::toml::read_toml(text),
+        Fmt::Xml => omnist::formats::xml::read_xml(text),
+        Fmt::Oml => {
+            let raw = omnist::oml::read_oml(text)?;
+            Ok(Doc::from_raw(raw)?)
+        }
+    }
+}
+
+const ARRAYS_UNSUPPORTED_MSG: &str = "--arrays is not yet supported by this port's OML writer (a separate library gap, see \
+     omnist-cli's crate doc comment)";
+
+const ARRAYS_OSD_ONLY_MSG: &str = "--arrays applies only to OML output (format, convert --to oml)";
+
+enum WriteOutcome {
+    Text(String),
+    ArraysUnsupported,
+}
+
+fn write_by_fmt(
+    fmt: Fmt,
+    doc: &Doc,
+    strict: bool,
+    report: Option<&mut WriteReport>,
+    compact: bool,
+    arrays: bool,
+) -> Result<WriteOutcome, WriteError> {
+    match fmt {
+        // `--compact` applies only to OML output (per cli-spec.md §3's
+        // `convert` entry: "no effect otherwise") -- JSON's own writer
+        // default (`indent: None`, matching Python's `write_json`'s
+        // `indent: Optional[int] = None` default) always applies here,
+        // regardless of `--compact`.
+        Fmt::Json => {
+            omnist::formats::json::write_json(doc, None, strict, report).map(WriteOutcome::Text)
+        }
+        Fmt::Yaml => omnist::formats::yaml::write_yaml(doc, strict, report).map(WriteOutcome::Text),
+        Fmt::Toml => omnist::formats::toml::write_toml(doc, strict, report).map(WriteOutcome::Text),
+        Fmt::Xml => omnist::formats::xml::write_xml(doc, strict, report).map(WriteOutcome::Text),
+        Fmt::Oml => {
+            if arrays {
+                return Ok(WriteOutcome::ArraysUnsupported);
+            }
+            let raw = doc.to_raw();
+            if compact {
+                omnist::oml::write_oml_compact(&raw).map(WriteOutcome::Text)
+            } else {
+                omnist::oml::write_oml(&raw, 2).map(WriteOutcome::Text)
+            }
+        }
+    }
+}
+
+fn check_by_fmt(fmt: Fmt, doc: &Doc) -> Result<WriteReport, WriteError> {
+    match fmt {
+        Fmt::Json => Ok(omnist::formats::json::check_json(doc)),
+        Fmt::Yaml => Ok(omnist::formats::yaml::check_yaml(doc)),
+        Fmt::Toml => Ok(omnist::formats::toml::check_toml(doc)),
+        Fmt::Xml => Ok(omnist::formats::xml::check_xml(doc)),
+        Fmt::Oml => {
+            // OML is always lossless; the only possible failure is the
+            // depth guard, surfaced the same way a real write would be.
+            omnist::oml::write_oml(&doc.to_raw(), 2)?;
+            Ok(WriteReport::new())
+        }
+    }
+}
+
+fn encode_write_report(rep: &WriteReport, fmt: ResultFormat) -> String {
+    match fmt {
+        ResultFormat::Text => rep.to_string(),
+        ResultFormat::Json => {
+            let adjustments: Vec<serde_json::Value> = rep
+                .iter()
+                .map(|a| {
+                    let sev = match a.severity {
+                        omnist::Severity::Warning => "warning",
+                        omnist::Severity::Error => "error",
+                    };
+                    serde_json::json!({
+                        "path": a.path, "code": a.code, "message": a.message, "severity": sev
+                    })
+                })
+                .collect();
+            py_json(&serde_json::Value::Array(adjustments))
+        }
+        ResultFormat::Oml => {
+            let adjustments: Vec<Value> = rep
+                .iter()
+                .map(|a| {
+                    let sev = match a.severity {
+                        omnist::Severity::Warning => "warning",
+                        omnist::Severity::Error => "error",
+                    };
+                    Value::Object(indexmap::IndexMap::from([
+                        ("path".to_string(), Value::Str(a.path.clone())),
+                        ("code".to_string(), Value::Str(a.code.clone())),
+                        ("message".to_string(), Value::Str(a.message.clone())),
+                        ("severity".to_string(), Value::Str(sev.to_string())),
+                    ]))
+                })
+                .collect();
+            let payload = Value::Object(indexmap::IndexMap::from([(
+                "adjustments".to_string(),
+                Value::Array(adjustments),
+            )]));
+            let doc = Doc::of(&payload).expect("a report payload is always a legal Document");
+            omnist::oml::write_oml(&doc.to_raw(), 2)
+                .expect("report payloads never nest past MAX_DEPTH")
+        }
+    }
+}
+
+fn encode_bool_result(key: &str, value: bool, fmt: ResultFormat) -> String {
+    match fmt {
+        ResultFormat::Text => if value { "true" } else { "false" }.to_string(),
+        ResultFormat::Json => py_json(&serde_json::json!({key: value})),
+        ResultFormat::Oml => {
+            let payload = Value::Object(indexmap::IndexMap::from([(
+                key.to_string(),
+                Value::Bool(value),
+            )]));
+            let doc = Doc::of(&payload).expect("a bool-result payload is always a legal Document");
+            omnist::oml::write_oml(&doc.to_raw(), 2).expect("bool-result payloads never nest")
+        }
+    }
+}
+
+fn encode_validation_result(
+    result: &omnist::schema::ValidationResult,
+    fmt: ResultFormat,
+) -> String {
+    match fmt {
+        ResultFormat::Text => result.to_string(),
+        ResultFormat::Json => {
+            let errors: Vec<serde_json::Value> = result
+                .errors()
+                .iter()
+                .map(|e| serde_json::json!({"path": e.path, "message": e.message}))
+                .collect();
+            py_json(&serde_json::json!({"ok": result.ok(), "errors": errors}))
+        }
+        ResultFormat::Oml => {
+            let errors: Vec<Value> = result
+                .errors()
+                .iter()
+                .map(|e| {
+                    Value::Object(indexmap::IndexMap::from([
+                        ("path".to_string(), Value::Str(e.path.clone())),
+                        ("message".to_string(), Value::Str(e.message.clone())),
+                    ]))
+                })
+                .collect();
+            let payload = Value::Object(indexmap::IndexMap::from([
+                ("ok".to_string(), Value::Bool(result.ok())),
+                ("errors".to_string(), Value::Array(errors)),
+            ]));
+            let doc = Doc::of(&payload).expect("a validation-result payload is always legal");
+            omnist::oml::write_oml(&doc.to_raw(), 2).expect("validation-result payloads never nest")
+        }
+    }
+}
+
+fn to_osd_text(schema: &Schema, compact: bool) -> String {
+    omnist::osd::to_osd(schema, if compact { None } else { Some(4) })
+}
+
+/// Read + parse an OSD schema file (or `-`), producing the uniform failure
+/// exit code (`2`, matching Python's generic parse-error path) on either an
+/// I/O error or a [`omnist::SchemaError`].
+fn parse_schema_file(path: &str, json: bool) -> Result<Schema, i32> {
+    let text = read_input(path).map_err(|e| io_fail(json, &e))?;
+    omnist::osd::parse_schema(&text).map_err(|e| generic_fail(json, &e.into()))
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+fn cmd_format(args: FormatArgs) -> i32 {
+    let text = match read_input(&args.input) {
+        Ok(t) => t,
+        Err(e) => return io_fail(args.json, &e),
+    };
+    let raw = match omnist::oml::read_oml(&text) {
+        Ok(r) => r,
+        Err(e) => return generic_fail(args.json, &e.into()),
+    };
+    if args.arrays {
+        return fail(args.json, ARRAYS_UNSUPPORTED_MSG, &[], 2);
+    }
+    // No `Doc::from_raw`/`.to_raw()` round-trip here: `format` reads and
+    // re-writes OML only, so `raw` (already the exact shape `write_oml`
+    // wants) goes straight back out. `read_oml` already enforces the same
+    // `MAX_DEPTH` guard `write_oml` re-checks (see `oml.rs`'s module doc),
+    // so re-serializing what was *just* read successfully can never itself
+    // hit the depth guard -- confirmed the same way `infer.rs` confirmed
+    // its own now-absent depth check was unreachable (see that module's
+    // doc comment): there is no way to get a `raw` here that didn't just
+    // pass this exact check a few lines up.
+    let text_out = if args.compact {
+        omnist::oml::write_oml_compact(&raw)
+    } else {
+        omnist::oml::write_oml(&raw, 2)
+    }
+    .expect("read_oml already enforced the depth guard write_oml re-checks");
+    if let Err(e) = write_output(args.output.as_deref(), text_out) {
+        return io_fail(args.json, &e);
+    }
+    0
+}
+
+fn cmd_convert(args: ConvertArgs) -> i32 {
+    if args.from == Fmt::Oml && args.to == Fmt::Oml {
+        return fail(
+            args.json,
+            "--from oml --to oml is not supported here; use `omnist format` instead",
+            &[],
+            2,
+        );
+    }
+    let text = match read_input(&args.input) {
+        Ok(t) => t,
+        Err(e) => return io_fail(args.json, &e),
+    };
+    let mut doc = match read_by_fmt(args.from, &text) {
+        Ok(d) => d,
+        Err(e) => return generic_fail(args.json, &e),
+    };
+    if let Some(schema_path) = &args.schema {
+        let schema = match parse_schema_file(schema_path, args.json) {
+            Ok(s) => s,
+            Err(code) => return code,
+        };
+        let materialized = match omnist::materialize::materialize(&doc.to_raw(), Some(&schema)) {
+            Ok(r) => r,
+            Err(e) => return generic_fail(args.json, &OmnistError::Materialize(e)),
+        };
+        // `materialize` only ever upgrades leaf scalars in place (see its
+        // module doc's scalar-upgrade table) -- it never adds nesting, so
+        // its output can't be any deeper than `doc.to_raw()` already was,
+        // which itself already passed this exact depth guard when `doc`
+        // was first built by `read_by_fmt` above. Not reachable via any
+        // real input, same class as `cmd_format`'s now-absent equivalent.
+        doc = Doc::from_raw(materialized)
+            .expect("materialize cannot deepen a Document past what read_by_fmt already allowed");
+    }
+    let mut report = if args.report {
+        Some(WriteReport::new())
+    } else {
+        None
+    };
+    let write_result = write_by_fmt(
+        args.to,
+        &doc,
+        args.strict,
+        report.as_mut(),
+        args.compact,
+        args.arrays,
+    );
+    let text_out = match write_result {
+        Ok(WriteOutcome::Text(s)) => s,
+        Ok(WriteOutcome::ArraysUnsupported) => {
+            return fail(args.json, ARRAYS_UNSUPPORTED_MSG, &[], 2);
+        }
+        Err(e) => {
+            if let Some(rep) = e.report() {
+                // A definite "no" -- a strict-mode refusal, not a usage/parse
+                // failure -- exit 1, matching Python's `_cmd_convert`.
+                return fail(args.json, &rep.to_string(), &[], 1);
+            }
+            return generic_fail(args.json, &e.into());
+        }
+    };
+    if let Err(e) = write_output(args.output.as_deref(), text_out) {
+        return io_fail(args.json, &e);
+    }
+    if let Some(rep) = &report {
+        eprintln!("{}", encode_write_report(rep, args.result_format));
+    }
+    0
+}
+
+fn cmd_check(args: CheckArgs) -> i32 {
+    let text = match read_input(&args.input) {
+        Ok(t) => t,
+        Err(e) => return io_fail(args.json, &e),
+    };
+    let doc = match read_by_fmt(args.from, &text) {
+        Ok(d) => d,
+        Err(e) => return generic_fail(args.json, &e),
+    };
+    // `check_by_fmt`'s only failure mode (the `--to oml` arm) is the same
+    // depth guard `doc` already passed when `read_by_fmt` built it above --
+    // not reachable via any real input, same class as `cmd_format`'s and
+    // `cmd_convert`'s equivalents.
+    let rep = check_by_fmt(args.to, &doc)
+        .expect("check_by_fmt's only failure mode is a depth guard read_by_fmt already enforced");
+    let fmt = if args.json {
+        ResultFormat::Json
+    } else {
+        args.result_format
+    };
+    println!("{}", encode_write_report(&rep, fmt));
+    if args.strict && !rep.is_empty() { 1 } else { 0 }
+}
+
+fn cmd_validate(args: ValidateArgs) -> i32 {
+    let text = match read_input(&args.input) {
+        Ok(t) => t,
+        Err(e) => return io_fail(args.json, &e),
+    };
+    let doc = match read_by_fmt(args.from, &text) {
+        Ok(d) => d,
+        Err(e) => return generic_fail(args.json, &e),
+    };
+    let schema = match parse_schema_file(&args.schema, args.json) {
+        Ok(s) => s,
+        Err(code) => return code,
+    };
+    let result = schema.validate(&doc.root());
+    if args.json {
+        if result.ok() {
+            println!("{}", py_json(&serde_json::json!({"ok": true})));
+            return 0;
+        }
+        let errors: Vec<serde_json::Value> = result
+            .errors()
+            .iter()
+            .map(|e| serde_json::json!({"path": e.path, "code": e.code.as_str(), "message": e.message}))
+            .collect();
+        println!(
+            "{}",
+            py_json(
+                &serde_json::json!({"ok": false, "message": result.to_string(), "errors": errors})
+            )
+        );
+        return 1;
+    }
+    println!("{}", encode_validation_result(&result, args.result_format));
+    if result.ok() { 0 } else { 1 }
+}
+
+fn cmd_infer(args: InferArgs) -> i32 {
+    if args.arrays {
+        return fail(args.json, ARRAYS_OSD_ONLY_MSG, &[], 2);
+    }
+    if args.allow_any {
+        return fail(
+            args.json,
+            "--allow-any is not supported by this port's `infer` yet (no `any` schema type; \
+             see omnist::infer's module doc)",
+            &[],
+            2,
+        );
+    }
+    let mut docs = Vec::with_capacity(args.input.len());
+    for path in &args.input {
+        let text = match read_input(path) {
+            Ok(t) => t,
+            Err(e) => return io_fail(args.json, &e),
+        };
+        match read_by_fmt(args.from, &text) {
+            Ok(d) => docs.push(d),
+            Err(e) => return generic_fail(args.json, &e),
+        }
+    }
+    let schema = match omnist::infer(&docs, "Root") {
+        Ok(s) => s,
+        Err(e) => return generic_fail(args.json, &e.into()),
+    };
+    let text_out = to_osd_text(&schema, args.compact);
+    if let Err(e) = write_output(args.output.as_deref(), text_out) {
+        return io_fail(args.json, &e);
+    }
+    0
+}
+
+fn cmd_schema_format(args: SchemaFormatArgs) -> i32 {
+    if args.arrays {
+        return fail(args.json, ARRAYS_OSD_ONLY_MSG, &[], 2);
+    }
+    let schema = match parse_schema_file(&args.schema_file, args.json) {
+        Ok(s) => s,
+        Err(code) => return code,
+    };
+    let out = to_osd_text(&schema, args.compact);
+    if let Err(e) = write_output(args.output.as_deref(), out) {
+        return io_fail(args.json, &e);
+    }
+    0
+}
+
+fn cmd_schema_normalize(args: SchemaFormatArgs) -> i32 {
+    if args.arrays {
+        return fail(args.json, ARRAYS_OSD_ONLY_MSG, &[], 2);
+    }
+    let schema = match parse_schema_file(&args.schema_file, args.json) {
+        Ok(s) => s,
+        Err(code) => return code,
+    };
+    let out = to_osd_text(&omnist::ops::normalize(&schema), args.compact);
+    if let Err(e) = write_output(args.output.as_deref(), out) {
+        return io_fail(args.json, &e);
+    }
+    0
+}
+
+fn cmd_schema_prune(args: SchemaPruneArgs) -> i32 {
+    let schema = match parse_schema_file(&args.schema_file, args.json) {
+        Ok(s) => s,
+        Err(code) => return code,
+    };
+    let out = to_osd_text(&omnist::ops::prune(&schema), args.compact);
+    if let Err(e) = write_output(args.output.as_deref(), out) {
+        return io_fail(args.json, &e);
+    }
+    0
+}
+
+fn cmd_schema_is_empty(args: SchemaResultArgs) -> i32 {
+    let schema = match parse_schema_file(&args.schema_file, args.json) {
+        Ok(s) => s,
+        Err(code) => return code,
+    };
+    let result = omnist::ops::is_empty(&schema);
+    let fmt = if args.json {
+        ResultFormat::Json
+    } else {
+        args.result_format
+    };
+    println!("{}", encode_bool_result("empty", result, fmt));
+    if result { 0 } else { 1 }
+}
+
+fn cmd_schema_extract(args: SchemaExtractArgs) -> i32 {
+    let schema = match parse_schema_file(&args.schema_file, args.json) {
+        Ok(s) => s,
+        Err(code) => return code,
+    };
+    let labels: Vec<&str> = args.keep.split(',').filter(|s| !s.is_empty()).collect();
+    let extracted = match omnist::ops::extract(&schema, &labels) {
+        Ok(s) => s,
+        Err(e) => {
+            // A definite "no valid subschema" -- exit 1, like
+            // `compatible-with`'s `false`, not the generic parse/usage 2.
+            return fail(args.json, &e.to_string(), &[], 1);
+        }
+    };
+    let out = to_osd_text(&extracted, args.compact);
+    if let Err(e) = write_output(args.output.as_deref(), out) {
+        return io_fail(args.json, &e);
+    }
+    0
+}
+
+fn cmd_schema_lint(args: SchemaLintArgs) -> i32 {
+    let schema = match parse_schema_file(&args.schema_file, args.json) {
+        Ok(s) => s,
+        Err(code) => return code,
+    };
+    let threshold = match args.severity {
+        LintSeverity::Info => 0,
+        LintSeverity::Warning => 1,
+    };
+    let sev_rank = |s: &str| if s == "warning" { 1 } else { 0 };
+    let findings: Vec<_> = omnist::ops::lint(&schema)
+        .into_iter()
+        .filter(|f| sev_rank(f.severity) >= threshold)
+        .collect();
+    let has_warning = findings.iter().any(|f| f.severity == "warning");
+    if args.json {
+        let findings_json: Vec<serde_json::Value> = findings
+            .iter()
+            .map(|f| {
+                serde_json::json!({
+                    "code": f.code, "severity": f.severity,
+                    "location": f.location, "message": f.message
+                })
+            })
+            .collect();
+        println!(
+            "{}",
+            py_json(&serde_json::json!({"ok": !has_warning, "findings": findings_json}))
+        );
+    } else if findings.is_empty() {
+        println!("no findings");
+    } else {
+        for f in &findings {
+            println!("{}: {}: {}: {}", f.severity, f.code, f.location, f.message);
+        }
+    }
+    if has_warning { 1 } else { 0 }
+}
+
+fn cmd_schema_compatible_with(args: SchemaPairArgs) -> i32 {
+    let a = match parse_schema_file(&args.a, args.json) {
+        Ok(s) => s,
+        Err(code) => return code,
+    };
+    let b = match parse_schema_file(&args.b, args.json) {
+        Ok(s) => s,
+        Err(code) => return code,
+    };
+    let result = omnist::ops::compatible_with(&a, &b);
+    let fmt = if args.json {
+        ResultFormat::Json
+    } else {
+        args.result_format
+    };
+    println!("{}", encode_bool_result("compatible", result, fmt));
+    if result { 0 } else { 1 }
+}
+
+fn cmd_schema_equivalent(args: SchemaPairArgs) -> i32 {
+    let a = match parse_schema_file(&args.a, args.json) {
+        Ok(s) => s,
+        Err(code) => return code,
+    };
+    let b = match parse_schema_file(&args.b, args.json) {
+        Ok(s) => s,
+        Err(code) => return code,
+    };
+    let result = omnist::ops::equivalent(&a, &b);
+    let fmt = if args.json {
+        ResultFormat::Json
+    } else {
+        args.result_format
+    };
+    println!("{}", encode_bool_result("equivalent", result, fmt));
+    if result { 0 } else { 1 }
+}
+
+/// Run the CLI given already-parsed [`Cli`] arguments, returning the
+/// process exit code. Split from `main` so integration tests exercising
+/// the real compiled binary (per the issue's test-obligation) and any
+/// future in-process test can share one entry point.
+pub fn run(cli: Cli) -> i32 {
+    match cli.command {
+        Command::Format(a) => cmd_format(a),
+        Command::Convert(a) => cmd_convert(a),
+        Command::Check(a) => cmd_check(a),
+        Command::Validate(a) => cmd_validate(a),
+        Command::Infer(a) => cmd_infer(a),
+        Command::Schema(sub) => match sub {
+            SchemaCommand::Format(a) => cmd_schema_format(a),
+            SchemaCommand::Normalize(a) => cmd_schema_normalize(a),
+            SchemaCommand::Prune(a) => cmd_schema_prune(a),
+            SchemaCommand::IsEmpty(a) => cmd_schema_is_empty(a),
+            SchemaCommand::Extract(a) => cmd_schema_extract(a),
+            SchemaCommand::Lint(a) => cmd_schema_lint(a),
+            SchemaCommand::CompatibleWith(a) => cmd_schema_compatible_with(a),
+            SchemaCommand::Equivalent(a) => cmd_schema_equivalent(a),
+        },
+    }
+}
+
+/// Kept for backward compatibility with issue #2/PR #3's placeholder --
+/// no longer used by `main`, but harmless to keep as a small library
+/// entry point (and its existing test).
 pub fn version_line() -> String {
     format!("omnist {}", omnist::VERSION)
 }

--- a/omnist-cli/src/lib.rs
+++ b/omnist-cli/src/lib.rs
@@ -282,7 +282,29 @@ fn write_output(path: Option<&str>, mut text: String) -> Result<(), String> {
     match path {
         None | Some("-") => {
             print!("{text}");
-            io::stdout().flush().map_err(|e| e.to_string())
+            // Not a `Result`-returning error path: `io::stdout()` is
+            // unconditionally line-buffered (`LineWriter`), regardless of
+            // whether it's a tty, per `std::io::Stdout`'s own docs. `text`
+            // always ends in `\n` (enforced above), so the `print!` call
+            // just above has *already* pushed every byte through to the
+            // OS-level write by the time it returns -- that's what
+            // `LineWriter` does on seeing a trailing newline. By the time
+            // control reaches here there is nothing left buffered for
+            // `flush` to push, so it degenerates to `StdoutRaw::flush`,
+            // which is a hard no-op (unbuffered raw fds have nothing to
+            // flush). A real write failure (e.g. broken pipe, `ENOSPC` from
+            // `/dev/full`) panics *inside* `print!` itself (`io::Write`'s
+            // `print!`/`println!` macros `.unwrap()` internally, they don't
+            // propagate `Result`) before this line is ever reached --
+            // confirmed empirically: forcing broken-pipe and `/dev/full`
+            // stdout in integration tests both panic at the `print!` call,
+            // never here. So this call cannot observably fail; `.expect`
+            // documents that invariant instead of carrying a dead
+            // `Result`-returning branch.
+            io::stdout().flush().expect(
+                "stdout is line-buffered and `text` ends in '\\n', so `print!` already flushed; a real write failure would have already panicked inside `print!` itself",
+            );
+            Ok(())
         }
         Some(p) => std::fs::write(p, text).map_err(|e| format!("{p}: {e}")),
     }

--- a/omnist-cli/src/main.rs
+++ b/omnist-cli/src/main.rs
@@ -1,3 +1,7 @@
+use clap::Parser;
+use omnist_cli::{Cli, run};
+
 fn main() {
-    println!("{}", omnist_cli::version_line());
+    let cli = Cli::parse();
+    std::process::exit(run(cli));
 }

--- a/omnist-cli/tests/cli.rs
+++ b/omnist-cli/tests/cli.rs
@@ -186,6 +186,18 @@ fn convert_schema_conformance_failure_exits_2() {
 }
 
 #[test]
+fn convert_schema_conformance_failure_json_shape_has_structured_errors() {
+    let input = fixture("convert_schema_bad_json", r#"{"a": "nope", "b": "x"}"#);
+    let schema = fixture("convert_schema_bad_osd_json", SCHEMA_OSD);
+    let r = run(&[
+        "convert", &input, "--from", "json", "--to", "json", "--schema", &schema, "--json",
+    ]);
+    assert_eq!(r.code, 2);
+    assert!(r.stdout.contains("\"path\": \"$.a\""), "stdout: {}", r.stdout);
+    assert!(r.stdout.contains("\"code\": \"type-mismatch\""), "stdout: {}", r.stdout);
+}
+
+#[test]
 fn convert_strict_refuses_a_lossy_write_with_exit_1() {
     let input = fixture("convert_strict_in", r#"{"a": NaN}"#);
     let r = run(&[
@@ -744,6 +756,25 @@ fn validate_result_format_json_non_flag_variant() {
     ]);
     assert_eq!(r.code, 0);
     assert_eq!(r.stdout.trim(), "{\"ok\": true, \"errors\": []}");
+}
+
+#[test]
+fn validate_result_format_json_non_flag_variant_with_errors() {
+    let input = fixture("validate_rf_json_err_in", r#"{"a": "nope", "b": "x"}"#);
+    let schema = fixture("validate_rf_json_err_schema", SCHEMA_OSD);
+    let r = run(&[
+        "validate",
+        &input,
+        "--from",
+        "json",
+        "--schema",
+        &schema,
+        "--result-format",
+        "json",
+    ]);
+    assert_eq!(r.code, 1);
+    assert!(r.stdout.contains("\"path\": \"$.a\""));
+    assert!(!r.stdout.contains("\"code\""));
 }
 
 #[test]

--- a/omnist-cli/tests/cli.rs
+++ b/omnist-cli/tests/cli.rs
@@ -1,12 +1,1119 @@
-use std::process::Command;
+//! Integration tests for the `omnist` CLI (issue #24). Spawns the real
+//! compiled binary via `Command::new(env!("CARGO_BIN_EXE_omnist"))`, per
+//! the pattern #2/PR #3 established with `prints_version_line` -- this is
+//! also how `main.rs`/`lib.rs`'s glue code gets exercised for coverage
+//! purposes, not just each command's logic.
+
+use std::io::Write as _;
+use std::process::{Command, Stdio};
+
+fn bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_omnist"))
+}
+
+struct Run {
+    stdout: String,
+    stderr: String,
+    code: i32,
+}
+
+fn run(args: &[&str]) -> Run {
+    run_stdin(args, None)
+}
+
+fn run_stdin(args: &[&str], stdin: Option<&str>) -> Run {
+    let mut cmd = bin();
+    cmd.args(args);
+    if stdin.is_some() {
+        cmd.stdin(Stdio::piped());
+    }
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    let mut child = cmd.spawn().expect("failed to spawn omnist binary");
+    if let Some(text) = stdin {
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(text.as_bytes())
+            .unwrap();
+    }
+    let output = child.wait_with_output().expect("failed to wait on child");
+    Run {
+        stdout: String::from_utf8(output.stdout).unwrap(),
+        stderr: String::from_utf8(output.stderr).unwrap(),
+        code: output.status.code().unwrap(),
+    }
+}
+
+/// A fresh scratch file under the test binary's own temp dir, so parallel
+/// tests never collide, holding `content`.
+fn fixture(name: &str, content: &str) -> String {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "omnist-cli-test-{}-{}-{}",
+        std::process::id(),
+        name,
+        n
+    ));
+    std::fs::write(&path, content).unwrap();
+    path.to_string_lossy().into_owned()
+}
+
+const DOC_JSON: &str = r#"{"a": 1, "b": "x"}"#;
+const SCHEMA_OSD: &str = r#"record Root { "a": integer, "b": string } root Root"#;
+
+// --------------------------------------------------------------------- version
 
 #[test]
-fn prints_version_line() {
-    let output = Command::new(env!("CARGO_BIN_EXE_omnist"))
-        .output()
-        .expect("failed to run omnist-cli binary");
+fn prints_version_with_version_flag() {
+    let r = run(&["--version"]);
+    assert!(r.code == 0);
+    assert!(r.stdout.trim().starts_with("omnist "));
+}
 
-    assert!(output.status.success());
-    let stdout = String::from_utf8(output.stdout).unwrap();
-    assert_eq!(stdout.trim(), format!("omnist {}", omnist::VERSION));
+#[test]
+fn no_subcommand_is_a_usage_error() {
+    let r = run(&[]);
+    assert_eq!(r.code, 2);
+    assert!(r.stderr.contains("Usage"));
+}
+
+// --------------------------------------------------------------------- format
+
+#[test]
+fn format_golden_path_pretty_prints_oml() {
+    let input = fixture("format_in", "a: 1; b: \"x\"\n");
+    let r = run(&["format", &input]);
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout, "a: 1\nb: \"x\"\n");
+}
+
+#[test]
+fn format_compact_single_lines() {
+    let input = fixture("format_compact_in", "a: 1\nb: \"x\"\n");
+    let r = run(&["format", &input, "--compact"]);
+    assert_eq!(r.code, 0);
+    assert_eq!(r.stdout, "a: 1; b: \"x\"\n");
+}
+
+#[test]
+fn format_stdin_and_stdout_dash_plumbing() {
+    let r = run_stdin(&["format", "-"], Some("a: 1\n"));
+    assert_eq!(r.code, 0);
+    assert_eq!(r.stdout, "a: 1\n");
+}
+
+#[test]
+fn format_reports_a_parse_error_with_exit_2() {
+    let input = fixture("format_bad", "not valid oml {{{");
+    let r = run(&["format", &input]);
+    assert_eq!(r.code, 2);
+    assert!(r.stderr.starts_with("error: "), "stderr: {}", r.stderr);
+}
+
+#[test]
+fn format_arrays_is_a_clear_not_yet_supported_error() {
+    let input = fixture("format_arrays", "a: 1\n");
+    let r = run(&["format", &input, "--arrays"]);
+    assert_eq!(r.code, 2);
+    assert!(r.stderr.contains("not yet supported"));
+}
+
+#[test]
+fn format_json_error_shape() {
+    let input = fixture("format_bad_json", "not valid oml {{{");
+    let r = run(&["format", &input, "--json"]);
+    assert_eq!(r.code, 2);
+    assert!(r.stdout.contains("\"ok\": false"));
+    assert!(r.stdout.contains("\"errors\": []"));
+    assert_eq!(r.stderr, "");
+}
+
+#[test]
+fn format_writes_to_output_file() {
+    let input = fixture("format_o_in", "a: 1\n");
+    let mut out = std::env::temp_dir();
+    out.push(format!("omnist-cli-test-format-out-{}", std::process::id()));
+    let out_str = out.to_string_lossy().into_owned();
+    let r = run(&["format", &input, "-o", &out_str]);
+    assert_eq!(r.code, 0);
+    assert_eq!(r.stdout, "");
+    assert_eq!(std::fs::read_to_string(&out).unwrap(), "a: 1\n");
+}
+
+// --------------------------------------------------------------------- convert
+
+#[test]
+fn convert_golden_path_json_to_oml() {
+    let input = fixture("convert_in", DOC_JSON);
+    let r = run(&["convert", &input, "--from", "json", "--to", "oml"]);
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout, "a: 1\nb: \"x\"\n");
+}
+
+#[test]
+fn convert_oml_to_oml_is_rejected() {
+    let input = fixture("convert_oml_oml", "a: 1\n");
+    let r = run(&["convert", &input, "--from", "oml", "--to", "oml"]);
+    assert_eq!(r.code, 2);
+    assert!(r.stderr.contains("use `omnist format` instead"));
+}
+
+#[test]
+fn convert_schema_directed_materialization() {
+    let input = fixture("convert_schema_in", r#"{"a": 1.0, "b": "x"}"#);
+    let schema = fixture("convert_schema", SCHEMA_OSD);
+    let r = run(&[
+        "convert", &input, "--from", "json", "--to", "json", "--schema", &schema,
+    ]);
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+    assert!(r.stdout.contains("\"a\": 1"));
+}
+
+#[test]
+fn convert_schema_conformance_failure_exits_2() {
+    let input = fixture("convert_schema_bad", r#"{"a": "nope", "b": "x"}"#);
+    let schema = fixture("convert_schema_bad_osd", SCHEMA_OSD);
+    let r = run(&[
+        "convert", &input, "--from", "json", "--to", "json", "--schema", &schema,
+    ]);
+    assert_eq!(r.code, 2);
+    assert!(r.stderr.starts_with("error: "));
+}
+
+#[test]
+fn convert_strict_refuses_a_lossy_write_with_exit_1() {
+    let input = fixture("convert_strict_in", r#"{"a": NaN}"#);
+    let r = run(&[
+        "convert", &input, "--from", "json", "--to", "json", "--strict",
+    ]);
+    assert_eq!(r.code, 1);
+    assert!(r.stderr.starts_with("error: "));
+}
+
+#[test]
+fn convert_report_prints_adjustments_to_stderr_and_still_writes() {
+    let input = fixture("convert_report_in", r#"{"a": NaN}"#);
+    let r = run(&[
+        "convert", &input, "--from", "json", "--to", "json", "--report",
+    ]);
+    assert_eq!(r.code, 0);
+    assert!(r.stdout.contains("null"));
+    assert!(!r.stderr.is_empty());
+}
+
+#[test]
+fn convert_result_format_json_encodes_the_report() {
+    let input = fixture("convert_report_json_in", r#"{"a": NaN}"#);
+    let r = run(&[
+        "convert",
+        &input,
+        "--from",
+        "json",
+        "--to",
+        "json",
+        "--report",
+        "--result-format",
+        "json",
+    ]);
+    assert_eq!(r.code, 0);
+    assert!(r.stderr.trim_end().starts_with('['));
+}
+
+#[test]
+fn convert_arrays_on_oml_output_is_a_clear_not_yet_supported_error() {
+    let input = fixture("convert_arrays_in", DOC_JSON);
+    let r = run(&[
+        "convert", &input, "--from", "json", "--to", "oml", "--arrays",
+    ]);
+    assert_eq!(r.code, 2);
+    assert!(r.stderr.contains("not yet supported"));
+}
+
+#[test]
+fn convert_stdin_stdout_dash_plumbing() {
+    let r = run_stdin(
+        &["convert", "-", "--from", "json", "--to", "oml"],
+        Some(DOC_JSON),
+    );
+    assert_eq!(r.code, 0);
+    assert_eq!(r.stdout, "a: 1\nb: \"x\"\n");
+}
+
+#[test]
+fn convert_missing_input_file_exits_2() {
+    let r = run(&[
+        "convert",
+        "/no/such/file.json",
+        "--from",
+        "json",
+        "--to",
+        "oml",
+    ]);
+    assert_eq!(r.code, 2);
+    assert!(r.stderr.starts_with("error: "));
+}
+
+// --------------------------------------------------------------------- check
+
+#[test]
+fn check_golden_path_never_writes_default_exit_0() {
+    let input = fixture("check_in", DOC_JSON);
+    let r = run(&["check", &input, "--from", "json", "--to", "toml"]);
+    assert_eq!(r.code, 0);
+    assert_eq!(r.stdout.trim(), "no adjustments");
+}
+
+#[test]
+fn check_strict_exits_1_when_something_would_be_adjusted() {
+    let input = fixture("check_strict_in", r#"{"a": NaN}"#);
+    let r = run(&[
+        "check", &input, "--from", "json", "--to", "json", "--strict",
+    ]);
+    assert_eq!(r.code, 1);
+}
+
+#[test]
+fn check_json_result_format() {
+    let input = fixture("check_json_in", r#"{"a": NaN}"#);
+    let r = run(&[
+        "check",
+        &input,
+        "--from",
+        "json",
+        "--to",
+        "json",
+        "--result-format",
+        "json",
+    ]);
+    assert_eq!(r.code, 0);
+    assert!(r.stdout.trim_end().starts_with('['));
+}
+
+// --------------------------------------------------------------------- validate
+
+#[test]
+fn validate_golden_path_is_valid_exit_0() {
+    let input = fixture("validate_in", DOC_JSON);
+    let schema = fixture("validate_schema", SCHEMA_OSD);
+    let r = run(&["validate", &input, "--from", "json", "--schema", &schema]);
+    assert_eq!(r.code, 0);
+    assert_eq!(r.stdout.trim(), "valid");
+}
+
+#[test]
+fn validate_conformance_failure_exit_1() {
+    let input = fixture("validate_bad_in", r#"{"a": "nope", "b": "x"}"#);
+    let schema = fixture("validate_bad_schema", SCHEMA_OSD);
+    let r = run(&["validate", &input, "--from", "json", "--schema", &schema]);
+    assert_eq!(r.code, 1);
+    assert!(r.stdout.contains("invalid"));
+}
+
+#[test]
+fn validate_json_success_shape() {
+    let input = fixture("validate_json_ok_in", DOC_JSON);
+    let schema = fixture("validate_json_ok_schema", SCHEMA_OSD);
+    let r = run(&[
+        "validate", &input, "--from", "json", "--schema", &schema, "--json",
+    ]);
+    assert_eq!(r.code, 0);
+    assert_eq!(r.stdout.trim(), "{\"ok\": true}");
+}
+
+#[test]
+fn validate_json_failure_shape_has_structured_errors() {
+    let input = fixture("validate_json_bad_in", r#"{"a": "nope", "b": "x"}"#);
+    let schema = fixture("validate_json_bad_schema", SCHEMA_OSD);
+    let r = run(&[
+        "validate", &input, "--from", "json", "--schema", &schema, "--json",
+    ]);
+    assert_eq!(r.code, 1);
+    assert!(r.stdout.contains("\"code\": \"type-mismatch\""));
+}
+
+#[test]
+fn validate_result_format_oml() {
+    let input = fixture("validate_oml_in", DOC_JSON);
+    let schema = fixture("validate_oml_schema", SCHEMA_OSD);
+    let r = run(&[
+        "validate",
+        &input,
+        "--from",
+        "json",
+        "--schema",
+        &schema,
+        "--result-format",
+        "oml",
+    ]);
+    assert_eq!(r.code, 0);
+    assert!(r.stdout.contains("ok: true"));
+}
+
+// --------------------------------------------------------------------- infer
+
+#[test]
+fn infer_golden_path_emits_osd() {
+    let input = fixture("infer_in", DOC_JSON);
+    let r = run(&["infer", &input, "--from", "json"]);
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+    assert!(r.stdout.contains("root Root"));
+    assert!(r.stdout.contains("\"a\": integer"));
+}
+
+#[test]
+fn infer_compact_single_line() {
+    let input = fixture("infer_compact_in", DOC_JSON);
+    let r = run(&["infer", &input, "--from", "json", "--compact"]);
+    assert_eq!(r.code, 0);
+    assert_eq!(r.stdout.lines().count(), 1);
+}
+
+#[test]
+fn infer_arrays_flag_is_rejected() {
+    let input = fixture("infer_arrays_in", DOC_JSON);
+    let r = run(&["infer", &input, "--from", "json", "--arrays"]);
+    assert_eq!(r.code, 2);
+    assert!(r.stderr.contains("applies only to OML output"));
+}
+
+#[test]
+fn infer_from_a_scalar_root_is_a_schema_error() {
+    let input = fixture("infer_scalar_root", "42");
+    let r = run(&["infer", &input, "--from", "json"]);
+    assert_eq!(r.code, 2);
+    assert!(r.stderr.starts_with("error: "));
+}
+
+// --------------------------------------------------------------------- schema *
+
+#[test]
+fn schema_format_golden_path() {
+    let schema = fixture("schema_format_in", SCHEMA_OSD);
+    let r = run(&["schema", "format", &schema]);
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+    assert!(r.stdout.contains("root Root"));
+}
+
+#[test]
+fn schema_format_arrays_flag_is_rejected() {
+    let schema = fixture("schema_format_arrays_in", SCHEMA_OSD);
+    let r = run(&["schema", "format", &schema, "--arrays"]);
+    assert_eq!(r.code, 2);
+    assert!(r.stderr.contains("applies only to OML output"));
+}
+
+#[test]
+fn schema_format_parse_error_exits_2() {
+    let schema = fixture("schema_format_bad", "not an osd schema {{{");
+    let r = run(&["schema", "format", &schema]);
+    assert_eq!(r.code, 2);
+}
+
+#[test]
+fn schema_normalize_golden_path() {
+    let schema = fixture(
+        "schema_normalize_in",
+        r#"record A { "x": string } record B { "x": string }
+           record Root { "a": A, "b": B } root Root"#,
+    );
+    let r = run(&["schema", "normalize", &schema]);
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+    // A and B are structurally identical -- normalize should collapse them
+    // to a single record.
+    assert_eq!(r.stdout.matches("record ").count(), 2);
+}
+
+#[test]
+fn schema_prune_golden_path() {
+    let schema = fixture(
+        "schema_prune_in",
+        r#"record Dead { "x": string } record Root { "a": string } root Root"#,
+    );
+    let r = run(&["schema", "prune", &schema]);
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+    assert!(!r.stdout.contains("Dead"));
+}
+
+#[test]
+fn schema_is_empty_false_exits_1_true_exits_0() {
+    let schema = fixture("schema_is_empty_in", SCHEMA_OSD);
+    let r = run(&["schema", "is-empty", &schema]);
+    assert_eq!(r.code, 1);
+    assert_eq!(r.stdout.trim(), "false");
+
+    let empty_schema = fixture(
+        "schema_is_empty_empty_in",
+        r#"record Root { "self": Root } root Root"#,
+    );
+    let r2 = run(&["schema", "is-empty", &empty_schema]);
+    assert_eq!(r2.code, 0);
+    assert_eq!(r2.stdout.trim(), "true");
+}
+
+#[test]
+fn schema_extract_golden_path() {
+    let schema = fixture("schema_extract_in", SCHEMA_OSD);
+    let r = run(&["schema", "extract", &schema, "--keep", "a,b"]);
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+    assert!(r.stdout.contains("root Root"));
+}
+
+#[test]
+fn schema_extract_no_valid_subschema_exits_1() {
+    let schema = fixture("schema_extract_bad_in", SCHEMA_OSD);
+    let r = run(&["schema", "extract", &schema, "--keep", "a"]);
+    assert_eq!(r.code, 1);
+    assert!(r.stderr.contains("no valid subschema"));
+}
+
+#[test]
+fn schema_lint_no_findings() {
+    let schema = fixture("schema_lint_in", SCHEMA_OSD);
+    let r = run(&["schema", "lint", &schema]);
+    assert_eq!(r.code, 0);
+    assert_eq!(r.stdout.trim(), "no findings");
+}
+
+#[test]
+fn schema_lint_warning_severity_exits_1() {
+    let schema = fixture(
+        "schema_lint_warn_in",
+        r#"record Dead { "x": string } record Root { "a": string } root Root"#,
+    );
+    let r = run(&["schema", "lint", &schema]);
+    assert_eq!(r.code, 1);
+    assert!(r.stdout.contains("warning"));
+}
+
+#[test]
+fn schema_lint_json_shape() {
+    let schema = fixture("schema_lint_json_in", SCHEMA_OSD);
+    let r = run(&["schema", "lint", &schema, "--json"]);
+    assert_eq!(r.code, 0);
+    assert!(r.stdout.contains("\"findings\""));
+}
+
+#[test]
+fn schema_compatible_with_true_and_false() {
+    let a = fixture("schema_compat_a", SCHEMA_OSD);
+    let b = fixture(
+        "schema_compat_b",
+        r#"record Root { "a": integer, "b": string, "c" [0,1]: string } root Root"#,
+    );
+    let r = run(&["schema", "compatible-with", &a, &a]);
+    assert_eq!(r.code, 0);
+    assert_eq!(r.stdout.trim(), "true");
+
+    let r2 = run(&["schema", "compatible-with", &b, &a]);
+    assert_eq!(r2.code, 1);
+    assert_eq!(r2.stdout.trim(), "false");
+}
+
+#[test]
+fn schema_equivalent_true_and_false() {
+    let a = fixture("schema_equiv_a", SCHEMA_OSD);
+    let b = fixture(
+        "schema_equiv_b",
+        r#"record Root { "a": integer, "b": string, "c" [0,1]: string } root Root"#,
+    );
+    let r = run(&["schema", "equivalent", &a, &a]);
+    assert_eq!(r.code, 0);
+    assert_eq!(r.stdout.trim(), "true");
+
+    let r2 = run(&["schema", "equivalent", &a, &b]);
+    assert_eq!(r2.code, 1);
+    assert_eq!(r2.stdout.trim(), "false");
+}
+
+#[test]
+fn schema_pair_stdin_dash_plumbing() {
+    let b = fixture("schema_pair_stdin_b", SCHEMA_OSD);
+    let r = run_stdin(&["schema", "equivalent", "-", &b], Some(SCHEMA_OSD));
+    assert_eq!(r.code, 0);
+    assert_eq!(r.stdout.trim(), "true");
+}
+
+// --------------------------------------------------------------------- every
+// format arm (read/write/check), coverage-closing per the issue's 100%
+// obligation -- `read_by_fmt`/`write_by_fmt`/`check_by_fmt` dispatch to a
+// codec per `Fmt` variant, so each one needs at least one exercise.
+
+#[test]
+fn convert_round_trips_every_non_oml_format_pair() {
+    // XML needs a single top-level document element, so this uses a
+    // single-field document (unlike `DOC_JSON`'s two fields) to stay valid
+    // across every pairing, including the `--to xml` one.
+    const SINGLE_FIELD_JSON: &str = r#"{"a": 1}"#;
+    for (from, to) in [
+        ("json", "yaml"),
+        ("yaml", "toml"),
+        ("toml", "xml"),
+        ("xml", "json"),
+    ] {
+        let input = fixture(&format!("roundtrip_{from}_{to}_in"), SINGLE_FIELD_JSON);
+        // Seed via a json->from conversion so every `from` gets a
+        // same-shaped valid document in its own syntax.
+        let seeded = run(&["convert", &input, "--from", "json", "--to", from]);
+        assert_eq!(seeded.code, 0, "seeding {from}: {}", seeded.stderr);
+        let seeded_file = fixture(&format!("roundtrip_{from}_{to}_seeded"), &seeded.stdout);
+        let r = run(&["convert", &seeded_file, "--from", from, "--to", to]);
+        assert_eq!(r.code, 0, "{from}->{to}: {}", r.stderr);
+        assert!(!r.stdout.is_empty());
+    }
+}
+
+#[test]
+fn check_every_non_oml_to_format() {
+    for to in ["json", "yaml", "toml", "xml"] {
+        let input = fixture(&format!("check_to_{to}_in"), DOC_JSON);
+        let r = run(&["check", &input, "--from", "json", "--to", to]);
+        assert_eq!(r.code, 0, "--to {to}: {}", r.stderr);
+    }
+}
+
+#[test]
+fn check_to_oml() {
+    let input = fixture("check_to_oml_in", DOC_JSON);
+    let r = run(&["check", &input, "--from", "json", "--to", "oml"]);
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout.trim(), "no adjustments");
+}
+
+#[test]
+fn convert_to_oml_compact() {
+    let input = fixture("convert_to_oml_compact_in", DOC_JSON);
+    let r = run(&[
+        "convert",
+        &input,
+        "--from",
+        "json",
+        "--to",
+        "oml",
+        "--compact",
+    ]);
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout, "a: 1; b: \"x\"\n");
+}
+
+#[test]
+fn convert_report_with_a_warning_severity_adjustment_json_and_oml() {
+    // TOML has no `null` -- writing one is a `Severity::Warning`
+    // (`null.omitted`) adjustment, unlike JSON's NaN->null (`Error`).
+    let input = fixture("convert_warning_report_in", r#"{"a": null}"#);
+    let r_json = run(&[
+        "convert",
+        &input,
+        "--from",
+        "json",
+        "--to",
+        "toml",
+        "--report",
+        "--result-format",
+        "json",
+    ]);
+    assert_eq!(r_json.code, 0, "stderr: {}", r_json.stderr);
+    assert!(r_json.stderr.contains("\"severity\": \"warning\""));
+
+    let r_oml = run(&[
+        "convert",
+        &input,
+        "--from",
+        "json",
+        "--to",
+        "toml",
+        "--report",
+        "--result-format",
+        "oml",
+    ]);
+    assert_eq!(r_oml.code, 0, "stderr: {}", r_oml.stderr);
+    assert!(r_oml.stderr.contains("severity: \"warning\""));
+}
+
+#[test]
+fn check_result_format_oml_with_a_warning_adjustment() {
+    let input = fixture("check_warning_oml_in", r#"{"a": null}"#);
+    let r = run(&[
+        "check",
+        &input,
+        "--from",
+        "json",
+        "--to",
+        "toml",
+        "--result-format",
+        "oml",
+    ]);
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+    assert!(r.stdout.contains("severity: \"warning\""));
+}
+
+// --------------------------------------------------------------------- I/O
+// failure paths -- missing input file / unwritable output path -- for
+// every command that reads/writes via `read_input`/`write_output`.
+
+#[test]
+fn format_missing_input_file_exits_2() {
+    let r = run(&["format", "/no/such/file.oml"]);
+    assert_eq!(r.code, 2);
+    assert!(r.stderr.starts_with("error: "));
+}
+
+#[test]
+fn format_write_output_failure_exits_2() {
+    let input = fixture("format_write_fail_in", "a: 1\n");
+    let r = run(&["format", &input, "-o", "/no/such/dir/out.oml"]);
+    assert_eq!(r.code, 2);
+    assert!(r.stderr.starts_with("error: "));
+}
+
+#[test]
+fn convert_write_output_failure_exits_2() {
+    let input = fixture("convert_write_fail_in", DOC_JSON);
+    let r = run(&[
+        "convert",
+        &input,
+        "--from",
+        "json",
+        "--to",
+        "oml",
+        "-o",
+        "/no/such/dir/out.oml",
+    ]);
+    assert_eq!(r.code, 2);
+}
+
+#[test]
+fn check_missing_input_file_exits_2() {
+    let r = run(&[
+        "check",
+        "/no/such/file.json",
+        "--from",
+        "json",
+        "--to",
+        "toml",
+    ]);
+    assert_eq!(r.code, 2);
+}
+
+#[test]
+fn check_read_by_fmt_parse_error_exits_2() {
+    let input = fixture("check_bad_json_in", "not json {{{");
+    let r = run(&["check", &input, "--from", "json", "--to", "toml"]);
+    assert_eq!(r.code, 2);
+}
+
+#[test]
+fn validate_missing_input_file_exits_2() {
+    let schema = fixture("validate_missing_schema", SCHEMA_OSD);
+    let r = run(&[
+        "validate",
+        "/no/such/file.json",
+        "--from",
+        "json",
+        "--schema",
+        &schema,
+    ]);
+    assert_eq!(r.code, 2);
+}
+
+#[test]
+fn validate_read_by_fmt_parse_error_exits_2() {
+    let input = fixture("validate_bad_json_in", "not json {{{");
+    let schema = fixture("validate_bad_json_schema", SCHEMA_OSD);
+    let r = run(&["validate", &input, "--from", "json", "--schema", &schema]);
+    assert_eq!(r.code, 2);
+}
+
+#[test]
+fn validate_result_format_json_non_flag_variant() {
+    let input = fixture("validate_rf_json_in", DOC_JSON);
+    let schema = fixture("validate_rf_json_schema", SCHEMA_OSD);
+    let r = run(&[
+        "validate",
+        &input,
+        "--from",
+        "json",
+        "--schema",
+        &schema,
+        "--result-format",
+        "json",
+    ]);
+    assert_eq!(r.code, 0);
+    assert_eq!(r.stdout.trim(), "{\"ok\": true, \"errors\": []}");
+}
+
+#[test]
+fn validate_result_format_oml_with_errors_exercises_the_error_list() {
+    let input = fixture("validate_rf_oml_err_in", r#"{"a": "nope", "b": "x"}"#);
+    let schema = fixture("validate_rf_oml_err_schema", SCHEMA_OSD);
+    let r = run(&[
+        "validate",
+        &input,
+        "--from",
+        "json",
+        "--schema",
+        &schema,
+        "--result-format",
+        "oml",
+    ]);
+    assert_eq!(r.code, 1);
+    assert!(r.stdout.contains("path: \"$.a\""));
+}
+
+#[test]
+fn infer_missing_input_file_exits_2() {
+    let r = run(&["infer", "/no/such/file.json", "--from", "json"]);
+    assert_eq!(r.code, 2);
+}
+
+#[test]
+fn infer_read_by_fmt_parse_error_exits_2() {
+    let input = fixture("infer_bad_json_in", "not json {{{");
+    let r = run(&["infer", &input, "--from", "json"]);
+    assert_eq!(r.code, 2);
+}
+
+#[test]
+fn infer_write_output_failure_exits_2() {
+    let input = fixture("infer_write_fail_in", DOC_JSON);
+    let r = run(&[
+        "infer",
+        &input,
+        "--from",
+        "json",
+        "-o",
+        "/no/such/dir/out.osd",
+    ]);
+    assert_eq!(r.code, 2);
+}
+
+// --------------------------------------------------------------------- schema
+// commands: missing/malformed schema file, write-output failure, second
+// (`b`) file variants, for every `schema *` subcommand.
+
+#[test]
+fn schema_format_missing_file_exits_2() {
+    let r = run(&["schema", "format", "/no/such/schema.osd"]);
+    assert_eq!(r.code, 2);
+}
+
+#[test]
+fn schema_format_write_output_failure_exits_2() {
+    let schema = fixture("schema_format_write_fail_in", SCHEMA_OSD);
+    let r = run(&["schema", "format", &schema, "-o", "/no/such/dir/out.osd"]);
+    assert_eq!(r.code, 2);
+}
+
+#[test]
+fn schema_normalize_missing_file_exits_2() {
+    let r = run(&["schema", "normalize", "/no/such/schema.osd"]);
+    assert_eq!(r.code, 2);
+}
+
+#[test]
+fn schema_normalize_arrays_flag_is_rejected() {
+    let schema = fixture("schema_normalize_arrays_in", SCHEMA_OSD);
+    let r = run(&["schema", "normalize", &schema, "--arrays"]);
+    assert_eq!(r.code, 2);
+    assert!(r.stderr.contains("applies only to OML output"));
+}
+
+#[test]
+fn schema_normalize_write_output_failure_exits_2() {
+    let schema = fixture("schema_normalize_write_fail_in", SCHEMA_OSD);
+    let r = run(&["schema", "normalize", &schema, "-o", "/no/such/dir/out.osd"]);
+    assert_eq!(r.code, 2);
+}
+
+#[test]
+fn schema_prune_missing_file_exits_2() {
+    let r = run(&["schema", "prune", "/no/such/schema.osd"]);
+    assert_eq!(r.code, 2);
+}
+
+#[test]
+fn schema_prune_write_output_failure_exits_2() {
+    let schema = fixture("schema_prune_write_fail_in", SCHEMA_OSD);
+    let r = run(&["schema", "prune", &schema, "-o", "/no/such/dir/out.osd"]);
+    assert_eq!(r.code, 2);
+}
+
+#[test]
+fn schema_is_empty_missing_file_exits_2() {
+    let r = run(&["schema", "is-empty", "/no/such/schema.osd"]);
+    assert_eq!(r.code, 2);
+}
+
+#[test]
+fn schema_is_empty_result_format_json() {
+    let schema = fixture("schema_is_empty_rf_json_in", SCHEMA_OSD);
+    let r = run(&["schema", "is-empty", &schema, "--result-format", "json"]);
+    assert_eq!(r.code, 1);
+    assert_eq!(r.stdout.trim(), "{\"empty\": false}");
+}
+
+#[test]
+fn schema_extract_missing_file_exits_2() {
+    let r = run(&["schema", "extract", "/no/such/schema.osd", "--keep", "a"]);
+    assert_eq!(r.code, 2);
+}
+
+#[test]
+fn schema_extract_write_output_failure_exits_2() {
+    let schema = fixture("schema_extract_write_fail_in", SCHEMA_OSD);
+    let r = run(&[
+        "schema",
+        "extract",
+        &schema,
+        "--keep",
+        "a,b",
+        "-o",
+        "/no/such/dir/out.osd",
+    ]);
+    assert_eq!(r.code, 2);
+}
+
+#[test]
+fn schema_lint_missing_file_exits_2() {
+    let r = run(&["schema", "lint", "/no/such/schema.osd"]);
+    assert_eq!(r.code, 2);
+}
+
+#[test]
+fn schema_lint_severity_warning_json_with_findings() {
+    let schema = fixture(
+        "schema_lint_severity_warning_json_in",
+        r#"record Dead { "x": string } record Root { "a": string } root Root"#,
+    );
+    let r = run(&["schema", "lint", &schema, "--severity", "warning", "--json"]);
+    assert_eq!(r.code, 1);
+    assert!(r.stdout.contains("unreachable-record"));
+}
+
+#[test]
+fn schema_compatible_with_missing_a_and_b_files() {
+    let b = fixture("schema_compat_missing_b_ok", SCHEMA_OSD);
+    let r = run(&["schema", "compatible-with", "/no/such/a.osd", &b]);
+    assert_eq!(r.code, 2);
+
+    let a = fixture("schema_compat_missing_a_ok", SCHEMA_OSD);
+    let r2 = run(&["schema", "compatible-with", &a, "/no/such/b.osd"]);
+    assert_eq!(r2.code, 2);
+}
+
+#[test]
+fn schema_compatible_with_result_format_json() {
+    let schema = fixture("schema_compat_rf_json_in", SCHEMA_OSD);
+    let r = run(&[
+        "schema",
+        "compatible-with",
+        &schema,
+        &schema,
+        "--result-format",
+        "json",
+    ]);
+    assert_eq!(r.code, 0);
+    assert_eq!(r.stdout.trim(), "{\"compatible\": true}");
+}
+
+#[test]
+fn schema_equivalent_missing_a_and_b_files() {
+    let b = fixture("schema_equiv_missing_b_ok", SCHEMA_OSD);
+    let r = run(&["schema", "equivalent", "/no/such/a.osd", &b]);
+    assert_eq!(r.code, 2);
+
+    let a = fixture("schema_equiv_missing_a_ok", SCHEMA_OSD);
+    let r2 = run(&["schema", "equivalent", &a, "/no/such/b.osd"]);
+    assert_eq!(r2.code, 2);
+}
+
+#[test]
+fn schema_equivalent_result_format_json() {
+    let schema = fixture("schema_equiv_rf_json_in", SCHEMA_OSD);
+    let r = run(&[
+        "schema",
+        "equivalent",
+        &schema,
+        &schema,
+        "--result-format",
+        "json",
+    ]);
+    assert_eq!(r.code, 0);
+    assert_eq!(r.stdout.trim(), "{\"equivalent\": true}");
+}
+
+#[test]
+fn schema_is_empty_result_format_oml() {
+    let schema = fixture("schema_is_empty_rf_oml_in", SCHEMA_OSD);
+    let r = run(&["schema", "is-empty", &schema, "--result-format", "oml"]);
+    assert_eq!(r.code, 1);
+    assert_eq!(r.stdout.trim(), "empty: false");
+}
+
+#[test]
+fn schema_compatible_with_result_format_oml() {
+    let schema = fixture("schema_compat_rf_oml_in", SCHEMA_OSD);
+    let r = run(&[
+        "schema",
+        "compatible-with",
+        &schema,
+        &schema,
+        "--result-format",
+        "oml",
+    ]);
+    assert_eq!(r.code, 0);
+    assert_eq!(r.stdout.trim(), "compatible: true");
+}
+
+#[test]
+fn schema_equivalent_result_format_oml() {
+    let schema = fixture("schema_equiv_rf_oml_in", SCHEMA_OSD);
+    let r = run(&[
+        "schema",
+        "equivalent",
+        &schema,
+        &schema,
+        "--result-format",
+        "oml",
+    ]);
+    assert_eq!(r.code, 0);
+    assert_eq!(r.stdout.trim(), "equivalent: true");
+}
+
+// --------------------------------------------------------------------- a
+// few more coverage-closing cases: `convert --from oml` to a non-oml
+// target, a report encoding an `Error`-severity (not just `Warning`)
+// adjustment via `--result-format oml`, bad-syntax (not just missing-file)
+// input on `convert`, a bad `--schema` path on `convert`, a structural
+// (non-strict, no-report) write failure, a bad `--schema` path on
+// `validate`, and `infer --allow-any`.
+
+#[test]
+fn convert_from_oml_to_a_non_oml_format() {
+    let input = fixture("convert_from_oml_in", "a: 1\n");
+    let r = run(&["convert", &input, "--from", "oml", "--to", "json"]);
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout.trim(), "{\"a\": 1}");
+}
+
+#[test]
+fn convert_report_result_format_oml_with_an_error_severity_adjustment() {
+    // JSON has no NaN -- writing one back to JSON is `Severity::Error`
+    // (`nan.to_null`), unlike TOML's null-omission `Warning`.
+    let input = fixture("convert_error_report_oml_in", r#"{"a": NaN}"#);
+    let r = run(&[
+        "convert",
+        &input,
+        "--from",
+        "json",
+        "--to",
+        "json",
+        "--report",
+        "--result-format",
+        "oml",
+    ]);
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+    assert!(r.stderr.contains("severity: \"error\""));
+}
+
+#[test]
+fn convert_bad_syntax_input_exits_2() {
+    let input = fixture("convert_bad_syntax_in", "not json {{{");
+    let r = run(&["convert", &input, "--from", "json", "--to", "oml"]);
+    assert_eq!(r.code, 2);
+    assert!(r.stderr.starts_with("error: "));
+}
+
+#[test]
+fn convert_missing_schema_file_exits_2() {
+    let input = fixture("convert_missing_schema_in", DOC_JSON);
+    let r = run(&[
+        "convert",
+        &input,
+        "--from",
+        "json",
+        "--to",
+        "json",
+        "--schema",
+        "/no/such/schema.osd",
+    ]);
+    assert_eq!(r.code, 2);
+}
+
+#[test]
+fn convert_structural_write_failure_exits_2_without_a_report() {
+    // XML needs exactly one top-level document element -- a two-field
+    // document has no valid single-root XML rendering, a structural
+    // `WriteError` with no `report` attached (unlike a strict-mode
+    // refusal), so it takes the generic exit-2 path, not exit 1.
+    let input = fixture("convert_structural_fail_in", DOC_JSON);
+    let r = run(&["convert", &input, "--from", "json", "--to", "xml"]);
+    assert_eq!(r.code, 2);
+    assert!(r.stderr.contains("document element"));
+}
+
+#[test]
+fn validate_missing_schema_file_exits_2() {
+    let input = fixture("validate_missing_schema_in", DOC_JSON);
+    let r = run(&[
+        "validate",
+        &input,
+        "--from",
+        "json",
+        "--schema",
+        "/no/such/schema.osd",
+    ]);
+    assert_eq!(r.code, 2);
+}
+
+#[test]
+fn infer_allow_any_is_a_clear_not_supported_error() {
+    let input = fixture("infer_allow_any_in", DOC_JSON);
+    let r = run(&["infer", &input, "--from", "json", "--allow-any"]);
+    assert_eq!(r.code, 2);
+    assert!(r.stderr.contains("--allow-any"));
+}
+
+// --------------------------------------------------------------------- the
+// shared `--json` flag's success-result encoding: `check`/`schema
+// is-empty`/`schema compatible-with`/`schema equivalent` each pick
+// `ResultFormat::Json` when `--json` is passed (overriding
+// `--result-format`, same as Python's `_cmd_*` `"json" if args.json else
+// args.result_format` -- these are distinct from `--result-format json`,
+// which exercises the `else` arm instead).
+
+#[test]
+fn check_json_flag_picks_json_result_encoding() {
+    let input = fixture("check_json_flag_in", DOC_JSON);
+    let r = run(&["check", &input, "--from", "json", "--to", "toml", "--json"]);
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout.trim(), "[]");
+}
+
+#[test]
+fn schema_is_empty_json_flag_picks_json_result_encoding() {
+    let schema = fixture("schema_is_empty_json_flag_in", SCHEMA_OSD);
+    let r = run(&["schema", "is-empty", &schema, "--json"]);
+    assert_eq!(r.code, 1);
+    assert_eq!(r.stdout.trim(), "{\"empty\": false}");
+}
+
+#[test]
+fn schema_compatible_with_json_flag_picks_json_result_encoding() {
+    let schema = fixture("schema_compat_json_flag_in", SCHEMA_OSD);
+    let r = run(&["schema", "compatible-with", &schema, &schema, "--json"]);
+    assert_eq!(r.code, 0);
+    assert_eq!(r.stdout.trim(), "{\"compatible\": true}");
+}
+
+#[test]
+fn schema_equivalent_json_flag_picks_json_result_encoding() {
+    let schema = fixture("schema_equiv_json_flag_in", SCHEMA_OSD);
+    let r = run(&["schema", "equivalent", &schema, &schema, "--json"]);
+    assert_eq!(r.code, 0);
+    assert_eq!(r.stdout.trim(), "{\"equivalent\": true}");
 }

--- a/omnist-cli/tests/cli.rs
+++ b/omnist-cli/tests/cli.rs
@@ -46,6 +46,26 @@ fn run_stdin(args: &[&str], stdin: Option<&str>) -> Run {
     }
 }
 
+/// Like `run_stdin`, but feeds raw (possibly non-UTF-8) bytes -- needed to
+/// force `read_input`'s stdin branch (`io::stdin().read_to_string`) to hit
+/// its error path, which a `&str` can never do since it's already valid
+/// UTF-8 by construction.
+fn run_stdin_bytes(args: &[&str], stdin: &[u8]) -> Run {
+    let mut cmd = bin();
+    cmd.args(args);
+    cmd.stdin(Stdio::piped());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    let mut child = cmd.spawn().expect("failed to spawn omnist binary");
+    child.stdin.take().unwrap().write_all(stdin).unwrap();
+    let output = child.wait_with_output().expect("failed to wait on child");
+    Run {
+        stdout: String::from_utf8(output.stdout).unwrap(),
+        stderr: String::from_utf8(output.stderr).unwrap(),
+        code: output.status.code().unwrap(),
+    }
+}
+
 /// A fresh scratch file under the test binary's own temp dir, so parallel
 /// tests never collide, holding `content`.
 fn fixture(name: &str, content: &str) -> String {
@@ -193,8 +213,16 @@ fn convert_schema_conformance_failure_json_shape_has_structured_errors() {
         "convert", &input, "--from", "json", "--to", "json", "--schema", &schema, "--json",
     ]);
     assert_eq!(r.code, 2);
-    assert!(r.stdout.contains("\"path\": \"$.a\""), "stdout: {}", r.stdout);
-    assert!(r.stdout.contains("\"code\": \"type-mismatch\""), "stdout: {}", r.stdout);
+    assert!(
+        r.stdout.contains("\"path\": \"$.a\""),
+        "stdout: {}",
+        r.stdout
+    );
+    assert!(
+        r.stdout.contains("\"code\": \"type-mismatch\""),
+        "stdout: {}",
+        r.stdout
+    );
 }
 
 #[test]
@@ -1148,3 +1176,30 @@ fn schema_equivalent_json_flag_picks_json_result_encoding() {
     assert_eq!(r.code, 0);
     assert_eq!(r.stdout.trim(), "{\"equivalent\": true}");
 }
+
+// --------------------------------------------------------------------- the
+// two `read_input`/`write_output` I/O error branches that only manifest on
+// stdin/stdout themselves (not a plain file path), tracked down as the
+// coverage-gap root cause for issue #24 / PR #25: `read_input`'s
+// `io::stdin().read_to_string` error arm, and `write_output`'s
+// `io::stdout().flush()` error arm. Both are forced by real OS-level I/O
+// failures rather than mocks, per this project's coverage-gap policy.
+
+#[test]
+fn format_stdin_dash_with_invalid_utf8_hits_read_input_stdin_error_path() {
+    // A lone continuation byte (0x80) is never valid UTF-8 in any context,
+    // so `read_to_string` on stdin fails deterministically -- this is the
+    // only branch of `read_input` reachable without a real file-path I/O
+    // failure, since "-" bypasses `std::fs::read_to_string` entirely.
+    let r = run_stdin_bytes(&["format", "-"], &[0x61, 0x80, 0x62]);
+    assert_eq!(r.code, 2);
+    assert!(r.stderr.starts_with("error: "), "stderr: {}", r.stderr);
+    assert!(r.stderr.contains("(reading stdin)"), "stderr: {}", r.stderr);
+}
+
+// `write_output`'s stdout `flush()` call itself is not separately tested
+// here: it was converted to an `.expect()`-documented invariant in
+// `lib.rs` rather than a testable `Result` branch (see that function's
+// comment) after empirically confirming a real write failure (broken pipe,
+// `/dev/full`) panics *inside* the preceding `print!` call, never at the
+// `flush()` call -- so there was no live branch left to exercise.

--- a/omnist/src/osd.rs
+++ b/omnist/src/osd.rs
@@ -384,6 +384,76 @@ pub fn parse_schema(text: &str) -> Result<Schema, SchemaError> {
     Parser::new(toks).parse_schema()
 }
 
+// ---------------------------------------------------------------------------
+// Serialize a Schema back to OSD text
+// ---------------------------------------------------------------------------
+
+/// Serialize a [`Schema`] back to OSD text. Ported from Python's
+/// `osd.to_osd`/`_record`/`_field`/`_card`/`_type`.
+///
+/// `indent: None` renders a single-line, machine-oriented form (record
+/// definitions and the trailing `root` statement joined by spaces, fields
+/// joined by `, `, no trailing comma) instead of the default
+/// pretty-printed, indented form -- mirroring `write_oml`/`write_json`'s
+/// own `indent: None` convention. A `Some(n)` sets the pretty-mode indent
+/// width in spaces. Both forms round-trip through [`parse_schema`].
+pub fn to_osd(schema: &Schema, indent: Option<usize>) -> String {
+    let mut parts: Vec<String> = schema
+        .env()
+        .iter()
+        .map(|(name, rec)| osd_record(name, rec, indent))
+        .collect();
+    parts.push(format!("root {}", schema.root().name));
+    if indent.is_none() {
+        return format!("{}\n", parts.join(" "));
+    }
+    format!("{}\n", parts.join("\n"))
+}
+
+fn osd_record(name: &str, rec: &Record, indent: Option<usize>) -> String {
+    if indent.is_none() {
+        let fields: Vec<String> = rec.fields().iter().map(osd_field).collect();
+        return format!("record {name} {{ {} }}", fields.join(", "));
+    }
+    let pad = " ".repeat(indent.unwrap_or(4));
+    let mut out = vec![format!("record {name} {{")];
+    for f in rec.fields() {
+        out.push(format!("{pad}{},", osd_field(f)));
+    }
+    out.push("}".to_string());
+    out.join("\n")
+}
+
+fn osd_field(f: &Field) -> String {
+    let card = if (f.min, f.max) == (1, Some(1)) {
+        String::new()
+    } else {
+        format!(" {}", osd_cardinality(f.min, f.max))
+    };
+    format!("\"{}\"{card}: {}", f.label, osd_type(&f.ty))
+}
+
+fn osd_cardinality(lo: usize, hi: Option<usize>) -> String {
+    match hi {
+        Some(hi) if hi == lo => format!("[{lo}]"),
+        Some(hi) => format!("[{lo},{hi}]"),
+        None => format!("[{lo},]"),
+    }
+}
+
+fn osd_type(t: &crate::schema::FieldType) -> String {
+    match t {
+        crate::schema::FieldType::Ref(r) => r.name.clone(),
+        crate::schema::FieldType::Scalar(s) => {
+            format!(
+                "{}{}",
+                s.kind().as_str(),
+                if s.is_nullable() { "?" } else { "" }
+            )
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -659,5 +729,70 @@ mod tests {
         )
         .unwrap();
         assert_eq!(schema.root().name, "X");
+    }
+
+    // -- to_osd ----------------------------------------------------------------
+
+    #[test]
+    fn to_osd_pretty_round_trips_through_parse_schema() {
+        let src = r#"
+            record X {
+                "a": string,
+                "b" [0,1]: integer?,
+                "c" [2,]: X,
+            }
+            root X
+        "#;
+        let schema = parse_schema(src).unwrap();
+        let rendered = to_osd(&schema, Some(4));
+        assert_eq!(
+            rendered,
+            "record X {\n    \"a\": string,\n    \"b\" [0,1]: integer?,\n    \
+             \"c\" [2,]: X,\n}\nroot X\n"
+        );
+        let reparsed = parse_schema(&rendered).unwrap();
+        assert_eq!(reparsed, schema);
+    }
+
+    #[test]
+    fn to_osd_compact_round_trips_through_parse_schema() {
+        let src = r#"record X { "a": string, "b" [0,1]: integer? } root X"#;
+        let schema = parse_schema(src).unwrap();
+        let rendered = to_osd(&schema, None);
+        assert_eq!(
+            rendered,
+            "record X { \"a\": string, \"b\" [0,1]: integer? } root X\n"
+        );
+        let reparsed = parse_schema(&rendered).unwrap();
+        assert_eq!(reparsed, schema);
+    }
+
+    #[test]
+    fn to_osd_renders_exact_cardinality_without_brackets_comma() {
+        let src = r#"record X { "a" [2]: string } root X"#;
+        let schema = parse_schema(src).unwrap();
+        assert_eq!(
+            to_osd(&schema, None),
+            "record X { \"a\" [2]: string } root X\n"
+        );
+    }
+
+    #[test]
+    fn to_osd_renders_ref_type_bare() {
+        let src = r#"record Leaf { "v": string } record X { "child": Leaf } root X"#;
+        let schema = parse_schema(src).unwrap();
+        let rendered = to_osd(&schema, None);
+        assert!(rendered.contains("\"child\": Leaf"));
+    }
+
+    #[test]
+    fn to_osd_empty_record_field_list_renders_braces() {
+        let schema = Schema::new(
+            Ref::new("X"),
+            IndexMap::from([("X".to_string(), Record::new(vec![]).unwrap())]),
+        )
+        .unwrap();
+        assert_eq!(to_osd(&schema, None), "record X {  } root X\n");
+        assert_eq!(to_osd(&schema, Some(2)), "record X {\n}\nroot X\n");
     }
 }


### PR DESCRIPTION
## Summary

- Implements the full `omnist-cli` command surface per `docs/design/cli-spec.md`: `format`, `convert`, `check`, `validate`, `infer`, and `schema {format,normalize,prune,is-empty,extract,lint,compatible-with,equivalent}`, using `clap` (derive) for argument parsing.
- Adds `omnist::osd::to_osd` (schema -> OSD text writer) with its own unit tests, a library gap this issue's command surface depends on (only `parse_schema` existed before).
- Exit codes, `--json`, and `--result-format text|json|oml` encodings are matched to the Python reference (`~/dev/omnist/omnist/cli.py`) and cross-checked live against the installed Python venv across every command, including error paths, `--strict`/`--report`, and schema-directed `--schema` on `convert`.

### Known, documented scope gap

`--arrays` is accepted by the argument parser (matching the Python surface) everywhere Python's `write_oml`/`to_osd` would honor it, but `omnist::oml::write_oml` has no `arrays` parameter yet in this Rust port. Passing `--arrays` where it would apply to OML output (`format`, `convert --to oml`) returns a clear "not yet supported" error (exit 2) instead of silently ignoring or faking it -- same scoping pattern as `infer.rs`'s existing `allow_any` gap. Everywhere `--arrays` has no effect per spec (OSD output, or `--to` other than `oml`), it's accepted and silently ignored, matching Python exactly.

### Cross-implementation check

Ran the live Python CLI (`~/dev/venvs/omnist`, console-script `omnist`) against the same inputs/flags as the Rust binary across every command. No genuine Python bugs found (tally unchanged: only #4 found one, omnist-dev/omnist#255). Two cosmetic, non-blocking divergences noted (not filed, not spec violations):
- OS error message text differs (Rust's `io::Error` Display vs Python's `OSError` string) -- exit codes and `--json` shape match exactly.
- A pre-existing (pre-#24) quote-style difference in some `SchemaError`/validation message text (`'b'` vs `"b"`, `nan` vs `NaN`) inherited from earlier-merged library modules, not introduced by this issue.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace`: 531 (omnist lib) + 1 (omnist-cli lib) + 94 (omnist-cli integration) = 626 tests pass
- [x] 94 integration tests spawn the compiled binary per command (golden path + error path), covering stdin/stdout `-` plumbing and every `--result-format`/`--json` encoding
- [ ] `cargo llvm-cov --workspace --fail-under-lines 100`: currently 99.95% total (7306 lines, 4 missed, all in `omnist-cli/src/lib.rs`'s `ResultFormat::Json`-selection branches for `check`/`schema is-empty`/`compatible-with`/`equivalent` under investigation -- flagging honestly rather than claiming a clean gate; every other module remains at its established 100% line baseline

Closes #24
