### PR TITLE
Port the any type for real: schema.rs, osd.rs, infer.rs (issue #29)

### DIFF
--- a/omnist-cli/src/lib.rs
+++ b/omnist-cli/src/lib.rs
@@ -18,11 +18,12 @@
 //!   Passing `--arrays` where it would apply to OML output (`format`,
 //!   `convert --to oml`) is accepted by the argument parser (matching the
 //!   Python surface) but reported as a clear, non-panicking "not supported
-//!   yet" error (exit 2) rather than silently ignored or faked -- the same
-//!   scoping pattern `infer.rs`'s `allow_any` gap and `ops`'s `any`-type
-//!   gap already established in this port. Wherever `--arrays` has no
-//!   effect per spec (OSD output, or a `--to` other than `oml`), it is
-//!   accepted and silently ignored, matching Python exactly.
+//!   yet" error (exit 2) rather than silently ignored or faked. Wherever
+//!   `--arrays` has no effect per spec (OSD output, or a `--to` other than
+//!   `oml`), it is accepted and silently ignored, matching Python exactly.
+//!   (`infer`'s `--allow-any` used to be scoped out the same way -- it is
+//!   now fully wired to [`omnist::infer_with_report`]'s `allow_any`, issue
+//!   #29.)
 //! - **schema-directed `--schema` on `convert`**: implemented via
 //!   [`omnist::materialize::materialize`] on the raw node after a
 //!   schema-less read, exactly mirroring Python's `_materialize(node,
@@ -745,15 +746,6 @@ fn cmd_infer(args: InferArgs) -> i32 {
     if args.arrays {
         return fail(args.json, ARRAYS_OSD_ONLY_MSG, &[], 2);
     }
-    if args.allow_any {
-        return fail(
-            args.json,
-            "--allow-any is not supported by this port's `infer` yet (no `any` schema type; \
-             see omnist::infer's module doc)",
-            &[],
-            2,
-        );
-    }
     let mut docs = Vec::with_capacity(args.input.len());
     for path in &args.input {
         let text = match read_input(path) {
@@ -765,10 +757,13 @@ fn cmd_infer(args: InferArgs) -> i32 {
             Err(e) => return generic_fail(args.json, &e),
         }
     }
-    let schema = match omnist::infer(&docs, "Root") {
-        Ok(s) => s,
+    let (schema, fallbacks) = match omnist::infer_with_report(&docs, "Root", args.allow_any) {
+        Ok(r) => r,
         Err(e) => return generic_fail(args.json, &e.into()),
     };
+    for fb in &fallbacks {
+        eprintln!("warning: {} opened as `any` ({})", fb.location, fb.reason);
+    }
     let text_out = to_osd_text(&schema, args.compact);
     if let Err(e) = write_output(args.output.as_deref(), text_out) {
         return io_fail(args.json, &e);

--- a/omnist-cli/tests/cli.rs
+++ b/omnist-cli/tests/cli.rs
@@ -1130,11 +1130,38 @@ fn validate_missing_schema_file_exits_2() {
 }
 
 #[test]
-fn infer_allow_any_is_a_clear_not_supported_error() {
+fn infer_allow_any_succeeds_and_emits_no_warning_when_nothing_is_ambiguous() {
     let input = fixture("infer_allow_any_in", DOC_JSON);
     let r = run(&["infer", &input, "--from", "json", "--allow-any"]);
+    assert_eq!(r.code, 0);
+    assert!(!r.stdout.contains("any"));
+    assert!(r.stderr.is_empty());
+}
+
+#[test]
+fn infer_allow_any_opens_an_ambiguous_label_as_any_and_warns() {
+    // "x" mixes a string and a boolean across the two samples -- without
+    // `--allow-any` this is a hard error; with it, `x` opens as `any` and a
+    // warning is emitted on stderr naming the field and the reason.
+    let a = fixture("infer_allow_any_ambiguous_a", r#"{"x": "s"}"#);
+    let b = fixture("infer_allow_any_ambiguous_b", r#"{"x": true}"#);
+    let r = run(&["infer", &a, &b, "--from", "json", "--allow-any"]);
+    assert_eq!(r.code, 0);
+    assert!(
+        r.stdout.contains("any"),
+        "expected an `any` field: {}",
+        r.stdout
+    );
+    assert!(r.stderr.contains("Root.x"));
+    assert!(r.stderr.contains("any"));
+}
+
+#[test]
+fn infer_without_allow_any_still_errors_on_an_ambiguous_label() {
+    let a = fixture("infer_no_allow_any_ambiguous_a", r#"{"x": "s"}"#);
+    let b = fixture("infer_no_allow_any_ambiguous_b", r#"{"x": true}"#);
+    let r = run(&["infer", &a, &b, "--from", "json"]);
     assert_eq!(r.code, 2);
-    assert!(r.stderr.contains("--allow-any"));
 }
 
 // --------------------------------------------------------------------- the

--- a/omnist/src/infer.rs
+++ b/omnist/src/infer.rs
@@ -24,24 +24,23 @@
 //! schema is wanted (issue #12, itself resolving issues #143/#151 in the
 //! Python reference).
 //!
-//! ## Scoping: no `any`/`allow_any`
+//! ## `allow_any` and `AnyFallback`
 //!
-//! The Python reference has an `AnyFallback` mechanism and an
-//! `allow_any` option that opens a field as `any` when inference can't
-//! otherwise resolve it to one precise type. This port's [`crate::schema`]
-//! has no `any`/`AnyType` equivalent (that's an explicitly deferred design
-//! question upstream, same scoping as issue #8's OSD `any`-keyword handling
-//! and issue #12's schema-algebra `any` scoping). So **this port does not
-//! implement `allow_any`**: the two scenarios Python would resolve via
-//! `allow_any` instead return a [`SchemaError`] explaining why, rather than
-//! silently misbehaving:
+//! [`infer`] keeps its original two-argument signature and always infers
+//! with `allow_any: false` (matching its long-standing behavior). Two
+//! scenarios can't be resolved to one precise type from the samples alone:
 //!
-//! 1. a label whose samples mix objects and scalars ("mixes objects and
-//!    values; cannot infer one type without the `any` fallback this port
-//!    doesn't yet support");
+//! 1. a label whose samples mix objects and scalars;
 //! 2. a label whose scalar samples disagree on kind in a way that isn't the
 //!    integer/number subset relation (e.g. `string` and `boolean` seen
 //!    under the same label).
+//!
+//! With `allow_any: false` (via [`infer`], or [`infer_with_report`] called
+//! that way), both scenarios are a [`SchemaError`]. [`infer_with_report`]
+//! additionally accepts `allow_any: true`, matching Python's
+//! `infer_with_report`/`AnyFallback`: instead of erroring, the field is
+//! opened as [`crate::schema::FieldType::Any`] and one [`AnyFallback`] is
+//! recorded (`location` is `RecordName.label`; `reason` says why).
 //!
 //! ## No native temporal input
 //!
@@ -60,11 +59,34 @@ use crate::document::{Doc, Scalar as DocScalar};
 use crate::error::SchemaError;
 use crate::schema::{Field, FieldType, Record, Ref, Scalar, ScalarKind, Schema};
 
+/// A single field [`infer_with_report`] opened as `any` under
+/// `allow_any: true`. `location` reads `RecordName.label`; `reason` says why
+/// the field could not be given a single precise type. Mirrors Python's
+/// `AnyFallback` dataclass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnyFallback {
+    pub location: String,
+    pub reason: String,
+}
+
 /// Infers a `record` [`Schema`] (rooted at `root_name`) that accepts every
 /// sample in `samples`. Every sample's root must be an object (a record
 /// shape) -- an empty `samples` list, or any sample whose root is a bare
-/// scalar, is a [`SchemaError`].
+/// scalar, is a [`SchemaError`]. Always infers with `allow_any: false` --
+/// see [`infer_with_report`] for the `allow_any: true` variant.
 pub fn infer(samples: &[Doc], root_name: &str) -> Result<Schema, SchemaError> {
+    infer_with_report(samples, root_name, false).map(|(schema, _)| schema)
+}
+
+/// Like [`infer`], but also takes `allow_any` and returns every
+/// [`AnyFallback`] recorded along the way (empty when `allow_any` is
+/// `false`, since every ambiguous field is a hard error in that mode
+/// instead). Mirrors Python's `infer_with_report`.
+pub fn infer_with_report(
+    samples: &[Doc],
+    root_name: &str,
+    allow_any: bool,
+) -> Result<(Schema, Vec<AnyFallback>), SchemaError> {
     if samples.is_empty() {
         return Err(SchemaError::new("cannot infer a schema from zero samples"));
     }
@@ -77,9 +99,18 @@ pub fn infer(samples: &[Doc], root_name: &str) -> Result<Schema, SchemaError> {
     }
     let mut env: IndexMap<String, Record> = IndexMap::new();
     let mut used: IndexSet<String> = IndexSet::new();
+    let mut fallbacks: Vec<AnyFallback> = Vec::new();
     let roots: Vec<_> = samples.iter().map(Doc::root).collect();
-    infer_record(&roots, root_name, &mut env, &mut used)?;
-    Schema::new(Ref::new(root_name), env)
+    infer_record(
+        &roots,
+        root_name,
+        &mut env,
+        &mut used,
+        allow_any,
+        &mut fallbacks,
+    )?;
+    let schema = Schema::new(Ref::new(root_name), env)?;
+    Ok((schema, fallbacks))
 }
 
 // Note: unlike the Python reference's `_infer_record`, there is no explicit
@@ -99,6 +130,8 @@ fn infer_record(
     name: &str,
     env: &mut IndexMap<String, Record>,
     used: &mut IndexSet<String>,
+    allow_any: bool,
+    fallbacks: &mut Vec<AnyFallback>,
 ) -> Result<(), SchemaError> {
     used.insert(name.to_string());
 
@@ -140,7 +173,15 @@ fn infer_record(
         let lo = *counts.iter().min().unwrap();
         let hi = *counts.iter().max().unwrap();
         let (cmin, cmax) = if hi > 1 { (0, None) } else { (lo, Some(1)) };
-        let ty = infer_type(&children[label], label, name, env, used)?;
+        let ty = infer_type(
+            &children[label],
+            label,
+            name,
+            env,
+            used,
+            allow_any,
+            fallbacks,
+        )?;
         fields.push(Field::new(label.clone(), ty, cmin, cmax)?);
     }
     env.insert(name.to_string(), Record::new(fields)?);
@@ -153,17 +194,25 @@ fn infer_type(
     record_name: &str,
     env: &mut IndexMap<String, Record>,
     used: &mut IndexSet<String>,
+    allow_any: bool,
+    fallbacks: &mut Vec<AnyFallback>,
 ) -> Result<FieldType, SchemaError> {
     let is_obj: Vec<bool> = child_nodes.iter().map(|c| !c.is_leaf()).collect();
     if is_obj.iter().all(|&b| b) {
         let rec_name = unique_name(label, used);
-        infer_record(child_nodes, &rec_name, env, used)?;
+        infer_record(child_nodes, &rec_name, env, used, allow_any, fallbacks)?;
         return Ok(FieldType::Ref(Ref::new(rec_name)));
     }
     if is_obj.iter().any(|&b| b) {
+        if allow_any {
+            fallbacks.push(AnyFallback {
+                location: format!("{record_name}.{label}"),
+                reason: "mixes objects and values".to_string(),
+            });
+            return Ok(FieldType::Any);
+        }
         return Err(SchemaError::new(format!(
-            "{record_name}.{label} mixes objects and values; cannot infer one \
-             type without the `any` fallback this port doesn't yet support"
+            "label {label:?} mixes objects and values; cannot infer one type"
         )));
     }
     // All scalars.
@@ -206,10 +255,19 @@ fn infer_type(
     if names.len() > 1 {
         let mut sorted: Vec<&str> = names.into_iter().collect();
         sorted.sort_unstable();
+        if allow_any {
+            fallbacks.push(AnyFallback {
+                location: format!("{record_name}.{label}"),
+                reason: format!(
+                    "values of more than one scalar kind ({})",
+                    sorted.join(", ")
+                ),
+            });
+            return Ok(FieldType::Any);
+        }
         return Err(SchemaError::new(format!(
-            "{record_name}.{label} has values of more than one scalar ({}); \
-             cannot infer one scalar type without the `any` fallback this \
-             port doesn't yet support",
+            "label {label:?} has values of more than one scalar ({}); cannot infer one \
+             scalar type",
             sorted.join(", ")
         )));
     }

--- a/omnist/src/infer/tests.rs
+++ b/omnist/src/infer/tests.rs
@@ -89,6 +89,7 @@ fn integer_and_number_samples_collapse_to_number() {
     match &f.ty {
         FieldType::Scalar(s) => assert_eq!(s.kind(), ScalarKind::Number),
         FieldType::Ref(_) => panic!("expected a scalar"),
+        FieldType::Any => panic!("expected a scalar"),
     }
 }
 
@@ -103,6 +104,7 @@ fn all_integer_samples_stay_integer() {
     match &f.ty {
         FieldType::Scalar(s) => assert_eq!(s.kind(), ScalarKind::Integer),
         FieldType::Ref(_) => panic!("expected a scalar"),
+        FieldType::Any => panic!("expected a scalar"),
     }
 }
 
@@ -120,6 +122,7 @@ fn null_sample_makes_the_scalar_nullable() {
             assert!(s.is_nullable());
         }
         FieldType::Ref(_) => panic!("expected a scalar"),
+        FieldType::Any => panic!("expected a scalar"),
     }
 }
 
@@ -134,6 +137,7 @@ fn only_null_samples_default_to_nullable_string() {
             assert!(s.is_nullable());
         }
         FieldType::Ref(_) => panic!("expected a scalar"),
+        FieldType::Any => panic!("expected a scalar"),
     }
 }
 
@@ -155,6 +159,7 @@ fn object_child_becomes_a_nested_named_record() {
             assert_eq!(r.name, "Address");
         }
         FieldType::Scalar(_) => panic!("expected a ref"),
+        FieldType::Any => panic!("expected a ref"),
     }
 }
 
@@ -187,7 +192,8 @@ fn disagreeing_scalar_shapes_raise_a_schema_error() {
 }
 
 // ---------------------------------------------------------------------------
-// `allow_any` scoping (not implemented -- clear SchemaError instead)
+// `allow_any: false` (via `infer`/`infer_with_report`): a hard error, no
+// mention of `any` in the message (there's no fallback in this mode).
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -198,17 +204,66 @@ fn mixing_objects_and_scalars_under_one_label_is_a_schema_error() {
     ];
     let err = infer(&samples, "Root").unwrap_err();
     assert!(err.to_string().contains("mixes objects and values"));
-    assert!(err.to_string().contains("any"));
 }
 
 #[test]
-fn disagreeing_scalar_shapes_error_mentions_the_any_fallback_gap() {
+fn disagreeing_scalar_shapes_error_does_not_mention_any_when_allow_any_is_false() {
     let samples = vec![
         doc(obj(&[("x", Value::Str("a".into()))])),
         doc(obj(&[("x", Value::Bool(true))])),
     ];
     let err = infer(&samples, "Root").unwrap_err();
-    assert!(err.to_string().contains("any"));
+    assert!(err.to_string().contains("more than one scalar"));
+    assert!(!err.to_string().contains("any"));
+}
+
+// ---------------------------------------------------------------------------
+// `allow_any: true` (via `infer_with_report`): real `any` fallback support.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn allow_any_opens_a_mixed_object_and_scalar_label_as_any() {
+    let samples = vec![
+        doc(obj(&[("x", obj(&[("a", Value::Int(1))]))])),
+        doc(obj(&[("x", Value::Int(1))])),
+    ];
+    let (schema, fallbacks) = infer_with_report(&samples, "Root", true).unwrap();
+    let f = field(schema.env(), "Root", "x");
+    assert_eq!(f.ty, FieldType::Any);
+    assert_eq!(fallbacks.len(), 1);
+    assert_eq!(fallbacks[0].location, "Root.x");
+    assert!(fallbacks[0].reason.contains("mixes objects and values"));
+}
+
+#[test]
+fn allow_any_opens_a_disagreeing_scalar_label_as_any() {
+    let samples = vec![
+        doc(obj(&[("x", Value::Str("a".into()))])),
+        doc(obj(&[("x", Value::Bool(true))])),
+    ];
+    let (schema, fallbacks) = infer_with_report(&samples, "Root", true).unwrap();
+    let f = field(schema.env(), "Root", "x");
+    assert_eq!(f.ty, FieldType::Any);
+    assert_eq!(fallbacks.len(), 1);
+    assert_eq!(fallbacks[0].location, "Root.x");
+    assert!(fallbacks[0].reason.contains("more than one scalar kind"));
+    assert!(fallbacks[0].reason.contains("boolean"));
+    assert!(fallbacks[0].reason.contains("string"));
+}
+
+#[test]
+fn allow_any_true_reports_no_fallbacks_when_nothing_is_ambiguous() {
+    let samples = vec![doc(obj(&[("name", Value::Str("a".into()))]))];
+    let (_, fallbacks) = infer_with_report(&samples, "Root", true).unwrap();
+    assert!(fallbacks.is_empty());
+}
+
+#[test]
+fn infer_with_report_allow_any_false_matches_infer_and_has_no_fallbacks() {
+    let samples = vec![doc(obj(&[("name", Value::Str("a".into()))]))];
+    let (schema, fallbacks) = infer_with_report(&samples, "Root", false).unwrap();
+    assert_eq!(schema, infer(&samples, "Root").unwrap());
+    assert!(fallbacks.is_empty());
 }
 
 // ---------------------------------------------------------------------------

--- a/omnist/src/lib.rs
+++ b/omnist/src/lib.rs
@@ -12,7 +12,7 @@ pub mod schema;
 pub use error::{
     DocumentError, MaterializeError, OmnistError, ParseError, SchemaError, WriteError,
 };
-pub use infer::infer;
+pub use infer::{AnyFallback, infer, infer_with_report};
 pub use materialize::materialize;
 pub use report::{Adjustment, Severity, WriteReport};
 

--- a/omnist/src/materialize.rs
+++ b/omnist/src/materialize.rs
@@ -53,11 +53,11 @@
 //! untouched), matching the Python reference's `schema=None` convention at
 //! the reader call sites.
 //!
-//! ## The `any` type is out of scope
+//! ## The `any` type
 //!
-//! Same scoping as `crate::ops` (issue #12): this port's [`crate::schema`]
-//! has no `AnyType` equivalent, so there is no `AnyType` branch to
-//! materialize through here either.
+//! An `Any`-typed field passes its node through completely untouched --
+//! no shape check, no scalar upgrade -- mirroring Python's
+//! `_materialize_type`: `if isinstance(d, AnyType): return node`.
 
 use crate::document::{RawNode, Scalar as DocScalar};
 use crate::error::MaterializeError;
@@ -90,6 +90,9 @@ fn materialize_type(
     res: &mut ValidationResult,
 ) -> RawNode {
     match schema.resolve(ty) {
+        // `any` accepts every legal value unchecked -- pass the node through
+        // exactly as read, no shape check or scalar upgrade.
+        Resolved::Any => node.clone(),
         Resolved::Scalar(s) => materialize_scalar(node, s.kind(), s.is_nullable(), path, res),
         Resolved::Record(rec) => materialize_record(node, schema, rec, path, res),
     }

--- a/omnist/src/materialize/tests.rs
+++ b/omnist/src/materialize/tests.rs
@@ -359,3 +359,27 @@ fn cardinality_array_field_accepts_repeated_labels() {
     };
     assert_eq!(out_edges.len(), 3);
 }
+
+// ---------------------------------------------------------------------------
+// `any` field: passes any node through untouched, no shape check/upgrade.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn any_field_passes_scalar_and_object_nodes_through_untouched() {
+    let fields = vec![Field::required("x", crate::schema::FieldType::Any).unwrap()];
+    let root = Record::new(fields).unwrap();
+    let mut env = IndexMap::new();
+    env.insert("Root".to_string(), root);
+    let schema = Schema::new(Ref::new("Root"), env).unwrap();
+
+    let scalar_node = edges(vec![("x", leaf(DocScalar::Int(1)))]);
+    let out = materialize(&scalar_node, Some(&schema)).unwrap();
+    assert_eq!(out, scalar_node);
+
+    let object_node = edges(vec![(
+        "x",
+        edges(vec![("nested", leaf(DocScalar::Str("v".into())))]),
+    )]);
+    let out2 = materialize(&object_node, Some(&schema)).unwrap();
+    assert_eq!(out2, object_node);
+}

--- a/omnist/src/ops/lint.rs
+++ b/omnist/src/ops/lint.rs
@@ -7,9 +7,7 @@
 //! mutates** -- `prune`/`normalize` are the transforms that fix these
 //! issues; `lint` only diagnoses them.
 //!
-//! Three checks (the Python reference's fourth, `any-field`, has no
-//! counterpart here -- see `super`'s module doc comment on why `AnyType`
-//! is out of scope for this port):
+//! Four checks:
 //!
 //! * `unsatisfiable-record` (`warning`) -- a reachable record no finite
 //!   document can match (e.g. a mandatory ref cycle). Reuses
@@ -23,6 +21,9 @@
 //!   records under different names. Reuses
 //!   [`super::minimize::equivalence_classes`] on the *raw* schema, so
 //!   duplicates are reported as authored.
+//! * `any-field` (`info`) -- an inventory of every `any`-typed field, so a
+//!   human can audit the schema's deliberate openings. Advisory only; never
+//!   affects a caller's exit code on its own.
 
 use indexmap::IndexSet;
 
@@ -33,8 +34,9 @@ use super::prune::satisfiable_set;
 
 /// One structural diagnostic. `code` is a stable machine-readable
 /// identifier (`unsatisfiable-record`, `unreachable-record`,
-/// `duplicate-record`); `severity` is `warning` or `info`; `location` is a
-/// record name; `message` is a human-readable, actionable description.
+/// `duplicate-record`, `any-field`); `severity` is `warning` or `info`;
+/// `location` is a record name (or `Record.label` for `any-field`);
+/// `message` is a human-readable, actionable description.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LintFinding {
     pub code: &'static str,
@@ -136,6 +138,27 @@ pub fn lint(s: &Schema) -> Vec<LintFinding> {
                     others.join(", ")
                 ),
             });
+        }
+    }
+
+    // any-field: inventory of every any-typed field, sorted by record name
+    // to match the input's declared env order deterministically before the
+    // final canonical sort below.
+    for name in s.env().keys() {
+        let rec = s.env().get(name).expect("name comes from s.env's own keys");
+        for f in rec.fields() {
+            if matches!(f.ty, FieldType::Any) {
+                findings.push(LintFinding {
+                    code: "any-field",
+                    severity: "info",
+                    location: format!("{name}.{}", f.label),
+                    message: format!(
+                        "field {:?} of record {name:?} is typed `any` (accepts any value \
+                         unchecked)",
+                        f.label
+                    ),
+                });
+            }
         }
     }
 

--- a/omnist/src/ops/minimize.rs
+++ b/omnist/src/ops/minimize.rs
@@ -172,7 +172,7 @@ fn refine_key(rec: &Record, block_of: &IndexMap<String, usize>) -> RefineKey {
                         .get(&r.name)
                         .expect("every ref target is classified before refine_key runs on it"),
                 ),
-                FieldType::Scalar(_) => None,
+                FieldType::Scalar(_) | FieldType::Any => None,
             };
             (f.label.clone(), f.min, f.max, blk)
         })
@@ -199,6 +199,7 @@ fn remap(rec: &Record, rep: &IndexMap<String, String>) -> Record {
                         .expect("every ref target is classified into rep"),
                 )),
                 FieldType::Scalar(s) => FieldType::Scalar(*s),
+                FieldType::Any => FieldType::Any,
             };
             Field::new(f.label.clone(), ty, f.min, f.max)
                 .expect("remapping a ref target name changes neither label nor cardinality")

--- a/omnist/src/ops/mod.rs
+++ b/omnist/src/ops/mod.rs
@@ -3,17 +3,17 @@
 //! (issue #12), one module per op (matching the Python layout, which is
 //! already a reasonable structure per "architecture freedom").
 //!
-//! ## The `any` type is out of scope here
+//! ## The `any` type
 //!
-//! The Python reference's `schema.py` has a fourth type kind, `AnyType`
-//! (accepts any value unchecked), threaded through every op in this family.
-//! `omnist-rs`'s [`crate::schema`] (issue #6) does not have an `AnyType`
-//! equivalent -- whether to add one is an explicitly deferred open design
-//! question upstream (not yet decided for this port), so every op below is
-//! written against the two-kind [`crate::schema::FieldType`] (`Scalar` /
-//! `Ref`) that issue #6 actually shipped. `lint`'s Python `any-field` check
-//! has no Rust counterpart for the same reason -- there is nothing to
-//! inventory yet.
+//! [`crate::schema::FieldType`] has three kinds: `Scalar`, `Ref`, and `Any`
+//! (issue #29). Every op in this family treats `Any` the same way the
+//! Python reference's `AnyType` is treated in the corresponding op:
+//! satisfiability treats it like a `Scalar` (always satisfiable, never
+//! blocks a mandatory field); `local_signature`/minimize give it its own
+//! target-blind shape key (`("any",)`); `subschema` treats `any` on the
+//! superschema side as absorbing everything, and `any` only on the
+//! subschema side as never compatible with a non-`any` target; `lint`'s
+//! `any-field` check inventories every `Any`-typed field in the schema.
 //!
 //! ## Determinism
 //!

--- a/omnist/src/ops/signature.rs
+++ b/omnist/src/ops/signature.rs
@@ -12,13 +12,14 @@
 
 use crate::schema::{FieldType, Record, ScalarKind};
 
-/// A field's target-blind shape: `Scalar(kind, nullable)` or `Ref` (the
+/// A field's target-blind shape: `Scalar(kind, nullable)`, `Ref` (the
 /// target record's name is deliberately excluded -- see the module doc
-/// comment).
+/// comment), or `Any`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ShapeKey {
     Scalar(ScalarKind, bool),
     Ref,
+    Any,
 }
 
 /// One field's signature entry: `(label, min, max, shape)`.
@@ -44,6 +45,7 @@ pub fn local_signature(rec: &Record) -> LocalSignature {
             let shape = match &f.ty {
                 FieldType::Scalar(s) => ShapeKey::Scalar(s.kind(), s.is_nullable()),
                 FieldType::Ref(_) => ShapeKey::Ref,
+                FieldType::Any => ShapeKey::Any,
             };
             (f.label.clone(), f.min, f.max, shape)
         })

--- a/omnist/src/ops/subschema.rs
+++ b/omnist/src/ops/subschema.rs
@@ -54,6 +54,14 @@ fn sub(
 ) -> bool {
     match (ta, tb) {
         (FieldType::Ref(ra), _) if !sat_a.contains(&ra.name) => true,
+        // `any` on the B (super-schema) side absorbs every A-side value --
+        // always sound, regardless of what `ta` is. Checked before the
+        // `ta == Any` arm below, mirroring Python's `if isinstance(db,
+        // AnyType): True` running before its `elif isinstance(da, AnyType)`.
+        (_, FieldType::Any) => true,
+        // Only `any` holds `any`; `ta` is `any` and `tb` isn't -> never a
+        // subschema relation.
+        (FieldType::Any, _) => false,
         (FieldType::Scalar(a), FieldType::Scalar(b)) => scalar_sub(*a, *b),
         (FieldType::Ref(ra), FieldType::Ref(rb)) => {
             let key = (ra.name.clone(), rb.name.clone());

--- a/omnist/src/ops/tests.rs
+++ b/omnist/src/ops/tests.rs
@@ -61,6 +61,21 @@ fn local_signature_distinguishes_scalar_kind_and_nullability() {
     );
 }
 
+#[test]
+fn local_signature_gives_any_its_own_shape_key_distinct_from_scalar_and_ref() {
+    let any_rec = rec(vec![req("x", FieldType::Any)]);
+    let scalar_rec = rec(vec![req("x", STRING)]);
+    let ref_rec = rec(vec![req("x", Ref::new("Other"))]);
+    assert_ne!(
+        signature::local_signature(&any_rec),
+        signature::local_signature(&scalar_rec)
+    );
+    assert_ne!(
+        signature::local_signature(&any_rec),
+        signature::local_signature(&ref_rec)
+    );
+}
+
 // ---------------------------------------------------------------------------
 // prune
 // ---------------------------------------------------------------------------
@@ -262,6 +277,30 @@ fn minimize_merges_structurally_identical_records() {
 }
 
 #[test]
+fn minimize_merges_records_that_only_differ_by_any_field_naming() {
+    let e = env(vec![
+        (
+            "Root",
+            rec(vec![req("a", Ref::new("A")), req("b", Ref::new("B"))]),
+        ),
+        ("A", rec(vec![req("x", FieldType::Any)])),
+        ("B", rec(vec![req("x", FieldType::Any)])),
+    ]);
+    let s = Schema::new(Ref::new("Root"), e).unwrap();
+    let m = minimize::normalize(&s);
+    assert_eq!(m.env().len(), 2);
+    // A and B collapse to one record; its field is still `any` (remap is a
+    // passthrough for non-ref types).
+    let root_rec = &m.env()[&m.root().name];
+    let FieldType::Ref(target) = &root_rec.field("a").unwrap().ty else {
+        panic!("expected a ref field");
+    };
+    let merged = &m.env()[&target.name];
+    assert_eq!(merged.field("x").unwrap().ty, FieldType::Any);
+    assert_minimize_preserves_semantics_and_reaches_a_fixpoint(&s);
+}
+
+#[test]
 fn minimize_is_a_no_op_on_an_already_minimal_schema() {
     let e = env(vec![("Root", rec(vec![req("x", STRING)]))]);
     let s = Schema::new(Ref::new("Root"), e).unwrap();
@@ -365,6 +404,39 @@ fn compatible_with_widening_cardinality_and_integer_to_number() {
     let b = Schema::new(Ref::new("B"), e_b).unwrap();
     assert!(subschema::compatible_with(&a, &b));
     assert!(!subschema::compatible_with(&b, &a));
+}
+
+#[test]
+fn compatible_with_any_on_the_b_side_absorbs_any_a_side_field() {
+    // `any` on B always absorbs A's field, whatever A's field is (scalar,
+    // ref, or any itself).
+    let e_a = env(vec![
+        ("A", rec(vec![req("x", Ref::new("X"))])),
+        ("X", rec(vec![req("v", STRING)])),
+    ]);
+    let e_b = env(vec![("B", rec(vec![req("x", FieldType::Any)]))]);
+    let a = Schema::new(Ref::new("A"), e_a).unwrap();
+    let b = Schema::new(Ref::new("B"), e_b).unwrap();
+    assert!(subschema::compatible_with(&a, &b));
+}
+
+#[test]
+fn compatible_with_any_on_the_a_side_is_never_compatible_with_a_non_any_b() {
+    let e_a = env(vec![("A", rec(vec![req("x", FieldType::Any)]))]);
+    let e_b = env(vec![("B", rec(vec![req("x", STRING)]))]);
+    let a = Schema::new(Ref::new("A"), e_a).unwrap();
+    let b = Schema::new(Ref::new("B"), e_b).unwrap();
+    assert!(!subschema::compatible_with(&a, &b));
+}
+
+#[test]
+fn compatible_with_any_on_both_sides_is_compatible() {
+    let e_a = env(vec![("A", rec(vec![req("x", FieldType::Any)]))]);
+    let e_b = env(vec![("B", rec(vec![req("x", FieldType::Any)]))]);
+    let a = Schema::new(Ref::new("A"), e_a).unwrap();
+    let b = Schema::new(Ref::new("B"), e_b).unwrap();
+    assert!(subschema::compatible_with(&a, &b));
+    assert!(subschema::equivalent(&a, &b));
 }
 
 #[test]
@@ -655,6 +727,28 @@ fn lint_flags_unreachable_and_unsatisfiable_and_duplicate_records() {
     assert!(codes.contains(&"duplicate-record"));
     assert!(findings.iter().any(|f| f.location == "Bad"));
     assert!(findings.iter().any(|f| f.location == "Orphan"));
+}
+
+#[test]
+fn lint_inventories_any_typed_fields_as_info_findings() {
+    let e = env(vec![("Root", rec(vec![req("x", FieldType::Any)]))]);
+    let s = Schema::new(Ref::new("Root"), e).unwrap();
+    let findings = lint::lint(&s);
+    let f = findings
+        .iter()
+        .find(|f| f.code == "any-field")
+        .expect("expected an any-field finding");
+    assert_eq!(f.severity, "info");
+    assert_eq!(f.location, "Root.x");
+    assert!(f.message.contains("typed `any`"));
+}
+
+#[test]
+fn lint_reports_no_any_field_findings_when_none_exist() {
+    let e = env(vec![("Root", rec(vec![req("x", STRING)]))]);
+    let s = Schema::new(Ref::new("Root"), e).unwrap();
+    let findings = lint::lint(&s);
+    assert!(!findings.iter().any(|f| f.code == "any-field"));
 }
 
 #[test]

--- a/omnist/src/osd.rs
+++ b/omnist/src/osd.rs
@@ -16,17 +16,15 @@
 //! There is no value-domain composition (no `|`, enum, literal fields, or
 //! `union`).
 //!
-//! ## The `any` type is deliberately out of scope
+//! ## The `any` keyword
 //!
 //! Python's `osd.py` recognizes `"any"` as a reserved type keyword and
-//! implements it (`AnyType`/`ANY`, imported from `schema.py`). This Rust
-//! port's [`crate::schema`] (issue #6/PR #7) deliberately did not implement
-//! `any` -- that type's inclusion in the public API is an explicitly
-//! deferred decision pending user sign-off. This module keeps the same
-//! scoping: `any` is still recognized as a reserved name (so it can't be
-//! used as a record name, matching the grammar), but using it as a field's
-//! type produces a clear [`SchemaError`] explaining it isn't supported yet,
-//! rather than silently misparsing or guessing.
+//! parses it to `ANY` (`RESERVED_TYPE_NAMES = SCALAR_NAMES | {"any"}`). This
+//! module mirrors that: `any` in a type position parses to
+//! [`crate::schema::FieldType::Any`], and -- exactly like Python -- `any` is
+//! still a reserved name that cannot be used as a record name (matching the
+//! grammar). Since `Any` already includes `null`, a trailing `?` after `any`
+//! (`"a": any?`) is a [`SchemaError`] ("redundant"), not silently accepted.
 
 use indexmap::IndexMap;
 use regex::Regex;
@@ -148,12 +146,11 @@ fn unquote(s: &str) -> String {
 // ---------------------------------------------------------------------------
 
 /// A field's type as produced by the parser, before being wired into
-/// [`Field::new`]. Kept private -- `Any` never survives past [`parse_type`],
-/// which turns it into an error immediately (see the module doc's scoping
-/// note).
+/// [`Field::new`].
 enum ParsedType {
     Scalar(Scalar),
     Ref(Ref),
+    Any,
 }
 
 impl From<ParsedType> for crate::schema::FieldType {
@@ -161,6 +158,7 @@ impl From<ParsedType> for crate::schema::FieldType {
         match t {
             ParsedType::Scalar(s) => s.into(),
             ParsedType::Ref(r) => r.into(),
+            ParsedType::Any => crate::schema::FieldType::Any,
         }
     }
 }
@@ -353,11 +351,14 @@ impl Parser {
             )));
         }
         if t.text == "any" {
-            return Err(SchemaError::new(format!(
-                "the 'any' type is not supported by this port yet (scoped out; \
-                 see omnist-rs issue #8) -- found at {}",
-                t.pos
-            )));
+            if self.peek().text == "?" {
+                let q = self.next_tok();
+                return Err(SchemaError::new(format!(
+                    "'any' already includes null; 'any?' is redundant at {}",
+                    q.pos
+                )));
+            }
+            return Ok(ParsedType::Any);
         }
         let mut nullable = false;
         if self.peek().text == "?" {
@@ -451,6 +452,7 @@ fn osd_type(t: &crate::schema::FieldType) -> String {
                 if s.is_nullable() { "?" } else { "" }
             )
         }
+        crate::schema::FieldType::Any => "any".to_string(),
     }
 }
 
@@ -702,15 +704,31 @@ mod tests {
         );
     }
 
-    // -- The `any` keyword: scoped-out, clear error --------------------------
+    // -- The `any` keyword: real support --------------------------------------
 
     #[test]
-    fn any_as_field_type_is_a_clear_scoped_out_error() {
-        let err = parse_schema(r#"record X { "a": any } root X"#).unwrap_err();
+    fn any_as_field_type_parses_to_the_any_field_type() {
+        let schema = parse_schema(r#"record X { "a": any } root X"#).unwrap();
+        let rec = schema.env().get("X").unwrap();
+        assert_eq!(rec.field("a").unwrap().ty, FieldType::Any);
+    }
+
+    #[test]
+    fn any_with_nullable_marker_is_redundant_error() {
+        let err = parse_schema(r#"record X { "a": any? } root X"#).unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("'any'"));
-        assert!(msg.contains("not supported"));
-        assert!(msg.contains("issue #8"));
+        assert!(msg.contains("already includes null"));
+        assert!(msg.contains("redundant"));
+    }
+
+    #[test]
+    fn any_round_trips_through_to_osd() {
+        let src = r#"record X { "a": any } root X"#;
+        let schema = parse_schema(src).unwrap();
+        let rendered = to_osd(&schema, None);
+        assert_eq!(rendered, "record X { \"a\": any } root X\n");
+        let reparsed = parse_schema(&rendered).unwrap();
+        assert_eq!(reparsed, schema);
     }
 
     #[test]

--- a/omnist/src/schema.rs
+++ b/omnist/src/schema.rs
@@ -12,9 +12,17 @@
 //!   principled way to choose).
 //! * **Ref** -- a pointer into the schema's named environment (records
 //!   only); enables reuse and recursion.
+//! * **Any** (`FieldType::Any`) -- accepts every legal document value
+//!   unchecked. Ported from Python's `AnyType`/`ANY` singleton, which has
+//!   been fully implemented and shipped there since v0.5.0 -- not a
+//!   speculative or deferred feature (the *separate*, still-unresolved
+//!   question is whether `any` should be a *permanent* part of the spec
+//!   long-term; that governance question is untouched by this port simply
+//!   catching up to Python's existing behavior, see omnist-rs issue #29).
 //!
-//! A field's type is a `Ref` or a `Scalar`. There are no inline records and
-//! no separate array type -- "array" is a field with cardinality `max > 1`.
+//! A field's type is a `Ref`, a `Scalar`, or `Any`. There are no inline
+//! records and no separate array type -- "array" is a field with
+//! cardinality `max > 1`.
 //! Validation ignores order (per `docs/design/model.md` §7).
 //!
 //! ## Temporal shape-check
@@ -305,11 +313,17 @@ impl std::fmt::Display for Ref {
     }
 }
 
-/// A field's type: a `Ref` to a named record, or a `Scalar`.
+/// A field's type: a `Ref` to a named record, a `Scalar`, or `Any` (accepts
+/// every legal document value -- ported from Python's `AnyType`/`ANY`
+/// singleton, shipped there since v0.5.0). `Any` is not a `Scalar` (it has
+/// no kind and no nullable flag -- null is already included) and not a
+/// `Ref` (it names nothing), so it gets its own unit variant rather than
+/// being folded into either.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum FieldType {
     Scalar(Scalar),
     Ref(Ref),
+    Any,
 }
 
 impl From<Scalar> for FieldType {
@@ -543,10 +557,11 @@ pub(crate) fn value_kind_name(v: &DocScalar) -> &'static str {
 // Schema
 // ---------------------------------------------------------------------------
 
-/// A resolved field type: either a record (via a `Ref`) or a bare `Scalar`.
+/// A resolved field type: a record (via a `Ref`), a bare `Scalar`, or `Any`.
 pub enum Resolved<'a> {
     Record(&'a Record),
     Scalar(Scalar),
+    Any,
 }
 
 /// A schema: a root reference plus an environment of named records.
@@ -598,6 +613,7 @@ impl Schema {
     pub fn resolve(&self, ty: &FieldType) -> Resolved<'_> {
         match ty {
             FieldType::Scalar(s) => Resolved::Scalar(*s),
+            FieldType::Any => Resolved::Any,
             FieldType::Ref(r) => Resolved::Record(
                 self.env
                     .get(&r.name)
@@ -621,6 +637,10 @@ impl Schema {
 
     fn conform(&self, cursor: &document::Cursor<'_>, ty: &FieldType, res: &mut ValidationResult) {
         match self.resolve(ty) {
+            // `any` accepts every legal Document value unchecked -- there is
+            // nothing to conform against, mirroring Python's
+            // `_conform`: `if isinstance(d, AnyType): return`.
+            Resolved::Any => {}
             Resolved::Scalar(s) => self.conform_scalar(cursor, s, res),
             Resolved::Record(r) => self.conform_record(cursor, r, res),
         }
@@ -1212,6 +1232,63 @@ mod tests {
     }
 
     // -- FieldType From conversions / Ref, Display --------------------------
+
+    // -- `any` field type: accepts every legal value unchecked ------------
+
+    #[test]
+    fn any_field_accepts_scalars_and_objects_unchecked() {
+        let mut env = Map::new();
+        env.insert(
+            "Root".to_string(),
+            Record::new(vec![Field::required("x", FieldType::Any).unwrap()]).unwrap(),
+        );
+        let schema = Schema::new(Ref::new("Root"), env).unwrap();
+
+        // Not an array here: cardinality (how many times a label occurs) is
+        // checked independently of the field's type, `any` included -- an
+        // array under a `[1,1]` field is still a cardinality violation, not
+        // an `any`-typed acceptance question. See the array/cardinality
+        // case in a separate `[0,]`-cardinality field below.
+        for v in [
+            Value::Str("hi".into()),
+            Value::Int(1),
+            Value::Float(1.5),
+            Value::Bool(true),
+            Value::Null,
+            obj(&[("nested", Value::Int(1))]),
+        ] {
+            let doc = Doc::of(&obj(&[("x", v.clone())])).unwrap();
+            assert!(schema.accepts(&doc.root()), "any field rejected {v:?}");
+        }
+    }
+
+    #[test]
+    fn any_field_with_array_cardinality_accepts_repeated_values_unchecked() {
+        let mut env = Map::new();
+        env.insert(
+            "Root".to_string(),
+            Record::new(vec![Field::new("x", FieldType::Any, 0, None).unwrap()]).unwrap(),
+        );
+        let schema = Schema::new(Ref::new("Root"), env).unwrap();
+        let doc = Doc::of(&obj(&[(
+            "x",
+            Value::Array(vec![Value::Int(1), Value::Str("mixed".into())]),
+        )]))
+        .unwrap();
+        assert!(schema.accepts(&doc.root()));
+    }
+
+    #[test]
+    fn any_resolves_without_touching_env() {
+        let env: Map<String, Record> = Map::new();
+        let schema = Schema::new(Ref::new("Root"), {
+            let mut e = env;
+            e.insert("Root".to_string(), Record::new(vec![]).unwrap());
+            e
+        })
+        .unwrap();
+        assert!(matches!(schema.resolve(&FieldType::Any), Resolved::Any));
+    }
 
     #[test]
     fn field_type_from_conversions() {


### PR DESCRIPTION
## Summary

- Ports the `any` type for real across `schema.rs`, `osd.rs`, and
  `infer.rs`, plus its downstream surface in `materialize.rs` and
  `ops/{signature,subschema,minimize,prune,lint}.rs` -- the three prior
  issues that scoped it out (#6/#8/#14) conflated an unresolved
  long-term governance question ("should `any` be permanent spec")
  with the fact that Python has fully shipped and exercised
  `AnyType`/`ANY`/`allow_any` since v0.5.0.
- Adds `FieldType::Any`/`Resolved::Any` (schema.rs), real `any` keyword
  parsing + a "any? is redundant" error (osd.rs), and
  `infer_with_report`/`AnyFallback` with a working `allow_any` (infer.rs).
  `omnist-cli infer --allow-any` is wired to it instead of erroring.
- Every test that asserted the old scoped-out error behavior was
  **updated to assert the real behavior**, not deleted.
- Cross-checked against live Python (`~/dev/venvs/omnist`) for OSD
  parsing/round-trip, `infer_with_report`'s exact fallback text, and
  `lint`'s `any-field` finding shape. No Python bugs found.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (all green)
- [x] `cargo llvm-cov --workspace --fail-under-lines 100` (100.00% lines)
- [x] Cross-checked OSD `any` parsing/round-trip, `infer_with_report`
      fallback text, and `lint` any-field output against live Python

Closes #29.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
