### PR TITLE
Fix float >= 1e17 round-tripping back as an integer (json/yaml/toml/xml)

### DIFF
--- a/omnist/src/formats/json.rs
+++ b/omnist/src/formats/json.rs
@@ -243,12 +243,23 @@ fn write_float(x: f64, out: &mut String) {
         out.push_str("NaN");
     } else if x.is_infinite() {
         out.push_str(if x > 0.0 { "Infinity" } else { "-Infinity" });
-    } else if x == x.trunc() && x.is_finite() && x.abs() < 1e17 {
-        // Match `json.dumps`'s float rendering of an integral value, e.g.
-        // `1.0` (not `1`) -- `repr(1.0) == "1.0"` in Python.
-        out.push_str(&format!("{x:.1}"));
     } else {
-        out.push_str(&x.to_string());
+        // Match `json.dumps`'s float rendering of an integral value, e.g.
+        // `1.0` (not `1`) -- `repr(1.0) == "1.0"` in Python. Rust's `f64`
+        // `Display` never adds a decimal point on its own -- and for large
+        // enough integral magnitudes (>= 1e17) it renders a bare digit run
+        // with no `.`/`e`/`E` at all, e.g. `1e17.to_string() ==
+        // "100000000000000000"` -- so the correct, magnitude-independent
+        // test is whether the *rendered string* already contains one of
+        // those markers, not whether `x` is below some fixed cutoff (see
+        // `oml.rs::write_float`, the reference implementation this mirrors).
+        let s = x.to_string();
+        if s.contains('.') || s.contains('e') || s.contains('E') {
+            out.push_str(&s);
+        } else {
+            out.push_str(&s);
+            out.push_str(".0");
+        }
     }
 }
 
@@ -1070,6 +1081,25 @@ mod tests {
         let text = write_json(&doc, None, false, None).unwrap();
         let back = read_json(&text).unwrap();
         assert!(doc.eq_doc(&back));
+    }
+
+    #[test]
+    fn round_trips_integral_float_at_and_above_1e17_boundary_issue_46() {
+        // Regression test for issue #46: an integral-valued float >= 1e17
+        // used to render as a bare digit run (Rust's `f64::to_string()`
+        // drops the decimal point up there), which `read_json` then
+        // re-read as `Scalar::Int` -- silently changing the scalar's type
+        // across a round trip.
+        for x in [1.0e17, 1.0e18, -1.23e17, 9.9e16_f64] {
+            let doc = doc_of(obj(vec![("a", Value::Float(x))]));
+            let text = write_json(&doc, None, false, None).unwrap();
+            let back = read_json(&text).unwrap();
+            assert_eq!(
+                *back.root().get_one("a").unwrap().value().unwrap(),
+                Scalar::Float(x),
+                "x={x} text={text}"
+            );
+        }
     }
 
     #[test]

--- a/omnist/src/formats/toml.rs
+++ b/omnist/src/formats/toml.rs
@@ -546,10 +546,18 @@ fn write_float(x: f64, out: &mut String) {
         out.push_str("nan");
     } else if x.is_infinite() {
         out.push_str(if x > 0.0 { "inf" } else { "-inf" });
-    } else if x == x.trunc() && x.is_finite() && x.abs() < 1e17 {
-        out.push_str(&format!("{x:.1}"));
     } else {
-        out.push_str(&x.to_string());
+        // See `json.rs::write_float` for why this checks the rendered
+        // string for `.`/`e`/`E` rather than comparing `x` against a fixed
+        // magnitude cutoff (issue #46: Rust's `f64::to_string()` drops the
+        // decimal point for integral values >= 1e17).
+        let s = x.to_string();
+        if s.contains('.') || s.contains('e') || s.contains('E') {
+            out.push_str(&s);
+        } else {
+            out.push_str(&s);
+            out.push_str(".0");
+        }
     }
 }
 
@@ -816,6 +824,23 @@ mod tests {
             *root.get_one("e").unwrap().value().unwrap(),
             Scalar::Bool(false)
         );
+    }
+
+    #[test]
+    fn round_trips_integral_float_at_and_above_1e17_boundary_issue_46() {
+        // Regression test for issue #46 (see json.rs's twin test for the
+        // full explanation): an integral-valued float >= 1e17 used to
+        // render as a bare digit run and re-read as `Scalar::Int`.
+        for x in [1.0e17, 1.0e18, -1.23e17, 9.9e16_f64] {
+            let doc = doc_of(obj(vec![("a", Value::Float(x))]));
+            let text = write_toml(&doc, false, None).unwrap();
+            let back = read_toml(&text).unwrap();
+            assert_eq!(
+                *back.root().get_one("a").unwrap().value().unwrap(),
+                Scalar::Float(x),
+                "x={x} text={text}"
+            );
+        }
     }
 
     #[test]

--- a/omnist/src/formats/xml.rs
+++ b/omnist/src/formats/xml.rs
@@ -648,19 +648,28 @@ fn xml_text(scalar: &Scalar) -> String {
 }
 
 /// Same float-formatting convention as `toml.rs`'s `write_float`: `nan`/
-/// `inf`/`-inf` lowercase for special values, an explicit `.0` for an
-/// integral finite value (matching Python's `str(float)`, which Rust's
-/// bare `{}` formatter does not add on its own), default `Display`
-/// otherwise.
+/// `inf`/`-inf` lowercase for special values, an explicit `.0` appended
+/// whenever the default `Display` rendering doesn't already contain a
+/// `.`/`e`/`E` marker (matching Python's `str(float)`, which always emits
+/// one of those markers; Rust's bare `{}` formatter does not, and for
+/// integral values >= 1e17 it doesn't even include a decimal point -- see
+/// issue #46).
 fn write_float_text(x: f64) -> String {
     if x.is_nan() {
         "nan".to_string()
     } else if x.is_infinite() {
         if x > 0.0 { "inf" } else { "-inf" }.to_string()
-    } else if x == x.trunc() && x.is_finite() && x.abs() < 1e17 {
-        format!("{x:.1}")
     } else {
-        x.to_string()
+        // See `json.rs::write_float` for why this checks the rendered
+        // string for `.`/`e`/`E` rather than comparing `x` against a fixed
+        // magnitude cutoff (issue #46: Rust's `f64::to_string()` drops the
+        // decimal point for integral values >= 1e17).
+        let s = x.to_string();
+        if s.contains('.') || s.contains('e') || s.contains('E') {
+            s
+        } else {
+            format!("{s}.0")
+        }
     }
 }
 

--- a/omnist/src/formats/xml/tests.rs
+++ b/omnist/src/formats/xml/tests.rs
@@ -560,6 +560,19 @@ fn float_integral_value_gets_a_decimal_point() {
 }
 
 #[test]
+fn round_trips_integral_float_at_and_above_1e17_boundary_issue_46() {
+    // Regression test for issue #46: an integral-valued float >= 1e17 used
+    // to render as a bare digit run, which `coerce()` then re-read via
+    // `try_parse_int` as `Scalar::Int` instead of `Scalar::Float`.
+    for x in [1.0e17, 1.0e18, -1.23e17, 9.9e16_f64] {
+        let doc = Doc::from_raw(edges(vec![("root", RawNode::Leaf(Scalar::Float(x)))])).unwrap();
+        let text = write_xml(&doc, false, None).unwrap();
+        let back = read_xml(&text).unwrap();
+        assert!(doc.eq_doc(&back), "x={x} text={text}");
+    }
+}
+
+#[test]
 fn nan_and_infinity_round_trip() {
     let doc = Doc::from_raw(edges(vec![(
         "root",

--- a/omnist/src/formats/yaml.rs
+++ b/omnist/src/formats/yaml.rs
@@ -859,10 +859,18 @@ fn write_float(x: f64, out: &mut String) {
         out.push_str(".nan");
     } else if x.is_infinite() {
         out.push_str(if x > 0.0 { ".inf" } else { "-.inf" });
-    } else if x == x.trunc() && x.is_finite() && x.abs() < 1e17 {
-        out.push_str(&format!("{x:.1}"));
     } else {
-        out.push_str(&x.to_string());
+        // See `json.rs::write_float` for why this checks the rendered
+        // string for `.`/`e`/`E` rather than comparing `x` against a fixed
+        // magnitude cutoff (issue #46: Rust's `f64::to_string()` drops the
+        // decimal point for integral values >= 1e17).
+        let s = x.to_string();
+        if s.contains('.') || s.contains('e') || s.contains('E') {
+            out.push_str(&s);
+        } else {
+            out.push_str(&s);
+            out.push_str(".0");
+        }
     }
 }
 
@@ -1509,6 +1517,23 @@ mod tests {
         let text = write_yaml(&doc, false, None).unwrap();
         let back = read_yaml(&text).unwrap();
         assert!(doc.eq_doc(&back));
+    }
+
+    #[test]
+    fn round_trips_integral_float_at_and_above_1e17_boundary_issue_46() {
+        // Regression test for issue #46 (see json.rs's twin test for the
+        // full explanation): an integral-valued float >= 1e17 used to
+        // render as a bare digit run and re-read as `Scalar::Int`.
+        for x in [1.0e17, 1.0e18, -1.23e17, 9.9e16_f64] {
+            let doc = doc_of(obj(vec![("a", Value::Float(x))]));
+            let text = write_yaml(&doc, false, None).unwrap();
+            let back = read_yaml(&text).unwrap();
+            assert_eq!(
+                *back.root().get_one("a").unwrap().value().unwrap(),
+                Scalar::Float(x),
+                "x={x} text={text}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- All four format writers (`json.rs`, `yaml.rs`, `toml.rs`, `xml.rs`) guarded their "keep the decimal point so it round-trips as a float" logic with `x.abs() < 1e17`. Above that magnitude, Rust's `f64` Display renders an integral value as a bare digit run (no `.`/`e`/`E`), so the written text re-parsed as `Scalar::Int` on read-back -- a silent, lossy round-trip type change.
- Replaced the magnitude-based cutoff in all four writers with the same rendered-string inspection `oml.rs::write_float` already used correctly: render the float, check whether the string already contains `.`/`e`/`E`, and append `.0` only if it doesn't.
- Added a regression test per format asserting `Scalar::Float` values at `1e17`, `1e18`, `-1.23e17`, and `9.9e16` (just under the old cutoff, confirming no regression) round-trip as `Scalar::Float`, not `Int`.

## Cross-check against Python

Confirmed live that Python does **not** have this bug class: `repr(1e17)` / `json.dumps(1e17)` always emit `1e+17` (an `e` marker), because Python's `float.__repr__` guarantees a `.`/`e` marker regardless of magnitude, unlike Rust's `f64::to_string()`. No upstream issue filed -- this is a Rust-port-specific bug, not a ported one.

## Verification (freshly run)

- `cargo fmt --all -- --check` -- clean
- `cargo clippy --workspace --all-targets -- -D warnings` -- clean
- `cargo test --workspace` -- all passing (unit + `cli.rs` 99 + `doc_cli.rs` 2 + fuzz/round-trip suites)
- `cargo llvm-cov --workspace --fail-under-lines 100` -- 100.00% line coverage maintained across every crate/file (TOTAL: 7882/7882 lines, 845/845 functions)

Closes #46

## Test plan

- [x] Red-before-green: confirmed `1.0e17` round-tripped as `Scalar::Int` before the fix
- [x] Fix applied to json/yaml/toml/xml writers
- [x] Regression tests added and passing for all four formats
- [x] Boundary case (9.9e16, just under old cutoff) still correct
- [x] Full workspace test suite green
- [x] 100% line coverage maintained
