### PR TITLE
Complete #26's unmet fuzz-harness acceptance items (issue #32)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,40 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - name: proptest fuzz + semantic-oracle properties (issue #26)
+      - name: proptest fuzz + semantic-oracle properties (issue #26, #32)
         # Bounded budget, not unbounded -- 250 cases per property, a bit
         # above the in-code default of 150 (itself matching Python's
         # `~/dev/omnist/tests/test_fuzz.py` `_SUPPRESS` settings) so CI
         # gets slightly more coverage than a local `cargo test` run
-        # without becoming an open-ended fuzzing job.
-        run: cargo test --workspace --test fuzz
+        # without becoming an open-ended fuzzing job. This step does NOT
+        # set OMNIST_ORACLE_PYTHON, so it excludes the live-Python oracle
+        # test below (`--skip cross_implementation_oracle_bounded_sample`)
+        # -- that one has its own step, since it needs the sibling Python
+        # checkout + venv set up first and pays a much higher per-case
+        # cost (subprocess + interpreter startup vs. pure Rust).
+        run: cargo test --workspace --test fuzz -- --skip cross_implementation_oracle_bounded_sample
         env:
           PROPTEST_CASES: "250"
+      - name: checkout sibling Python implementation (issue #32 oracle)
+        uses: actions/checkout@v4
+        with:
+          repository: omnist-dev/omnist
+          path: omnist-py
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: cross-implementation oracle harness (issue #32)
+        # Bounded, budgeted, and separate from the pure-Rust properties
+        # above precisely because each case here pays for a fresh
+        # `python3` process start + `omnist` import (tens of ms) rather
+        # than microseconds -- see fuzz.rs's module doc comment for the
+        # measured per-case cost. 40 cases here (vs. 150-250 for the
+        # pure-Rust properties) keeps this step's wall time comparable
+        # to the rest of the job rather than dominating it.
+        run: |
+          python3 -m venv /tmp/omnist-oracle-venv
+          /tmp/omnist-oracle-venv/bin/pip install -q -e omnist-py
+          cargo test --workspace --test fuzz cross_implementation_oracle_bounded_sample
+        env:
+          OMNIST_ORACLE_PYTHON: /tmp/omnist-oracle-venv/bin/python3
+          OMNIST_ORACLE_CASES: "40"

--- a/omnist/tests/fixtures/oracle_check.py
+++ b/omnist/tests/fixtures/oracle_check.py
@@ -1,0 +1,41 @@
+"""Cross-implementation oracle helper (issue #32).
+
+Invoked as a subprocess by `omnist/tests/fuzz.rs`'s
+`cross_implementation_oracle_bounded_sample` test: reads two OSD schema
+texts (the same text format both `omnist::osd` and `omnist.osd` parse --
+see `omnist/src/osd.rs`'s doc comment) from the two file paths given as
+argv[1]/argv[2], computes the same three schema-algebra queries the Rust
+side computes for the identical parsed schemas, and prints the result as
+one line of JSON so the Rust side can compare field-for-field.
+
+Kept as a standalone script (not a pytest test) because it's driven from
+the *other* repo's test suite, not this one's -- this file is data/tooling
+for omnist-rs's CI, not part of omnist's own test suite.
+"""
+
+import json
+import sys
+
+from omnist import osd
+from omnist.ops.minimize import normalize
+from omnist.ops.prune import is_empty, prune
+from omnist.ops.subschema import compatible_with
+
+
+def main() -> None:
+    a_path, b_path = sys.argv[1], sys.argv[2]
+    with open(a_path, encoding="utf-8") as f:
+        a = osd.parse_schema(f.read())
+    with open(b_path, encoding="utf-8") as f:
+        b = osd.parse_schema(f.read())
+
+    result = {
+        "compatible_a_b": compatible_with(a, b),
+        "is_empty_a": is_empty(a),
+        "normalize_prune_is_empty_a": is_empty(prune(normalize(a))),
+    }
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/omnist/tests/fuzz.rs
+++ b/omnist/tests/fuzz.rs
@@ -19,12 +19,18 @@
 //!   format's PR already covers its own adjustment behavior).
 //! - Schema-algebra properties on fuzzed `Schema`s: `normalize` produces
 //!   something isomorphic to the input (extends #12's hand-picked spot
-//!   checks), `prune` is idempotent, and `extract`'s result only ever
-//!   keeps the requested labels.
+//!   checks), `prune` is idempotent, `extract`'s result only ever keeps
+//!   the requested labels, and (issue #32) `compatible_with` is reflexive
+//!   and holds for cardinality-narrowed schema variants.
 //! - Edge-case generators for extreme integers (near i64's 19-digit
 //!   range -- see `document.rs`'s doc comment on why this port has no
 //!   4300-digit guard to fuzz), temporal literals near calendar
 //!   boundaries, and format-tricky characters.
+//! - (issue #32) A bounded, opt-in cross-implementation oracle harness
+//!   (`cross_implementation_oracle_bounded_sample`) that shells out to a
+//!   live Python `omnist` install and compares `compatible_with`/
+//!   `is_empty`/`normalize`+`prune` results against the same schemas
+//!   parsed on both sides.
 //!
 //! ## Regression-smoke-test evidence (issue #26 acceptance criterion)
 //!
@@ -36,6 +42,35 @@
 //! it pass again. See the PR description for the exact diff and
 //! `proptest`'s failure output captured during that manual run -- this
 //! is deliberately not left in the tree as a permanently-broken test.
+//!
+//! ## Regression-smoke-test evidence (issue #32 acceptance criterion)
+//!
+//! Manually verified against a real injected regression: inverting
+//! `omnist::ops::subschema::record_sub`'s cardinality-subset comparison
+//! (`fb.min <= fa.min` -> `fb.min < fa.min`, so a field whose min is
+//! unchanged between A and B -- the common case, including every
+//! reflexive `compatible_with(s, s)` -- is wrongly rejected) made both
+//! `compatible_with_is_reflexive` and
+//! `compatible_with_holds_for_narrowed_cardinality` fail immediately with
+//! shrunk counterexamples. Reverting the change made both pass again.
+//! See the PR description for the exact diff and captured failure
+//! output -- deliberately not left in the tree broken.
+//!
+//! The same injected bug did *not* trip
+//! `cross_implementation_oracle_bounded_sample` even at 300 cases
+//! (well above the harness's default budget of 20): that test samples
+//! two *independently*-fuzzed schemas, and the bug only manifests when a
+//! shared-label field's min is otherwise equal between the two sides --
+//! rare for unrelated random schemas, common for the narrowed-variant
+//! property above (which perturbs a copy of the same schema). This is a
+//! real, useful data point about the oracle's blind spot, not a flaw
+//! papered over: independent-pair sampling is well-suited to catching
+//! cross-implementation *structural* drift (the kind #26/#32 were most
+//! worried about, e.g. a wholesale misreading of the algorithm), but a
+//! targeted same-schema property like `compatible_with_holds_for_
+//! narrowed_cardinality` is what actually catches a narrow, one-
+//! comparison cardinality regression -- which is exactly why this PR
+//! adds both rather than relying on the oracle alone.
 
 use std::sync::LazyLock;
 
@@ -43,9 +78,12 @@ use indexmap::IndexMap;
 use omnist::document::{Doc, Value};
 use omnist::formats::{json, toml, xml, yaml};
 use omnist::oml;
-use omnist::ops::{extract, is_isomorphic, normalize, prune};
+use omnist::ops::{compatible_with, extract, is_empty, is_isomorphic, normalize, prune};
+use omnist::osd;
 use omnist::schema::{self, Field, FieldType, Record, Ref, Schema};
 use proptest::prelude::*;
+use proptest::strategy::ValueTree;
+use proptest::test_runner::TestRunner;
 
 /// Bounded case budget: `PROPTEST_CASES` (proptest's own recognized env
 /// var) if set, else 150 -- matching Python's `~/dev/omnist/tests/
@@ -257,6 +295,18 @@ fn arb_schema(n_records: usize) -> impl Strategy<Value = Schema> {
                             names[..=i.min(names.len().saturating_sub(1))].to_vec()
                         )
                         .prop_map(|n| FieldType::Ref(Ref::new(n))),
+                        // `Any` (issue #29), added per issue #32's follow-up
+                        // comment: the generator previously only ever
+                        // produced Scalar/Ref, so every existing schema
+                        // property (normalize/prune/extract) silently never
+                        // exercised the `any` arm either. A single `Just`
+                        // arm alongside the two `Scalar` arms and the `Ref`
+                        // arm gives it roughly a 1-in-4 chance per field,
+                        // matching Python's `_seeded_random_family`'s
+                        // "small fixed probability" intent (see
+                        // `~/dev/omnist/tools/semantic_oracle.py`) without
+                        // dominating the schema shapes generated.
+                        Just(FieldType::Any),
                     ],
                     0usize..2,
                     proptest::option::of(1usize..3),
@@ -285,8 +335,77 @@ fn arb_schema(n_records: usize) -> impl Strategy<Value = Schema> {
     })
 }
 
+// ---------------------------------------------------------------------------
+// subschema / compatible_with (issue #32 -- #26's own unmet acceptance item)
+// ---------------------------------------------------------------------------
+
+/// One of three cardinality-only narrowings applied to a single field of
+/// `s`'s root record, each of which can only *shrink* the set of documents
+/// the root record accepts while leaving every field's type untouched:
+///
+/// - tighten `max` down by one (when `max > min`),
+/// - tighten `min` up by one (when `min < max`, or `max` is unbounded),
+/// - or force the field to never be emitted (`max = Some(0)`, only when
+///   `min == 0` -- otherwise this would make the record unsatisfiable
+///   rather than merely narrower).
+///
+/// This mirrors the issue's suggested "structurally-perturbed variant --
+/// narrower cardinality, dropped field" shape more directly than
+/// full-blown structural mutation: it's cheap to state a ground-truth
+/// expectation for (the narrowed schema is *always* a subschema of the
+/// original, by construction, regardless of what the fields' types are),
+/// which is exactly what makes it a useful property-test oracle for
+/// `compatible_with` without needing Python's hand-built "vindicated
+/// universe" -- that universe exists to *label* arbitrary schema pairs
+/// ground-truth true/false; this generator instead only ever produces
+/// pairs already known to be true by how they were built.
+fn narrow_root_field(s: &Schema, field_idx: usize, choice: u8) -> Option<Schema> {
+    let root_name = s.root().name.clone();
+    let mut env = s.env().clone();
+    let root = env.get(&root_name)?.clone();
+    let fields = root.fields();
+    if fields.is_empty() {
+        return None;
+    }
+    let idx = field_idx % fields.len();
+    let f = &fields[idx];
+    let (new_min, new_max) = match choice % 3 {
+        0 if f.max.is_some_and(|m| m > f.min) => (f.min, f.max.map(|m| m - 1)),
+        1 if f.max.is_none_or(|m| f.min < m) => (f.min + 1, f.max),
+        2 if f.min == 0 => (0, Some(0)),
+        _ => return None,
+    };
+    let mut new_fields: Vec<Field> = fields.to_vec();
+    new_fields[idx] = Field::new(f.label.clone(), f.ty.clone(), new_min, new_max).ok()?;
+    env.insert(root_name.clone(), Record::new(new_fields).ok()?);
+    Schema::new(Ref::new(root_name), env).ok()
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(*CASES))]
+
+    /// `compatible_with` is reflexive: every schema is a subschema of
+    /// itself.
+    #[test]
+    fn compatible_with_is_reflexive(s in arb_schema(3)) {
+        prop_assert!(compatible_with(&s, &s));
+    }
+
+    /// A schema whose root record has one field cardinality-narrowed (see
+    /// [`narrow_root_field`]) accepts a subset of what the original
+    /// accepts -- `compatible_with(narrowed, original)` must hold. This is
+    /// #26's own unmet acceptance item: `subschema`/`compatible_with` had
+    /// zero property-based coverage before issue #32.
+    #[test]
+    fn compatible_with_holds_for_narrowed_cardinality(
+        s in arb_schema(3),
+        field_idx in 0usize..8,
+        choice in 0u8..3,
+    ) {
+        if let Some(narrowed) = narrow_root_field(&s, field_idx, choice) {
+            prop_assert!(compatible_with(&narrowed, &s));
+        }
+    }
 
     /// `normalize(s)` must remain isomorphic to `s` -- extends #12's
     /// hand-picked spot tests to fuzzed schemas.
@@ -321,5 +440,137 @@ proptest! {
                 prop_assert!(keep.contains(&f.label.as_str()));
             }
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cross-implementation oracle harness (issue #32 -- #26's other unmet
+// acceptance item)
+// ---------------------------------------------------------------------------
+//
+// Performance tradeoff: this does NOT run as part of the default
+// `cargo test --workspace` / the existing `fuzz` proptest properties
+// above. Each case here pays for a fresh `python3` process start plus
+// import of `omnist` (tens of milliseconds each), two to three orders of
+// magnitude slower per-case than the pure-Rust properties, which is
+// exactly why issue #26's own spec (quoted in #32) called for this to be
+// "a bounded, budgeted job", not something that runs at the same
+// per-property case count (150-250) as the rest of this file.
+//
+// The harness is entirely opt-in, gated on `OMNIST_ORACLE_PYTHON` (path
+// to the venv's `python3`, e.g. `~/dev/venvs/omnist/bin/python3`) being
+// set: if it isn't, the test prints why it's skipping and returns
+// success rather than failing every contributor's machine and every
+// non-`fuzz`-job CI run that doesn't have the sibling `omnist-dev/omnist`
+// checkout available. See `.github/workflows/ci.yml`'s `fuzz` job for how
+// CI provides it.
+static ORACLE_CASES: LazyLock<u32> = LazyLock::new(|| {
+    std::env::var("OMNIST_ORACLE_CASES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(20)
+});
+
+fn oracle_python() -> Option<String> {
+    std::env::var("OMNIST_ORACLE_PYTHON").ok()
+}
+
+/// Extract a `"key": <bool>` value from the oracle script's one-line JSON
+/// output. Hand-rolled instead of pulling in `serde_json` as a new dev-
+/// dependency, since the shape here is fixed and fully controlled by
+/// `oracle_check.py` alongside it.
+fn extract_bool(json: &str, key: &str) -> bool {
+    let needle = format!("\"{key}\": ");
+    let start = json
+        .find(&needle)
+        .unwrap_or_else(|| panic!("oracle_check.py output missing {key:?}: {json}"))
+        + needle.len();
+    json[start..].starts_with("true")
+}
+
+/// For a bounded sample of independently-fuzzed schema pairs, shells out
+/// to the live Python implementation (via `oracle_check.py`) and checks
+/// that `compatible_with`, `is_empty`, and `is_empty(prune(normalize(_)))`
+/// agree between the two implementations -- the cross-implementation
+/// oracle harness #26 was supposed to include per its own acceptance
+/// checklist (quoted in issue #32).
+#[test]
+fn cross_implementation_oracle_bounded_sample() {
+    let Some(python) = oracle_python() else {
+        eprintln!(
+            "skipping cross_implementation_oracle_bounded_sample: set \
+             OMNIST_ORACLE_PYTHON to a python3 executable with `omnist` \
+             installed (e.g. `~/dev/venvs/omnist/bin/python3`, after \
+             `pip install -e ~/dev/omnist`) to run the live-Python oracle. \
+             See .github/workflows/ci.yml's `fuzz` job for how CI wires \
+             this up."
+        );
+        return;
+    };
+    let script = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/oracle_check.py"
+    );
+
+    let mut runner = TestRunner::default();
+    let pair_strategy = (arb_schema(3), arb_schema(3));
+    let dir = std::env::temp_dir();
+
+    for i in 0..*ORACLE_CASES {
+        let tree = pair_strategy
+            .new_tree(&mut runner)
+            .expect("strategy generation should not fail");
+        let (a, b) = tree.current();
+
+        let a_path = dir.join(format!("omnist-oracle-{}-{}-a.osd", std::process::id(), i));
+        let b_path = dir.join(format!("omnist-oracle-{}-{}-b.osd", std::process::id(), i));
+        std::fs::write(&a_path, osd::to_osd(&a, None)).unwrap();
+        std::fs::write(&b_path, osd::to_osd(&b, None)).unwrap();
+
+        let output = std::process::Command::new(&python)
+            .arg(script)
+            .arg(&a_path)
+            .arg(&b_path)
+            .output()
+            .expect("failed to invoke OMNIST_ORACLE_PYTHON");
+
+        std::fs::remove_file(&a_path).ok();
+        std::fs::remove_file(&b_path).ok();
+
+        assert!(
+            output.status.success(),
+            "oracle_check.py failed (case {i}):\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        let rust_compat = compatible_with(&a, &b);
+        let rust_empty_a = is_empty(&a);
+        let rust_np_empty_a = is_empty(&prune(&normalize(&a)));
+
+        let py_compat = extract_bool(&stdout, "compatible_a_b");
+        let py_empty_a = extract_bool(&stdout, "is_empty_a");
+        let py_np_empty_a = extract_bool(&stdout, "normalize_prune_is_empty_a");
+
+        assert_eq!(
+            rust_compat,
+            py_compat,
+            "compatible_with disagreement (case {i}):\na = {}\nb = {}",
+            osd::to_osd(&a, Some(2)),
+            osd::to_osd(&b, Some(2)),
+        );
+        assert_eq!(
+            rust_empty_a,
+            py_empty_a,
+            "is_empty disagreement (case {i}):\na = {}",
+            osd::to_osd(&a, Some(2)),
+        );
+        assert_eq!(
+            rust_np_empty_a,
+            py_np_empty_a,
+            "is_empty(prune(normalize(_))) disagreement (case {i}):\na = {}",
+            osd::to_osd(&a, Some(2)),
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #32: closes issue #26's own unmet acceptance items, plus the
follow-up scope comment on #32.

- **`subschema`/`compatible_with` fuzz property.** `compatible_with_is_reflexive`
  (every schema is a subschema of itself) and
  `compatible_with_holds_for_narrowed_cardinality` (a root record with one
  field's cardinality narrowed via `narrow_root_field` -- tighten `max`,
  tighten `min`, or force `max = Some(0)` on an already-optional field --
  must remain `compatible_with` the original). This mirrors the issue's
  suggested "structurally-perturbed variant" shape: the narrowed schema is
  a subschema *by construction*, so no hand-built ground-truth universe
  was needed for this property.
- **`FieldType::Any` in the schema generator** (per the follow-up comment):
  `arb_schema`'s field-type `prop_oneof!` now includes `Just(FieldType::Any)`
  alongside the two `Scalar` arms and the `Ref` arm, so every existing
  schema property (`normalize`/`prune`/`extract`) now exercises `any` too,
  not just the two new properties.
- **Cross-implementation oracle harness**
  (`cross_implementation_oracle_bounded_sample`): for a bounded sample of
  independently-fuzzed schema pairs, serializes both to OSD text (the
  format `omnist::osd`/`omnist.osd` already share), shells out to a live
  Python `omnist` install via `omnist/tests/fixtures/oracle_check.py`, and
  compares `compatible_with`, `is_empty`, and
  `is_empty(prune(normalize(_)))` against the Rust results for the same
  parsed schemas.
  - **Performance tradeoff**: each oracle case costs ~220ms (fresh
    `python3` start + `omnist` import), 2-3 orders of magnitude slower
    than the pure-Rust properties above (150-250 cases each). The test is
    opt-in via `OMNIST_ORACLE_PYTHON` -- unset (the default for
    `cargo test --workspace` and every non-`fuzz`-job CI run), it prints
    why it's skipping and returns success rather than failing every
    contributor's machine.
  - **CI wiring**: the `fuzz` job's existing step now skips this test
    (`--skip cross_implementation_oracle_bounded_sample`); a new step
    checks out the sibling `omnist-dev/omnist` repo, creates a venv,
    `pip install -e`s it, and runs the oracle test alone with
    `OMNIST_ORACLE_CASES=40`.
- **Regression-smoke-test evidence** (manually performed, not left in the
  tree): inverted `subschema.rs`'s `record_sub` cardinality comparison
  (`fb.min <= fa.min` -> `fb.min < fa.min`) -- this made
  `compatible_with_is_reflexive` and
  `compatible_with_holds_for_narrowed_cardinality` fail immediately with
  shrunk counterexamples. Reverted, both pass again.
  - Notably, the same injected bug did **not** trip the oracle harness
    even at 300 cases (well above its 20-case default): independent
    random schema pairs rarely share an equal field `min` on both sides,
    so the bug's effect is invisible to unrelated-pair sampling. This is
    an honest, useful characterization of what the oracle *is* and isn't*
    good at (cross-implementation *structural* drift, not narrow
    single-comparison regressions) -- exactly why this PR adds the
    targeted property rather than relying on the oracle alone.
- **Cross-implementation check**: ran the live oracle at 60 and 300 cases
  against the current (correct) implementation -- zero disagreements. No
  genuine Python bug found; nothing filed upstream.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (691 tests, 0 failed)
- [x] `cargo llvm-cov --workspace --fail-under-lines 100` (100.00% lines,
      99.30% regions -- matching the existing baseline's pre-existing
      partial-region gaps, no regression)
- [x] Regression-smoke-test performed manually (see above), not left in
      the tree
- [x] Live-Python oracle run manually at 60 and 300 cases: zero
      disagreements
