### PR TITLE
Fuzzing + semantic-oracle cross-check (issue #26)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,18 @@ jobs:
         run: cargo test --workspace
       - name: coverage
         run: cargo llvm-cov --workspace --fail-under-lines 100
+
+  fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: proptest fuzz + semantic-oracle properties (issue #26)
+        # Bounded budget, not unbounded -- 250 cases per property, a bit
+        # above the in-code default of 150 (itself matching Python's
+        # `~/dev/omnist/tests/test_fuzz.py` `_SUPPRESS` settings) so CI
+        # gets slightly more coverage than a local `cargo test` run
+        # without becoming an open-ended fuzzing job.
+        run: cargo test --workspace --test fuzz
+        env:
+          PROPTEST_CASES: "250"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "clap"
 version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,7 +131,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -120,10 +153,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
 
 [[package]]
 name = "hashbrown"
@@ -178,16 +256,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "omnist"
 version = "0.0.1-alpha"
 dependencies = [
  "indexmap",
+ "proptest",
  "quick-xml",
  "regex",
  "thiserror",
@@ -206,10 +306,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -219,6 +334,31 @@ checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -236,6 +376,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -268,6 +458,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,7 +508,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -318,6 +533,17 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
@@ -325,6 +551,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -344,7 +583,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -385,6 +624,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +640,24 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "windows-link"
@@ -421,6 +684,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "yaml-rust2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +697,26 @@ checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
 dependencies = [
  "arraydeque",
  "hashlink",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/omnist/Cargo.toml
+++ b/omnist/Cargo.toml
@@ -14,3 +14,6 @@ regex = "1"
 yaml-rust2 = { version = "0.11.0", default-features = false }
 toml_edit = { version = "0.25.13", default-features = false, features = ["parse", "display"] }
 quick-xml = "0.41.0"
+
+[dev-dependencies]
+proptest = "1"

--- a/omnist/src/formats/yaml.rs
+++ b/omnist/src/formats/yaml.rs
@@ -521,9 +521,40 @@ fn parse_int_literal(text: &str) -> Result<Value, ParseError> {
             ),
         ));
     }
-    match i64::from_str_radix(digits, radix) {
-        Ok(v) => Ok(Value::Int(if neg { -v } else { v })),
-        Err(_) => Err(ParseError::new(
+    // Parse the unsigned magnitude first, then apply the sign -- issue #26's
+    // fuzz harness caught the previous version parsing `-9223372036854775808`
+    // (`i64::MIN`) by stripping the sign and calling
+    // `i64::from_str_radix("9223372036854775808", 10)`, which itself
+    // overflows (the positive magnitude `9223372036854775808` is one past
+    // `i64::MAX`) even though the signed value is perfectly representable.
+    // `u64` holds the full magnitude range for both `i64::MIN` and
+    // `i64::MAX`, so parse there and negate via `checked_neg` on the signed
+    // conversion instead of negating a possibly-unrepresentable positive
+    // `i64`.
+    let magnitude = match u64::from_str_radix(digits, radix) {
+        Ok(m) => m,
+        Err(_) => {
+            return Err(ParseError::new(
+                1,
+                1,
+                format!(
+                    "invalid YAML: integer literal {text:?} is out of range for a 64-bit integer"
+                ),
+            ));
+        }
+    };
+    let value = if neg {
+        if magnitude == i64::MIN.unsigned_abs() {
+            Some(i64::MIN)
+        } else {
+            i64::try_from(magnitude).ok().and_then(i64::checked_neg)
+        }
+    } else {
+        i64::try_from(magnitude).ok()
+    };
+    match value {
+        Some(v) => Ok(Value::Int(v)),
+        None => Err(ParseError::new(
             1,
             1,
             format!("invalid YAML: integer literal {text:?} is out of range for a 64-bit integer"),
@@ -1228,6 +1259,46 @@ mod tests {
         let err = read_yaml(&text).unwrap_err();
         assert!(
             matches!(&err, OmnistError::Parse(e) if e.message.contains("4300-digit")),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn i64_min_round_trips_through_yaml() {
+        // Regression test for issue #26's fuzz harness finding: the
+        // previous `parse_int_literal` stripped the sign, then parsed the
+        // *positive* magnitude as `i64`, which overflows for `i64::MIN`
+        // (whose magnitude, 9223372036854775808, is one past `i64::MAX`)
+        // even though the signed value itself is representable.
+        let doc = read_yaml("a: -9223372036854775808\n").unwrap();
+        assert_eq!(
+            *doc.root().get_one("a").unwrap().value().unwrap(),
+            Scalar::Int(i64::MIN)
+        );
+    }
+
+    #[test]
+    fn positive_integer_one_past_i64_max_is_out_of_range_error() {
+        // Fits in u64 (so passes the magnitude parse) but not in i64 --
+        // exercises the final `None` arm of `parse_int_literal`'s match,
+        // distinct from `integer_literal_over_i64_range_is_out_of_range_error`
+        // below (whose 20-nines literal overflows even `u64`).
+        let err = read_yaml("a: 9223372036854775808\n").unwrap_err();
+        assert!(
+            matches!(&err, OmnistError::Parse(e) if e.message.contains("out of range")),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn negative_integer_one_past_i64_min_is_out_of_range_error() {
+        // Magnitude 9223372036854775809 fits in u64 and isn't
+        // `i64::MIN.unsigned_abs()`, so it falls through to the
+        // `checked_neg` arm, which correctly reports out-of-range instead
+        // of silently wrapping.
+        let err = read_yaml("a: -9223372036854775809\n").unwrap_err();
+        assert!(
+            matches!(&err, OmnistError::Parse(e) if e.message.contains("out of range")),
             "got {err:?}"
         );
     }

--- a/omnist/tests/fuzz.rs
+++ b/omnist/tests/fuzz.rs
@@ -1,0 +1,325 @@
+//! Property-based fuzzing + semantic-oracle cross-check (issue #26).
+//!
+//! Ported strategy from `~/dev/omnist/tests/test_fuzz.py` (Python's
+//! `hypothesis` generators for `Document`/`Schema`), using `proptest` per
+//! issue #1's toolchain mapping. This is the port order's explicit
+//! fuzzing item (`docs/workflow-playbook.md` §4), closed retroactively
+//! rather than per-module.
+//!
+//! ## What's covered
+//!
+//! - Bounded `Document`/`Value` tree generators (depth/breadth-limited,
+//!   well inside [`omnist::document::MAX_DEPTH`]).
+//! - Round-trip properties for all five formats: OML, JSON, YAML, TOML,
+//!   XML. Each format's writer can be lossy (see
+//!   `omnist::report::WriteReport`); a case is only asserted when the
+//!   writer reports no adjustments (`check_*(&doc).is_ok()` with zero
+//!   adjustments), since a known-lossy write is expected to fail
+//!   round-trip equality and is not this property's concern (each
+//!   format's PR already covers its own adjustment behavior).
+//! - Schema-algebra properties on fuzzed `Schema`s: `normalize` produces
+//!   something isomorphic to the input (extends #12's hand-picked spot
+//!   checks), `prune` is idempotent, and `extract`'s result only ever
+//!   keeps the requested labels.
+//! - Edge-case generators for extreme integers (near i64's 19-digit
+//!   range -- see `document.rs`'s doc comment on why this port has no
+//!   4300-digit guard to fuzz), temporal literals near calendar
+//!   boundaries, and format-tricky characters.
+//!
+//! ## Regression-smoke-test evidence (issue #26 acceptance criterion)
+//!
+//! This file's properties were manually verified to actually catch a
+//! broken round trip during development: temporarily changing
+//! `write_json`'s writer to swap two adjacent leaf values (breaking
+//! order-preservation) made `json_round_trips_when_lossless` fail
+//! immediately with a shrunk counterexample; reverting the change made
+//! it pass again. See the PR description for the exact diff and
+//! `proptest`'s failure output captured during that manual run -- this
+//! is deliberately not left in the tree as a permanently-broken test.
+
+use std::sync::LazyLock;
+
+use indexmap::IndexMap;
+use omnist::document::{Doc, Value};
+use omnist::formats::{json, toml, xml, yaml};
+use omnist::oml;
+use omnist::ops::{extract, is_isomorphic, normalize, prune};
+use omnist::schema::{self, Field, FieldType, Record, Ref, Schema};
+use proptest::prelude::*;
+
+/// Bounded case budget: `PROPTEST_CASES` (proptest's own recognized env
+/// var) if set, else 150 -- matching Python's `~/dev/omnist/tests/
+/// test_fuzz.py` `_SUPPRESS = settings(max_examples=150, ...)` as the
+/// starting point per the issue's request to check Python's actual CI
+/// budget. CI (`.github/workflows/ci.yml`, the `fuzz` job) sets
+/// `PROPTEST_CASES=250`; a bounded, non-default local run can override
+/// further. Never unbounded.
+static CASES: LazyLock<u32> = LazyLock::new(|| {
+    std::env::var("PROPTEST_CASES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(150)
+});
+
+// ---------------------------------------------------------------------------
+// Value / Document generators
+// ---------------------------------------------------------------------------
+
+/// Labels drawn from a small alphabet so objects plausibly share keys
+/// (matching Python's `_labels` strategy intent) and are always valid
+/// identifiers (avoids the `join()` bracket-quoting path entirely, which
+/// is exercised elsewhere by hand-written tests, not by this fuzzer).
+fn arb_label() -> impl Strategy<Value = String> {
+    "[a-z][a-z0-9_]{0,5}"
+}
+
+/// A scalar leaf. Kept ASCII-ish for strings so YAML/TOML/XML's tricky-
+/// character handling is exercised deliberately (see `arb_tricky_string`)
+/// rather than accidentally.
+fn arb_scalar() -> impl Strategy<Value = Value> {
+    prop_oneof![
+        Just(Value::Null),
+        any::<bool>().prop_map(Value::Bool),
+        // Bounded well away from i64::MAX/MIN edge weirdness in most
+        // cases, plus a dedicated extreme-integer arm.
+        (-1_000_000i64..1_000_000).prop_map(Value::Int),
+        prop_oneof![Just(i64::MAX), Just(i64::MIN), Just(0i64), Just(-1i64),].prop_map(Value::Int),
+        (-1e6f64..1e6)
+            .prop_filter("finite", |f| f.is_finite())
+            .prop_map(Value::Float),
+        "[a-zA-Z0-9 _.-]{0,12}".prop_map(Value::Str),
+        arb_tricky_string().prop_map(Value::Str),
+        arb_temporal_string().prop_map(Value::Str),
+    ]
+}
+
+/// Strings containing characters each format's own PR flagged as tricky:
+/// YAML flow/indicator chars, TOML quote/backslash, XML `< & > " '`.
+fn arb_tricky_string() -> impl Strategy<Value = String> {
+    prop_oneof![
+        Just("a: b".to_string()),
+        Just("- item".to_string()),
+        Just("\"quoted\\path\"".to_string()),
+        Just("<tag>&amp;</tag>".to_string()),
+        Just("line1\nline2".to_string()),
+        Just("tab\there".to_string()),
+        Just("both \" and '".to_string()),
+        Just("\u{0085}".to_string()), // NEL, YAML's own documented edge case
+        Just(String::new()),
+    ]
+}
+
+/// Temporal literals near calendar boundaries (leap day, year rollover,
+/// midnight/end-of-day, sub-second precision).
+fn arb_temporal_string() -> impl Strategy<Value = String> {
+    prop_oneof![
+        Just("2024-02-29".to_string()), // leap day
+        Just("2023-02-28".to_string()),
+        Just("0001-01-01".to_string()),
+        Just("9999-12-31".to_string()),
+        Just("00:00:00".to_string()),
+        Just("23:59:59".to_string()),
+        Just("23:59:59.999999".to_string()),
+        Just("2024-01-01T00:00:00".to_string()),
+        Just("2024-12-31T23:59:59.500000".to_string()),
+    ]
+}
+
+/// A bounded `Value` tree: `depth` counts remaining recursion allowance,
+/// well under `MAX_DEPTH` (200) so the depth guard is never the limiting
+/// factor -- this fuzzer is about content shape, not the guard itself
+/// (which has its own hand-written audit test in `document.rs`).
+fn arb_value(depth: u32) -> BoxedStrategy<Value> {
+    if depth == 0 {
+        arb_scalar().boxed()
+    } else {
+        let leaf = arb_scalar();
+        let recurse = arb_value(depth - 1);
+        prop_oneof![
+            2 => leaf,
+            3 => proptest::collection::vec((arb_label(), recurse.clone()), 0..4)
+                .prop_map(|pairs| {
+                    let mut map = IndexMap::new();
+                    for (k, v) in pairs {
+                        map.insert(k, v);
+                    }
+                    Value::Object(map)
+                }),
+        ]
+        .boxed()
+    }
+}
+
+/// An object-rooted `Value` (every format's real-world root shape; XML
+/// additionally requires exactly one top-level key, enforced at each
+/// XML-specific property site below).
+fn arb_object_value(depth: u32) -> impl Strategy<Value = Value> {
+    proptest::collection::vec((arb_label(), arb_value(depth)), 1..4).prop_map(|pairs| {
+        let mut map = IndexMap::new();
+        for (k, v) in pairs {
+            map.insert(k, v);
+        }
+        Value::Object(map)
+    })
+}
+
+/// Single-top-level-key variant, for XML's single-document-element rule.
+fn arb_single_root_value(depth: u32) -> impl Strategy<Value = Value> {
+    (arb_label(), arb_value(depth)).prop_map(|(k, v)| {
+        let mut map = IndexMap::new();
+        map.insert(k, v);
+        Value::Object(map)
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Round-trip properties
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(*CASES))]
+
+    /// OML is always lossless (it's omnist's own format) -- no
+    /// `prop_assume!` gate needed.
+    #[test]
+    fn oml_round_trips(v in arb_object_value(3)) {
+        let doc = Doc::of(&v).unwrap();
+        let raw = doc.to_raw();
+        let text = oml::write_oml(&raw, 2).unwrap();
+        let parsed = oml::read_oml(&text).unwrap();
+        let doc2 = Doc::from_raw(parsed).unwrap();
+        prop_assert!(doc.eq_doc(&doc2));
+    }
+
+    #[test]
+    fn json_round_trips_when_lossless(v in arb_object_value(3)) {
+        let doc = Doc::of(&v).unwrap();
+        prop_assume!(json::check_json(&doc).is_ok() && json::check_json(&doc).is_empty());
+        let text = json::write_json(&doc, None, true, None).unwrap();
+        let doc2 = json::read_json(&text).unwrap();
+        prop_assert!(doc.eq_doc(&doc2));
+    }
+
+    #[test]
+    fn yaml_round_trips_when_lossless(v in arb_object_value(3)) {
+        let doc = Doc::of(&v).unwrap();
+        prop_assume!(yaml::check_yaml(&doc).is_empty());
+        let text = yaml::write_yaml(&doc, true, None).unwrap();
+        let doc2 = yaml::read_yaml(&text).unwrap();
+        prop_assert!(doc.eq_doc(&doc2));
+    }
+
+    #[test]
+    fn toml_round_trips_when_lossless(v in arb_object_value(3)) {
+        let doc = Doc::of(&v).unwrap();
+        prop_assume!(toml::check_toml(&doc).is_empty());
+        let text = toml::write_toml(&doc, true, None).unwrap();
+        let doc2 = toml::read_toml(&text).unwrap();
+        prop_assert!(doc.eq_doc(&doc2));
+    }
+
+    #[test]
+    fn xml_round_trips_when_lossless(v in arb_single_root_value(3)) {
+        let doc = Doc::of(&v).unwrap();
+        prop_assume!(xml::check_xml(&doc).is_empty());
+        let text = xml::write_xml(&doc, true, None).unwrap();
+        let doc2 = xml::read_xml(&text).unwrap();
+        prop_assert!(doc.eq_doc(&doc2));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Schema-algebra generators + properties
+// ---------------------------------------------------------------------------
+
+fn arb_scalar_kind() -> impl Strategy<Value = schema::ScalarKind> {
+    proptest::sample::select(schema::ScalarKind::ALL.to_vec())
+}
+
+/// A schema with `n_records` named records (`r0`, `r1`, ...), each with a
+/// small number of scalar-typed fields, and later records allowed to
+/// reference earlier ones (acyclic by construction order, matching
+/// Python's `schemas()` strategy shape). Root is always `r0`.
+fn arb_schema(n_records: usize) -> impl Strategy<Value = Schema> {
+    let names: Vec<String> = (0..n_records).map(|i| format!("r{i}")).collect();
+    let record_strats: Vec<_> = (0..n_records)
+        .map(|i| {
+            let names = names.clone();
+            proptest::collection::vec(
+                (
+                    arb_label(),
+                    prop_oneof![
+                        arb_scalar_kind()
+                            .prop_map(|k| FieldType::Scalar(schema::Scalar::new(k, false))),
+                        arb_scalar_kind()
+                            .prop_map(|k| FieldType::Scalar(schema::Scalar::new(k, true))),
+                        proptest::sample::select(
+                            names[..=i.min(names.len().saturating_sub(1))].to_vec()
+                        )
+                        .prop_map(|n| FieldType::Ref(Ref::new(n))),
+                    ],
+                    0usize..2,
+                    proptest::option::of(1usize..3),
+                ),
+                0..3,
+            )
+        })
+        .collect();
+    record_strats.prop_map(move |all_fields| {
+        let mut env = IndexMap::new();
+        for (i, fields) in all_fields.into_iter().enumerate() {
+            let mut seen = std::collections::HashSet::new();
+            let mut built = Vec::new();
+            for (label, ty, min, max_extra) in fields {
+                if !seen.insert(label.clone()) {
+                    continue; // duplicate label: skip (Record::new rejects)
+                }
+                let max = max_extra.map(|m| min + m);
+                if let Ok(f) = Field::new(label, ty, min, max) {
+                    built.push(f);
+                }
+            }
+            env.insert(format!("r{i}"), Record::new(built).unwrap());
+        }
+        Schema::new(Ref::new("r0"), env).unwrap()
+    })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(*CASES))]
+
+    /// `normalize(s)` must remain isomorphic to `s` -- extends #12's
+    /// hand-picked spot tests to fuzzed schemas.
+    #[test]
+    fn normalize_preserves_isomorphism(s in arb_schema(3)) {
+        let n = normalize(&s);
+        prop_assert!(is_isomorphic(&s, &n));
+    }
+
+    /// `prune` is idempotent: pruning an already-pruned schema changes
+    /// nothing further.
+    #[test]
+    fn prune_is_idempotent(s in arb_schema(3)) {
+        let once = prune(&s);
+        let twice = prune(&once);
+        prop_assert_eq!(once, twice);
+    }
+
+    /// `extract(s, keep)`'s root record never keeps a field whose label
+    /// isn't in `keep`.
+    #[test]
+    fn extract_only_keeps_requested_labels(s in arb_schema(3), keep_idx in proptest::collection::vec(0usize..4, 0..3)) {
+        let root = s.env().get(s.root().name.as_str()).unwrap();
+        let all_labels: Vec<&str> = root.fields().iter().map(|f| f.label.as_str()).collect();
+        let keep: Vec<&str> = keep_idx
+            .into_iter()
+            .filter_map(|i| all_labels.get(i).copied())
+            .collect();
+        if let Ok(extracted) = extract(&s, &keep) {
+            let root2 = extracted.env().get(extracted.root().name.as_str()).unwrap();
+            for f in root2.fields() {
+                prop_assert!(keep.contains(&f.label.as_str()));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `proptest` (dev-dependency) with bounded generators for
  `Document`/`Value` trees and fuzzed `Schema`s, per issue #1's
  `hypothesis` -> `proptest` toolchain mapping.
- Round-trip properties for all five formats (OML/JSON/YAML/TOML/XML),
  each gated on a lossless write (`check_*(&doc)` has no adjustments)
  since known-lossy writes are each format's own PR's concern, not
  this one's.
- Schema-algebra properties on fuzzed schemas: `normalize` stays
  isomorphic to its input (extends #12's hand-picked spot tests),
  `prune` is idempotent, `extract` never keeps an unrequested label.
- Edge-case generators: extreme integers (`i64::MAX`/`MIN`), calendar-
  boundary temporal literals (leap day, midnight/end-of-day, year
  rollover), and the tricky characters each codec's own PR already
  flagged (YAML flow indicators, TOML quote/backslash, XML `< & > " '`,
  the NEL U+0085 codepoint).
- A bounded `fuzz` CI job (`PROPTEST_CASES=250`, starting from Python's
  `test_fuzz.py` CI budget of 150 `max_examples`).

## Genuine bug found and fixed

The fuzz harness's first real run failed
`yaml_round_trips_when_lossless` on `Object({"a": Int(i64::MIN)})`:
`parse_int_literal` stripped the `-` sign and parsed the *positive*
magnitude as `i64`, which overflows for `i64::MIN` (whose magnitude,
9223372036854775808, is one past `i64::MAX`) even though the signed
value itself is representable. Fixed in `omnist/src/formats/yaml.rs`
by parsing the magnitude as `u64` and applying the sign via
`checked_neg`; added `i64_min_round_trips_through_yaml`,
`positive_integer_one_past_i64_max_is_out_of_range_error`, and
`negative_integer_one_past_i64_min_is_out_of_range_error` as
regression tests (the last two needed for the 100%-coverage gate,
since they're the only way to reach the final `None` match arm).

## Regression-smoke-test evidence

Confirmed the harness actually catches regressions using this exact
bug: with the old (buggy) `parse_int_literal`,
`yaml_round_trips_when_lossless` failed immediately with proptest's
shrunk counterexample `Object({"a": Int(-9223372036854775808)})` and a
panic from `read_yaml`'s `unwrap()`. After the fix, all 8 fuzz tests
pass. (Also manually verified during development that corrupting
`write_json`'s leaf-order writer makes `json_round_trips_when_lossless`
fail with a shrunk counterexample, then reverting restores a pass --
this was not left in the tree.)

## Cross-implementation check

Ran a live cross-check against `~/dev/venvs/omnist` (Python `omnist`
0.7.9) over a hand-picked sample (extreme ints, tricky strings,
temporal literals, nesting, empty containers) comparing
`Doc.to_json()/to_yaml()/to_toml()` against the Rust CLI's
`convert --from json --to <fmt>`. 15/21 comparisons matched exactly;
the other 6 were known writer-style differences (TOML line-wrapping
for arrays/tables, YAML quote-style choice for special strings, TOML
writing dates as bare TOML dates vs Python's quoted-string dates) --
not data-losing bugs. Nothing filed upstream this round per the
cross-implementation bug policy (running tally unchanged: only #4
found a real bug, omnist-dev/omnist#255).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (532 lib + 8 fuzz + 97 CLI-integration +
      1 = all passing)
- [x] `cargo llvm-cov --workspace --fail-under-lines 100` -- 100.00%
      lines, exit 0

Closes #26
