### PR TITLE
Fix flaky registry test via per-test unique format names

### DIFF
--- a/omnist/src/registry/tests.rs
+++ b/omnist/src/registry/tests.rs
@@ -142,43 +142,57 @@ fn lines_write(doc: &Doc) -> Result<String, OmnistError> {
 
 #[test]
 fn register_a_plugin_and_use_it_via_doc() {
-    register_format(Format::new("lines", lines_read, lines_write));
+    // Registry-mutating tests each use a name unique to themselves (rather
+    // than a shared literal like "lines") so they can't collide with each
+    // other regardless of execution order under parallel test threads --
+    // the global registry (see `registry.rs`'s module doc: "this crate's
+    // only piece of global mutable state") is process-wide, so two tests
+    // registering the same name concurrently can otherwise observe each
+    // other's writes (issue #58).
+    let name = "lines-register_a_plugin_and_use_it_via_doc";
+    register_format(Format::new(name, lines_read, lines_write));
 
-    assert!(formats().contains(&"lines".to_string()));
-    let d = Doc::from_format("lines", "1 2 3").unwrap();
-    assert_eq!(d.to_format("lines").unwrap(), "1 2 3");
+    assert!(formats().contains(&name.to_string()));
+    let d = Doc::from_format(name, "1 2 3").unwrap();
+    assert_eq!(d.to_format(name).unwrap(), "1 2 3");
 }
 
 #[test]
 fn plugin_without_check_errors_cleanly_on_check_format() {
-    register_format(Format::new("nocheck", lines_read, lines_write));
+    let name = "nocheck-plugin_without_check_errors_cleanly_on_check_format";
+    register_format(Format::new(name, lines_read, lines_write));
 
-    let d = Doc::from_format("nocheck", "1 2 3").unwrap();
-    let err = d.check_format("nocheck").unwrap_err();
+    let d = Doc::from_format(name, "1 2 3").unwrap();
+    let err = d.check_format(name).unwrap_err();
     assert!(matches!(err, OmnistError::Document(_)));
     assert!(err.to_string().contains("has no check"));
 }
 
 #[test]
 fn plugin_replaces_earlier_registration_of_the_same_name() {
-    // register_format is "register (or replace)" -- registering "lines"
-    // again under a writer that always emits a fixed string confirms the
-    // second registration wins, matching Python's plain-dict-assignment
-    // semantics (`_REGISTRY[fmt.name] = fmt`).
-    register_format(Format::new("lines", lines_read, lines_write));
-    register_format(Format::new("lines", lines_read, |_doc| {
+    // register_format is "register (or replace)" -- registering the same
+    // name again under a writer that always emits a fixed string confirms
+    // the second registration wins, matching Python's plain-dict-assignment
+    // semantics (`_REGISTRY[fmt.name] = fmt`). The name itself is unique to
+    // this test (see comment on `register_a_plugin_and_use_it_via_doc`)
+    // since what's under test is same-name replacement *within* one test,
+    // not a fixed shared name across tests.
+    let name = "lines-plugin_replaces_earlier_registration_of_the_same_name";
+    register_format(Format::new(name, lines_read, lines_write));
+    register_format(Format::new(name, lines_read, |_doc| {
         Ok("replaced".to_string())
     }));
-    let d = Doc::from_format("lines", "1 2 3").unwrap();
-    assert_eq!(d.to_format("lines").unwrap(), "replaced");
+    let d = Doc::from_format(name, "1 2 3").unwrap();
+    assert_eq!(d.to_format(name).unwrap(), "replaced");
 }
 
 #[test]
 fn plugin_with_check_is_usable_via_check_format() {
+    let name = "withcheck-plugin_with_check_is_usable_via_check_format";
     register_format(
-        Format::new("withcheck", lines_read, lines_write)
+        Format::new(name, lines_read, lines_write)
             .with_check(|_doc| crate::report::WriteReport::new()),
     );
-    let d = Doc::from_format("withcheck", "1 2 3").unwrap();
-    assert!(d.check_format("withcheck").unwrap().is_ok());
+    let d = Doc::from_format(name, "1 2 3").unwrap();
+    assert!(d.check_format(name).unwrap().is_ok());
 }


### PR DESCRIPTION
## Root cause

`register_a_plugin_and_use_it_via_doc` and
`plugin_replaces_earlier_registration_of_the_same_name` (`omnist/src/registry/tests.rs`)
both registered a format under the shared literal name `"lines"` against the
process-wide registry singleton (`OnceLock<RwLock<IndexMap<...>>>`, issue #31 / PR #35).
Under parallel test threads, one test's registration/write could interleave
with the other's, producing a `"replaced"` vs `"1 2 3"` mismatch.

Confirmed with a 100-iteration stress loop at `--test-threads=4`: ~2-3% flake
rate, alternating which of the two tests failed. 30 iterations at
`--test-threads=1` passed every time, matching the issue's report.

## Fix

Test isolation via unique names, not serialization: every registry-mutating
test in `registry/tests.rs` now derives its format name from its own test
name (e.g. `"lines-register_a_plugin_and_use_it_via_doc"`), so tests can't
collide regardless of execution order. No test-only mutex needed — this
scales cleanly if more registry tests are added later.

## Verification

- 300 iterations of the registry test module alone at `--test-threads=4`: 0 failures.
- 10 full `cargo test --workspace` runs under default parallel threading: 0 failures.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo llvm-cov --workspace --fail-under-lines 100`: 100.00% lines (8006/8006), exit 0.

Closes #58
