### PR TITLE
Refactor: one int_cap module for the 4300-digit guard

### DIFF
--- a/omnist/src/formats/int_cap.rs
+++ b/omnist/src/formats/int_cap.rs
@@ -1,0 +1,84 @@
+//! Shared digit-cap guard for integer literals, factored out of
+//! `oml.rs`, `formats/json.rs`, `formats/toml.rs`, and `formats/yaml.rs`
+//! (issue #49) -- those four modules each declared their own copy of
+//! `MAX_INT_DIGITS` and hand-spelled the same two-tier error-message pair,
+//! with each file's comment explicitly noting it was a copy of the others.
+//!
+//! This is a pure refactor: no observable behavior change. The per-format
+//! *findings* documented in each module's own doc comment (provenance,
+//! divergences from Python, etc.) stay where they are -- only the constant
+//! and the two message constructors move here.
+//!
+//! The one wrinkle: `json.rs` (via `oml.rs`-style `error_at`) does not
+//! embed a format-name prefix in its message text, while `toml.rs` and
+//! `yaml.rs` embed `"invalid TOML: "`/`"invalid YAML: "` inline. Both
+//! constructors below take that prefix as a parameter -- pass `""` to
+//! reproduce the unprefixed form -- so every call site's produced string
+//! is byte-identical to what it emitted before this refactor.
+
+/// Same guard, same constant, previously copied into `oml.rs`,
+/// `formats/json.rs`, `formats/toml.rs`, and `formats/yaml.rs` -- see
+/// issue #49. Provenance: omnist-ts#54, CPython's
+/// `sys.set_int_max_str_digits`.
+pub(crate) const MAX_INT_DIGITS: usize = 4300;
+
+/// The digit-cap rejection message, spelled identically for every format
+/// modulo each format's own error-prefix convention.
+///
+/// `prefix` is prepended verbatim -- pass `""` for formats (OML, JSON) that
+/// don't embed a format-name prefix in this message, or `"invalid TOML: "`/
+/// `"invalid YAML: "` for the formats that do.
+pub(crate) fn over_cap_message(prefix: &str, digit_count: usize) -> String {
+    format!(
+        "{prefix}integer literal has {digit_count} digits, exceeding the {MAX_INT_DIGITS}-digit \
+         limit (security: unbounded-digit int-to-str conversion is superlinear)"
+    )
+}
+
+/// The "fits the cap but not an `i64`" message, spelled identically for
+/// every format modulo each format's own error-prefix convention.
+///
+/// `prefix` is prepended verbatim, same convention as [`over_cap_message`].
+pub(crate) fn out_of_range_message(prefix: &str, literal: &str) -> String {
+    format!("{prefix}integer literal {literal:?} is out of range for a 64-bit integer")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn over_cap_message_no_prefix() {
+        assert_eq!(
+            over_cap_message("", 4301),
+            "integer literal has 4301 digits, exceeding the 4300-digit limit (security: \
+             unbounded-digit int-to-str conversion is superlinear)"
+        );
+    }
+
+    #[test]
+    fn over_cap_message_with_prefix() {
+        assert_eq!(
+            over_cap_message("invalid TOML: ", 4301),
+            "invalid TOML: integer literal has 4301 digits, exceeding the 4300-digit limit \
+             (security: unbounded-digit int-to-str conversion is superlinear)"
+        );
+    }
+
+    #[test]
+    fn out_of_range_message_no_prefix() {
+        assert_eq!(
+            out_of_range_message("", "99999999999999999999"),
+            "integer literal \"99999999999999999999\" is out of range for a 64-bit integer"
+        );
+    }
+
+    #[test]
+    fn out_of_range_message_with_prefix() {
+        assert_eq!(
+            out_of_range_message("invalid YAML: ", "99999999999999999999"),
+            "invalid YAML: integer literal \"99999999999999999999\" is out of range for a \
+             64-bit integer"
+        );
+    }
+}

--- a/omnist/src/formats/json.rs
+++ b/omnist/src/formats/json.rs
@@ -46,12 +46,13 @@
 use crate::WriteError;
 use crate::document::{Doc, Value};
 use crate::error::{OmnistError, ParseError};
+use crate::formats::int_cap::{MAX_INT_DIGITS, out_of_range_message, over_cap_message};
 use crate::report::{Severity, WriteReport};
 use indexmap::IndexMap;
 
-/// Same guard, same constant as `oml.rs`'s `MAX_INT_DIGITS` -- see this
-/// module's doc comment.
-const MAX_INT_DIGITS: usize = 4300;
+// Same guard, same constant as `oml.rs`'s -- see this module's doc
+// comment. Constant and message constructors now live in
+// [`crate::formats::int_cap`] (issue #49).
 
 /// Parse JSON text into a [`Doc`].
 ///
@@ -637,21 +638,11 @@ impl Parser {
         } else {
             let digits = &text[if text.starts_with('-') { 1 } else { 0 }..];
             if digits.len() > MAX_INT_DIGITS {
-                return Err(self.error_at(
-                    start,
-                    format!(
-                        "integer literal has {} digits, exceeding the {MAX_INT_DIGITS}-digit \
-                         limit (security: unbounded-digit int-to-str conversion is superlinear)",
-                        digits.len()
-                    ),
-                ));
+                return Err(self.error_at(start, over_cap_message("", digits.len())));
             }
             match text.parse::<i64>() {
                 Ok(v) => Ok(Value::Int(v)),
-                Err(_) => Err(self.error_at(
-                    start,
-                    format!("integer literal {text:?} is out of range for a 64-bit integer"),
-                )),
+                Err(_) => Err(self.error_at(start, out_of_range_message("", &text))),
             }
         }
     }

--- a/omnist/src/formats/mod.rs
+++ b/omnist/src/formats/mod.rs
@@ -13,6 +13,7 @@
 //! [`yaml`]; issue #20 added [`toml`]; issue #22 adds [`xml`], the last and
 //! structurally different one -- see `xml.rs`'s own doc comment.
 
+pub(crate) mod int_cap;
 pub mod json;
 pub mod toml;
 pub mod xml;

--- a/omnist/src/formats/toml.rs
+++ b/omnist/src/formats/toml.rs
@@ -207,14 +207,15 @@
 use crate::WriteError;
 use crate::document::{Doc, Value};
 use crate::error::{OmnistError, ParseError};
+use crate::formats::int_cap::{MAX_INT_DIGITS, out_of_range_message, over_cap_message};
 use crate::report::{Severity, WriteReport};
 use crate::schema::{is_iso_date, is_iso_datetime, is_iso_time};
 use indexmap::IndexMap;
 use toml_edit::{Item, TableLike};
 
-/// Same guard, same constant as `json.rs`'s/`yaml.rs`'s `MAX_INT_DIGITS` --
-/// see this module's doc comment.
-const MAX_INT_DIGITS: usize = 4300;
+// Same guard, same constant as `json.rs`'s/`yaml.rs`'s -- see this
+// module's doc comment. Constant and message constructors now live in
+// [`crate::formats::int_cap`] (issue #49).
 
 // ============================================================== Reader
 
@@ -274,21 +275,9 @@ fn toml_overflow_error(text: &str, span: std::ops::Range<usize>) -> ParseError {
         .trim_start_matches("0X")
         .len();
     if digit_count > MAX_INT_DIGITS {
-        return ParseError::new(
-            line,
-            col,
-            format!(
-                "invalid TOML: integer literal has {digit_count} digits, exceeding the \
-                 {MAX_INT_DIGITS}-digit limit (security: unbounded-digit int-to-str \
-                 conversion is superlinear)",
-            ),
-        );
+        return ParseError::new(line, col, over_cap_message("invalid TOML: ", digit_count));
     }
-    ParseError::new(
-        line,
-        col,
-        format!("invalid TOML: integer literal {raw:?} is out of range for a 64-bit integer"),
-    )
+    ParseError::new(line, col, out_of_range_message("invalid TOML: ", raw))
 }
 
 /// 1-based (line, column) of byte offset `pos` in `text`.

--- a/omnist/src/formats/yaml.rs
+++ b/omnist/src/formats/yaml.rs
@@ -97,12 +97,13 @@ use yaml_rust2::scanner::{Marker, ScanError, TScalarStyle};
 use crate::WriteError;
 use crate::document::{Doc, Value};
 use crate::error::{OmnistError, ParseError};
+use crate::formats::int_cap::{MAX_INT_DIGITS, out_of_range_message, over_cap_message};
 use crate::report::{Severity, WriteReport};
 use indexmap::IndexMap;
 
-/// Same guard, same constant as `json.rs`'s/`oml.rs`'s `MAX_INT_DIGITS` -- see
-/// this module's doc comment.
-const MAX_INT_DIGITS: usize = 4300;
+// Same guard, same constant as `json.rs`'s/`oml.rs`'s -- see this
+// module's doc comment. Constant and message constructors now live in
+// [`crate::formats::int_cap`] (issue #49).
 
 /// Bound on the total number of [`Raw`] tree nodes materialized while
 /// rebuilding the event stream (issue #42, "YAML alias/anchor expansion
@@ -631,12 +632,7 @@ fn parse_int_literal(text: &str) -> Result<Value, ParseError> {
         return Err(ParseError::new(
             1,
             1,
-            format!(
-                "invalid YAML: integer literal has {} digits, exceeding the \
-                 {MAX_INT_DIGITS}-digit limit (security: unbounded-digit int-to-str \
-                 conversion is superlinear)",
-                digits.len()
-            ),
+            over_cap_message("invalid YAML: ", digits.len()),
         ));
     }
     // Parse the unsigned magnitude first, then apply the sign -- issue #26's
@@ -655,9 +651,7 @@ fn parse_int_literal(text: &str) -> Result<Value, ParseError> {
             return Err(ParseError::new(
                 1,
                 1,
-                format!(
-                    "invalid YAML: integer literal {text:?} is out of range for a 64-bit integer"
-                ),
+                out_of_range_message("invalid YAML: ", text),
             ));
         }
     };
@@ -675,7 +669,7 @@ fn parse_int_literal(text: &str) -> Result<Value, ParseError> {
         None => Err(ParseError::new(
             1,
             1,
-            format!("invalid YAML: integer literal {text:?} is out of range for a 64-bit integer"),
+            out_of_range_message("invalid YAML: ", text),
         )),
     }
 }

--- a/omnist/src/oml.rs
+++ b/omnist/src/oml.rs
@@ -62,17 +62,19 @@
 
 use crate::document::{self, RawNode, Scalar, check_write_depth};
 use crate::error::{ParseError, WriteError};
+use crate::formats::int_cap::{MAX_INT_DIGITS, out_of_range_message, over_cap_message};
 use crate::schema::{is_iso_date, is_iso_datetime, is_iso_time};
 
-/// Same security guard as Python's `_MAX_INT_DIGITS`: reject an integer
-/// literal with more than this many digits before ever attempting to
-/// convert it (unbounded-digit int-to-str/str-to-int conversion is
-/// superlinear). `document.rs` has no equivalent constant -- its `Scalar`
-/// uses `i64` (max 19 digits), so the guard would be permanently dead code
-/// there (see that module's doc comment) -- this module is the one place an
-/// arbitrarily-long *digit run* can actually reach the parser (as OML
-/// source text), so the cap lives here instead.
-const MAX_INT_DIGITS: usize = 4300;
+// Same security guard as Python's `_MAX_INT_DIGITS`: reject an integer
+// literal with more than this many digits before ever attempting to
+// convert it (unbounded-digit int-to-str/str-to-int conversion is
+// superlinear). `document.rs` has no equivalent constant -- its `Scalar`
+// uses `i64` (max 19 digits), so the guard would be permanently dead code
+// there (see that module's doc comment) -- this module is the one place an
+// arbitrarily-long *digit run* can actually reach the parser (as OML
+// source text), so the cap lives here instead. Constant and message
+// constructors now live in [`crate::formats::int_cap`] (issue #49); this
+// module still owns the *finding* documented above.
 
 // ---------------------------------------------------------------------------
 // Scanner
@@ -600,21 +602,11 @@ impl Scanner {
         } else {
             let digits = &text[if text.starts_with('-') { 1 } else { 0 }..];
             if digits.len() > MAX_INT_DIGITS {
-                return Err(self.error_at(
-                    start,
-                    format!(
-                        "integer literal has {} digits, exceeding the {MAX_INT_DIGITS}-digit \
-                         limit (security: unbounded-digit int-to-str conversion is superlinear)",
-                        digits.len()
-                    ),
-                ));
+                return Err(self.error_at(start, over_cap_message("", digits.len())));
             }
-            let v: i64 = text.parse().map_err(|_| {
-                self.error_at(
-                    start,
-                    format!("integer literal {text:?} is out of range for a 64-bit integer"),
-                )
-            })?;
+            let v: i64 = text
+                .parse()
+                .map_err(|_| self.error_at(start, out_of_range_message("", &text)))?;
             Ok((TokKind::Int(v), start, end))
         }
     }


### PR DESCRIPTION
## Summary

- `MAX_INT_DIGITS = 4300` and its two-tier error-message pair (over-cap vs.
  out-of-i64-range) were hand-copied into `oml.rs`, `formats/json.rs`,
  `formats/toml.rs`, and `formats/yaml.rs`, each file's comment already
  noting it was a copy of the others.
- Extracted the constant and two message constructors into
  `omnist/src/formats/int_cap.rs`, `pub(crate)`, and updated all four call
  sites to use it.
- Preserved every existing error message byte-for-byte: `json.rs`/`oml.rs`
  stay unprefixed, `toml.rs`/`yaml.rs` keep their `"invalid TOML: "`/
  `"invalid YAML: "` prefixes, passed in as a parameter rather than
  homogenized away.
- Pure refactor: no observable behavior change.

Closes #49

## Test plan

- [x] `cargo test --workspace` — 101 tests pass (99 + 2 doc_cli), including
      every existing digit-cap/overflow assertion in `json.rs`, `toml.rs`,
      `yaml.rs`, `oml.rs` with unchanged expected strings, plus 4 new unit
      tests for `int_cap.rs`'s message constructors
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo llvm-cov --workspace --fail-under-lines 100` — 100.00% lines
      (7995/7995), including the new `int_cap.rs` module

🤖 Generated with [Claude Code](https://claude.com/claude-code)
