### PR TITLE
Document safe-by-construction unwraps in osd.rs and yaml.rs (issue #45)

### DIFF
--- a/omnist/src/formats/yaml.rs
+++ b/omnist/src/formats/yaml.rs
@@ -1028,6 +1028,9 @@ fn needs_quoting(s: &str) -> bool {
     } else {
         return true; // would be re-read as null/bool/int/float/timestamp
     }
+    // `s` is guaranteed non-empty here: the early return at line 1021-1023
+    // already handles `s.is_empty()`, so `.chars().next()` always yields a
+    // char.
     let first = s.chars().next().unwrap();
     if matches!(
         first,

--- a/omnist/src/osd.rs
+++ b/omnist/src/osd.rs
@@ -80,6 +80,12 @@ fn tokenize(text: &str) -> Result<Vec<Tok>, SchemaError> {
     let mut i = 0usize;
     while i < text.len() {
         let Some(m) = TOKEN_RE.captures(&text[i..]) else {
+            // `i` is always either `0` or a previous iteration's
+            // `whole.len()` -- a match length reported by the `regex`
+            // crate against `&str` input -- so it always lands on a char
+            // boundary. `text[i..]` can't panic here, and `.chars().next()`
+            // always yields a char (the loop guard `i < text.len()` rules
+            // out an empty remainder).
             let ch = text[i..].chars().next().unwrap();
             return Err(SchemaError::new(format!(
                 "unexpected character {ch:?} at {i}"
@@ -89,6 +95,9 @@ fn tokenize(text: &str) -> Result<Vec<Tok>, SchemaError> {
         // characters at `i` didn't match any alternative.
         let whole = m.get(0).unwrap();
         if whole.start() != 0 {
+            // Same char-boundary invariant as above: `i` hasn't changed
+            // since the last successful match (or loop start), so it's
+            // still a valid boundary and the slice/next() can't fail.
             let ch = text[i..].chars().next().unwrap();
             return Err(SchemaError::new(format!(
                 "unexpected character {ch:?} at {i}"


### PR DESCRIPTION
## Summary

Bundled, low-severity docs-only follow-up from the security audit (#37), tracked in #45.

Adds one-line invariant comments above two previously undocumented-but-safe `.unwrap()` sites:

- `omnist/src/osd.rs` (tokenizer, both unrecognized-character branches): `i` only ever advances by a previous regex match's `whole.len()` (or starts at `0`), so it's always a char boundary -- `text[i..]` can't panic and `.chars().next()` always yields a char.
- `omnist/src/formats/yaml.rs` (`needs_quoting`): the function returns early for `s.is_empty()`, so by the time `s.chars().next().unwrap()` runs, `s` is guaranteed non-empty.

Both invariants were re-verified while writing the comments (not just copied from the audit) and confirmed to hold. No behavior change; no new tests needed per the issue's acceptance criteria.

Closes #45

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (all passing)
- [x] `cargo llvm-cov --workspace --fail-under-lines 100` (100.00% lines)
