### PR TITLE
Refactor: one shared float writer instead of five copies (#47)

### DIFF
--- a/omnist/src/formats/float_fmt.rs
+++ b/omnist/src/formats/float_fmt.rs
@@ -1,0 +1,113 @@
+//! Shared float-writing logic, factored out of `oml.rs`, `formats/json.rs`,
+//! `formats/toml.rs`, `formats/xml.rs`, and `formats/yaml.rs` (issue #47) --
+//! those five modules each declared their own copy of the same
+//! render-then-inspect float writer, differing only in how each format
+//! spells NaN/+Infinity/-Infinity.
+//!
+//! This is a pure refactor: no observable behavior change. Each format's
+//! non-special-value rendering was already identical -- `x.to_string()`,
+//! with a trailing `.0` appended only if the rendered string doesn't
+//! already contain `.`/`e`/`E`. That check (not a fixed magnitude cutoff)
+//! is issue #46's fix: Rust's `f64::to_string()` drops the decimal point
+//! for integral values >= 1e17, e.g. `1e17.to_string() ==
+//! "100000000000000000"`, which a magnitude-cutoff check would miss.
+//!
+//! The one wrinkle: the five call sites split into two shapes -- `json.rs`,
+//! `toml.rs`, and `yaml.rs` append into a caller-owned `&mut String` buffer,
+//! while `xml.rs` and `oml.rs` return an owned `String`. [`write_float`]
+//! takes the `&mut String` shape (the majority); [`float_to_string`] is a
+//! thin wrapper for the two return-a-`String` call sites.
+
+/// Appends `x`'s float rendering to `out`, using `nan`/`inf`/`neg_inf` as
+/// the literal spellings for the three non-finite cases -- each format
+/// spells these differently (e.g. JSON's `NaN`/`Infinity`/`-Infinity` vs.
+/// YAML's `.nan`/`.inf`/`-.inf` vs. TOML/XML/OML's `nan`/`inf`/`-inf`), so
+/// callers pass their own spelling table rather than this module
+/// homogenizing it.
+pub(crate) fn write_float(x: f64, nan: &str, inf: &str, neg_inf: &str, out: &mut String) {
+    if x.is_nan() {
+        out.push_str(nan);
+    } else if x.is_infinite() {
+        out.push_str(if x > 0.0 { inf } else { neg_inf });
+    } else {
+        // Match `json.dumps`'s (and every other format's) float rendering
+        // of an integral value, e.g. `1.0` (not `1`) -- `repr(1.0) ==
+        // "1.0"` in Python. Rust's `f64` `Display` never adds a decimal
+        // point on its own -- and for large enough integral magnitudes
+        // (>= 1e17) it renders a bare digit run with no `.`/`e`/`E` at all
+        // -- so the correct, magnitude-independent test is whether the
+        // *rendered string* already contains one of those markers, not
+        // whether `x` is below some fixed cutoff (issue #46).
+        let s = x.to_string();
+        if s.contains('.') || s.contains('e') || s.contains('E') {
+            out.push_str(&s);
+        } else {
+            out.push_str(&s);
+            out.push_str(".0");
+        }
+    }
+}
+
+/// Same rendering as [`write_float`], returned as an owned `String` -- for
+/// the two call sites (`xml.rs`, `oml.rs`) that build the whole value as a
+/// `String` rather than appending into a shared buffer.
+pub(crate) fn float_to_string(x: f64, nan: &str, inf: &str, neg_inf: &str) -> String {
+    let mut out = String::new();
+    write_float(x, nan, inf, neg_inf, &mut out);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_float_covers_every_branch() {
+        let mut out = String::new();
+        write_float(f64::NAN, "NaN", "Infinity", "-Infinity", &mut out);
+        assert_eq!(out, "NaN");
+        out.clear();
+        write_float(f64::INFINITY, "NaN", "Infinity", "-Infinity", &mut out);
+        assert_eq!(out, "Infinity");
+        out.clear();
+        write_float(f64::NEG_INFINITY, "NaN", "Infinity", "-Infinity", &mut out);
+        assert_eq!(out, "-Infinity");
+        out.clear();
+        write_float(1.5, "NaN", "Infinity", "-Infinity", &mut out);
+        assert_eq!(out, "1.5");
+        out.clear();
+        write_float(2.0, "NaN", "Infinity", "-Infinity", &mut out);
+        assert_eq!(out, "2.0");
+    }
+
+    #[test]
+    fn write_float_uses_the_caller_supplied_spelling_table() {
+        let mut out = String::new();
+        write_float(f64::NAN, ".nan", ".inf", "-.inf", &mut out);
+        assert_eq!(out, ".nan");
+        out.clear();
+        write_float(f64::NEG_INFINITY, ".nan", ".inf", "-.inf", &mut out);
+        assert_eq!(out, "-.inf");
+    }
+
+    #[test]
+    fn round_trips_integral_float_at_and_above_1e17_boundary_issue_46() {
+        for x in [1.0e17, 1.0e18, -1.23e17, 9.9e16_f64] {
+            let s = float_to_string(x, "nan", "inf", "-inf");
+            assert!(s.contains('.'), "x={x} s={s}");
+            let back: f64 = s.parse().unwrap();
+            assert_eq!(back, x, "x={x} s={s}");
+        }
+    }
+
+    #[test]
+    fn float_to_string_matches_write_float() {
+        assert_eq!(float_to_string(1.5, "nan", "inf", "-inf"), "1.5");
+        assert_eq!(float_to_string(f64::NAN, "nan", "inf", "-inf"), "nan");
+        assert_eq!(float_to_string(f64::INFINITY, "nan", "inf", "-inf"), "inf");
+        assert_eq!(
+            float_to_string(f64::NEG_INFINITY, "nan", "inf", "-inf"),
+            "-inf"
+        );
+    }
+}

--- a/omnist/src/formats/json.rs
+++ b/omnist/src/formats/json.rs
@@ -46,6 +46,7 @@
 use crate::WriteError;
 use crate::document::{Doc, Value};
 use crate::error::{OmnistError, ParseError};
+use crate::formats::float_fmt;
 use crate::formats::int_cap::{MAX_INT_DIGITS, out_of_range_message, over_cap_message};
 use crate::formats::textpos::line_col_bytes;
 use crate::report::{Severity, WriteReport};
@@ -240,29 +241,12 @@ fn write_seq<I, T>(
 /// `finish_write` raises, but still produced -- see `write_json`'s call
 /// site): bare `NaN`/`Infinity`/`-Infinity` tokens, not valid JSON on their
 /// own but exactly what Python's own encoder emits by default.
+///
+/// The non-special-value rendering (issue #46's render-then-inspect fix)
+/// and the shared core live in `formats::float_fmt` (issue #47) -- this is
+/// now just JSON's spelling table for the three special values.
 fn write_float(x: f64, out: &mut String) {
-    if x.is_nan() {
-        out.push_str("NaN");
-    } else if x.is_infinite() {
-        out.push_str(if x > 0.0 { "Infinity" } else { "-Infinity" });
-    } else {
-        // Match `json.dumps`'s float rendering of an integral value, e.g.
-        // `1.0` (not `1`) -- `repr(1.0) == "1.0"` in Python. Rust's `f64`
-        // `Display` never adds a decimal point on its own -- and for large
-        // enough integral magnitudes (>= 1e17) it renders a bare digit run
-        // with no `.`/`e`/`E` at all, e.g. `1e17.to_string() ==
-        // "100000000000000000"` -- so the correct, magnitude-independent
-        // test is whether the *rendered string* already contains one of
-        // those markers, not whether `x` is below some fixed cutoff (see
-        // `oml.rs::write_float`, the reference implementation this mirrors).
-        let s = x.to_string();
-        if s.contains('.') || s.contains('e') || s.contains('E') {
-            out.push_str(&s);
-        } else {
-            out.push_str(&s);
-            out.push_str(".0");
-        }
-    }
+    float_fmt::write_float(x, "NaN", "Infinity", "-Infinity", out);
 }
 
 fn write_json_string(s: &str, out: &mut String) {

--- a/omnist/src/formats/mod.rs
+++ b/omnist/src/formats/mod.rs
@@ -13,6 +13,7 @@
 //! [`yaml`]; issue #20 added [`toml`]; issue #22 adds [`xml`], the last and
 //! structurally different one -- see `xml.rs`'s own doc comment.
 
+pub(crate) mod float_fmt;
 pub(crate) mod int_cap;
 pub mod json;
 pub(crate) mod textpos;

--- a/omnist/src/formats/toml.rs
+++ b/omnist/src/formats/toml.rs
@@ -207,6 +207,7 @@
 use crate::WriteError;
 use crate::document::{Doc, Value};
 use crate::error::{OmnistError, ParseError};
+use crate::formats::float_fmt;
 use crate::formats::int_cap::{MAX_INT_DIGITS, out_of_range_message, over_cap_message};
 use crate::formats::textpos::line_col_bytes;
 use crate::report::{Severity, WriteReport};
@@ -514,24 +515,10 @@ fn write_scalar(v: &Value, out: &mut String) {
     }
 }
 
+/// See `formats::float_fmt` (issue #47) for the shared render-then-inspect
+/// core (issue #46's fix); this is just TOML's spelling table.
 fn write_float(x: f64, out: &mut String) {
-    if x.is_nan() {
-        out.push_str("nan");
-    } else if x.is_infinite() {
-        out.push_str(if x > 0.0 { "inf" } else { "-inf" });
-    } else {
-        // See `json.rs::write_float` for why this checks the rendered
-        // string for `.`/`e`/`E` rather than comparing `x` against a fixed
-        // magnitude cutoff (issue #46: Rust's `f64::to_string()` drops the
-        // decimal point for integral values >= 1e17).
-        let s = x.to_string();
-        if s.contains('.') || s.contains('e') || s.contains('E') {
-            out.push_str(&s);
-        } else {
-            out.push_str(&s);
-            out.push_str(".0");
-        }
-    }
+    float_fmt::write_float(x, "nan", "inf", "-inf", out);
 }
 
 /// Writes a string scalar: as a *native* TOML temporal literal (unquoted)

--- a/omnist/src/formats/xml.rs
+++ b/omnist/src/formats/xml.rs
@@ -153,6 +153,7 @@
 use crate::WriteError;
 use crate::document::{Doc, MAX_DEPTH, RawNode, Scalar};
 use crate::error::{DocumentError, OmnistError, ParseError};
+use crate::formats::float_fmt;
 use crate::formats::textpos::line_col_bytes;
 use crate::report::{Severity, WriteReport};
 use quick_xml::Reader;
@@ -638,22 +639,7 @@ fn xml_text(scalar: &Scalar) -> String {
 /// integral values >= 1e17 it doesn't even include a decimal point -- see
 /// issue #46).
 fn write_float_text(x: f64) -> String {
-    if x.is_nan() {
-        "nan".to_string()
-    } else if x.is_infinite() {
-        if x > 0.0 { "inf" } else { "-inf" }.to_string()
-    } else {
-        // See `json.rs::write_float` for why this checks the rendered
-        // string for `.`/`e`/`E` rather than comparing `x` against a fixed
-        // magnitude cutoff (issue #46: Rust's `f64::to_string()` drops the
-        // decimal point for integral values >= 1e17).
-        let s = x.to_string();
-        if s.contains('.') || s.contains('e') || s.contains('E') {
-            s
-        } else {
-            format!("{s}.0")
-        }
-    }
+    float_fmt::float_to_string(x, "nan", "inf", "-inf")
 }
 
 /// Replaces every character XML 1.0 cannot represent with U+FFFD --

--- a/omnist/src/formats/yaml.rs
+++ b/omnist/src/formats/yaml.rs
@@ -97,6 +97,7 @@ use yaml_rust2::scanner::{Marker, ScanError, TScalarStyle};
 use crate::WriteError;
 use crate::document::{Doc, Value};
 use crate::error::{OmnistError, ParseError};
+use crate::formats::float_fmt;
 use crate::formats::int_cap::{MAX_INT_DIGITS, out_of_range_message, over_cap_message};
 use crate::report::{Severity, WriteReport};
 use indexmap::IndexMap;
@@ -966,24 +967,10 @@ fn write_scalar_value(v: &Value, out: &mut String) {
     }
 }
 
+/// See `formats::float_fmt` (issue #47) for the shared render-then-inspect
+/// core (issue #46's fix); this is just YAML's spelling table.
 fn write_float(x: f64, out: &mut String) {
-    if x.is_nan() {
-        out.push_str(".nan");
-    } else if x.is_infinite() {
-        out.push_str(if x > 0.0 { ".inf" } else { "-.inf" });
-    } else {
-        // See `json.rs::write_float` for why this checks the rendered
-        // string for `.`/`e`/`E` rather than comparing `x` against a fixed
-        // magnitude cutoff (issue #46: Rust's `f64::to_string()` drops the
-        // decimal point for integral values >= 1e17).
-        let s = x.to_string();
-        if s.contains('.') || s.contains('e') || s.contains('E') {
-            out.push_str(&s);
-        } else {
-            out.push_str(&s);
-            out.push_str(".0");
-        }
-    }
+    float_fmt::write_float(x, ".nan", ".inf", "-.inf", out);
 }
 
 /// Writes `s` as a YAML scalar: double-quoted (with the U+0085 escape

--- a/omnist/src/oml.rs
+++ b/omnist/src/oml.rs
@@ -1141,22 +1141,7 @@ fn write_str_scalar(s: &str) -> String {
 /// trailing `.0`, unlike Python's `repr()`), or the OML round-trip would
 /// silently reclassify it as `Scalar::Int` on read-back.
 fn write_float(v: f64) -> String {
-    if v.is_nan() {
-        return "nan".to_string();
-    }
-    if v.is_infinite() {
-        return if v < 0.0 {
-            "-inf".to_string()
-        } else {
-            "inf".to_string()
-        };
-    }
-    let s = format!("{v}");
-    if s.contains('.') || s.contains('e') || s.contains('E') {
-        s
-    } else {
-        format!("{s}.0")
-    }
+    crate::formats::float_fmt::float_to_string(v, "nan", "inf", "-inf")
 }
 
 /// Escapes every occurrence of a special character -- a per-char loop, not


### PR DESCRIPTION
Refactor: one shared float writer instead of five copies (#47)

json.rs, yaml.rs, toml.rs, xml.rs, and oml.rs each carried their own copy
of the same render-then-inspect float writer (issue #46's fix: append
`.0` only if `x.to_string()` lacks `.`/`e`/`E`, not a magnitude cutoff).
Extract the shared core into formats/float_fmt.rs, parameterized by each
format's NaN/Infinity/-Infinity spelling table. Pure refactor, no
observable behavior change -- verified byte-for-byte via each format's
existing tests, including the #46 regression tests at the >= 1e17
boundary.

Closes #47

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
