### PR TITLE
Refactor: shared report-path walker + defer path allocation on validate/materialize

### DIFF
--- a/omnist/src/document.rs
+++ b/omnist/src/document.rs
@@ -480,11 +480,7 @@ impl<'a> Cursor<'a> {
                 for (label, child) in edges {
                     let i = *counts.entry(label.as_str()).or_insert(0);
                     counts.insert(label.as_str(), i + 1);
-                    let cp = if i == 0 {
-                        format!("{}.{}", self.path, label)
-                    } else {
-                        format!("{}.{}[{}]", self.path, label, i)
-                    };
+                    let cp = crate::report::child_path(&self.path, label, i);
                     out.push((
                         label.clone(),
                         Cursor {
@@ -497,6 +493,41 @@ impl<'a> Cursor<'a> {
                 Ok(out)
             }
             NodeData::Leaf(_) => Err(DocumentError::new(&self.path, "a leaf has no edges")),
+        }
+    }
+
+    /// Like [`Cursor::edges`], but doesn't build a path `String` for every
+    /// child up front (issue #44) -- returns each edge's label, its
+    /// same-label occurrence index, and its `NodeId`, leaving path
+    /// construction to the caller. Paired with [`Cursor::seek`], used by
+    /// `schema.rs`'s `conform_record` (the validate hot path), which reuses
+    /// one path buffer for the whole tree walk instead of allocating one
+    /// `String` per edge regardless of whether that edge ever needs one.
+    pub(crate) fn raw_edges(&self) -> Result<Vec<(&'a str, usize, NodeId)>, DocumentError> {
+        match &self.doc.entry(self.id).data {
+            NodeData::Internal(edges) => {
+                let mut counts: IndexMap<&str, usize> = IndexMap::new();
+                let mut out = Vec::with_capacity(edges.len());
+                for (label, child) in edges {
+                    let i = *counts.entry(label.as_str()).or_insert(0);
+                    counts.insert(label.as_str(), i + 1);
+                    out.push((label.as_str(), i, *child));
+                }
+                Ok(out)
+            }
+            NodeData::Leaf(_) => Err(DocumentError::new(&self.path, "a leaf has no edges")),
+        }
+    }
+
+    /// Build a cursor for `id` without a meaningful `path` -- only valid for
+    /// callers (like `schema.rs`'s buffer-threaded `conform`) that never
+    /// read the returned cursor's `path` field directly, tracking the real
+    /// path in their own reused buffer instead. Paired with [`Cursor::raw_edges`].
+    pub(crate) fn seek(&self, id: NodeId) -> Cursor<'a> {
+        Cursor {
+            doc: self.doc,
+            id,
+            path: String::new(),
         }
     }
 
@@ -973,6 +1004,14 @@ mod tests {
     fn edges_on_a_leaf_is_rejected() {
         let doc = Doc::of(&Value::Int(1)).unwrap();
         assert!(doc.root().edges().is_err());
+    }
+
+    #[test]
+    fn raw_edges_on_a_leaf_is_rejected() {
+        // Mirrors `edges_on_a_leaf_is_rejected` for the lazy-path variant
+        // `edges()` piggybacks its own path-numbering on -- see issue #44.
+        let doc = Doc::of(&Value::Int(1)).unwrap();
+        assert!(doc.root().raw_edges().is_err());
     }
 
     // -- export / equality ------------------------------------------------

--- a/omnist/src/formats/json.rs
+++ b/omnist/src/formats/json.rs
@@ -104,13 +104,20 @@ pub fn write_json(
 }
 
 /// Report what writing JSON would adjust, without producing output.
+///
+/// Walks every leaf via the shared [`crate::formats::visit_grouped`] walker
+/// (issue #51) rather than a bespoke `collect_leaves` pass; the path
+/// `String` that ends up in a [`crate::report::Adjustment`] is only built
+/// for the (rare) NaN/Infinity leaf -- not for every leaf up front (issue
+/// #44), since `visit_grouped` reuses one path buffer for the whole walk.
 pub fn check_json(doc: &Doc) -> WriteReport {
     let mut rep = WriteReport::new();
-    let mut leaves = Vec::new();
     let grouped = doc.to_grouped();
-    collect_leaves(&grouped, "$", &mut leaves);
-    for (path, v) in leaves {
-        if let Value::Float(x) = v
+    let mut path = String::from("$");
+    crate::formats::visit_grouped(&grouped, &mut path, &mut |visited, path| {
+        if let crate::formats::Visited::Node {
+            value: Value::Float(x),
+        } = visited
             && (x.is_nan() || x.is_infinite())
         {
             rep.add(
@@ -120,41 +127,8 @@ pub fn check_json(doc: &Doc) -> WriteReport {
                 Severity::Error,
             );
         }
-    }
+    });
     rep
-}
-
-/// Yield `(path, value)` for every scalar leaf in a grouped `Value`, mirroring
-/// Python's `_leaves` generator. `Doc::to_grouped()` output is already
-/// depth-checked (see this module's doc comment), so no depth guard is
-/// needed here -- only path bookkeeping for same-label array indices.
-fn collect_leaves<'a>(node: &'a Value, path: &str, out: &mut Vec<(String, &'a Value)>) {
-    match node {
-        Value::Object(map) => {
-            for (label, child) in map {
-                match child {
-                    Value::Array(items) => {
-                        for (i, item) in items.iter().enumerate() {
-                            let p = if i == 0 {
-                                format!("{path}.{label}")
-                            } else {
-                                format!("{path}.{label}[{i}]")
-                            };
-                            collect_leaves(item, &p, out);
-                        }
-                    }
-                    other => {
-                        collect_leaves(other, &format!("{path}.{label}"), out);
-                    }
-                }
-            }
-        }
-        // A grouped `Value` never has a bare top-level/standalone `Array`
-        // outside an object edge -- `to_grouped` only ever produces one
-        // under an `Object` entry (see `document.rs`) -- so this arm only
-        // ever matches a scalar leaf.
-        other => out.push((path.to_string(), other)),
-    }
 }
 
 /// Lenient-mode substitution: a NaN/Infinity leaf becomes `Null` so the

--- a/omnist/src/formats/mod.rs
+++ b/omnist/src/formats/mod.rs
@@ -20,3 +20,75 @@ pub(crate) mod textpos;
 pub mod toml;
 pub mod xml;
 pub mod yaml;
+
+use crate::document::Value;
+
+/// One position `visit_grouped` reaches, passed to its callback alongside
+/// the current path. Kept as a single enum (rather than two separate
+/// closures) so callers only need one `&mut` capture of their accumulator
+/// (e.g. a `WriteReport`) -- two closures both borrowing the same
+/// `&mut WriteReport` for the whole walk don't borrow-check, since both
+/// would be alive simultaneously across the recursion.
+pub(crate) enum Visited<'a> {
+    /// A `(label, child)` map entry, fired once per label regardless of
+    /// whether `label`'s value is a same-label array -- e.g. for
+    /// `yaml.rs`'s NEL-in-label scan, which must not fire once per array
+    /// entry.
+    Edge { label: &'a str },
+    /// A value actually reached by the traversal (a leaf, or a
+    /// non-`Object` node on the way down) -- e.g. `json.rs`'s
+    /// NaN/Infinity check or `yaml.rs`'s NEL-in-value check, both of
+    /// which only care about a subset of node kinds and filter for it
+    /// themselves.
+    Node { value: &'a Value },
+}
+
+/// Shared traversal for the two codec scanners built directly over a grouped
+/// `Value` tree (`json::collect_leaves`/`check_json`, `yaml::scan_nel`) --
+/// see issue #51. Both re-implemented the same recursion and the same
+/// same-label-array path-numbering rule; this walker does it once.
+///
+/// `path` is a single reused buffer: every recursive step pushes its segment
+/// (via [`crate::report::push_child_path`]), recurses, then truncates back --
+/// so a full walk of an all-valid document allocates a path `String` only
+/// when `f` itself decides to keep one (e.g. to store it in a
+/// `WriteReport`), never once per edge just to *have* a path available
+/// (issue #44).
+///
+/// `toml.rs::strip_nulls` (which transforms the tree, not merely visits it)
+/// and `xml.rs::scan_xml_into` (a different tree type, `RawNode`, not
+/// `Value`) don't fit this shape and keep their own recursion -- they still
+/// use [`crate::report::child_path`] for the path-numbering rule itself.
+pub(crate) fn visit_grouped(
+    node: &Value,
+    path: &mut String,
+    f: &mut impl FnMut(Visited<'_>, &str),
+) {
+    match node {
+        Value::Object(map) => {
+            for (label, child) in map {
+                let base = path.len();
+                path.push('.');
+                path.push_str(label);
+                f(Visited::Edge { label }, path.as_str());
+
+                match child {
+                    Value::Array(items) => {
+                        path.truncate(base);
+                        for (i, item) in items.iter().enumerate() {
+                            let ibase = path.len();
+                            crate::report::push_child_path(path, label, i);
+                            visit_grouped(item, path, f);
+                            path.truncate(ibase);
+                        }
+                    }
+                    other => {
+                        visit_grouped(other, path, f);
+                        path.truncate(base);
+                    }
+                }
+            }
+        }
+        other => f(Visited::Node { value: other }, path.as_str()),
+    }
+}

--- a/omnist/src/formats/toml.rs
+++ b/omnist/src/formats/toml.rs
@@ -414,7 +414,7 @@ fn strip_nulls(node: Value, path: &str, rep: &mut WriteReport) -> Value {
                 match child {
                     Value::Null => {
                         rep.add(
-                            format!("{path}.{label}"),
+                            crate::report::child_path(path, &label, 0),
                             "null.omitted",
                             "null value dropped (TOML has no null)",
                             Severity::Warning,
@@ -423,11 +423,7 @@ fn strip_nulls(node: Value, path: &str, rep: &mut WriteReport) -> Value {
                     Value::Array(items) => {
                         let mut kept = Vec::with_capacity(items.len());
                         for (i, item) in items.into_iter().enumerate() {
-                            let p = if i == 0 {
-                                format!("{path}.{label}")
-                            } else {
-                                format!("{path}.{label}[{i}]")
-                            };
+                            let p = crate::report::child_path(path, &label, i);
                             if matches!(item, Value::Null) {
                                 rep.add(
                                     p,
@@ -442,7 +438,7 @@ fn strip_nulls(node: Value, path: &str, rep: &mut WriteReport) -> Value {
                         out.insert(label, Value::Array(kept));
                     }
                     other => {
-                        let p = format!("{path}.{label}");
+                        let p = crate::report::child_path(path, &label, 0);
                         out.insert(label, strip_nulls(other, &p, rep));
                     }
                 }

--- a/omnist/src/formats/xml.rs
+++ b/omnist/src/formats/xml.rs
@@ -156,9 +156,9 @@ use crate::error::{DocumentError, OmnistError, ParseError};
 use crate::formats::float_fmt;
 use crate::formats::textpos::line_col_bytes;
 use crate::report::{Severity, WriteReport};
+use indexmap::IndexMap;
 use quick_xml::Reader;
 use quick_xml::events::Event;
-use std::collections::HashMap;
 
 // ============================================================== Reader
 
@@ -482,15 +482,18 @@ fn scan_xml_into(node: &RawNode, path: &str, rep: &mut WriteReport) {
                 );
                 return;
             }
-            let mut counts: HashMap<String, usize> = HashMap::new();
+            // `IndexMap`, not `HashMap`: `ops/mod.rs`'s no-`HashMap`
+            // convention is for anything feeding canonical output, and
+            // while iteration order is never observed here (each entry is
+            // looked up by its own label), an ordered map keeps that
+            // determinism argument local instead of requiring the reader to
+            // re-derive it (issue #51).
+            let mut counts: IndexMap<&str, usize> = IndexMap::new();
             for (label, child) in edges {
-                let i = *counts.get(label).unwrap_or(&0);
-                counts.insert(label.clone(), i + 1);
-                let p = if i == 0 {
-                    format!("{path}.{label}")
-                } else {
-                    format!("{path}.{label}[{i}]")
-                };
+                let entry = counts.entry(label.as_str()).or_insert(0);
+                let i = *entry;
+                *entry += 1;
+                let p = crate::report::child_path(path, label, i);
                 if !is_valid_xml_name(label) {
                     rep.add(
                         p.clone(),

--- a/omnist/src/formats/yaml.rs
+++ b/omnist/src/formats/yaml.rs
@@ -817,39 +817,20 @@ pub fn write_yaml(
 /// (NEL) string/label -- see this module's doc comment.
 pub fn check_yaml(doc: &Doc) -> WriteReport {
     let mut rep = WriteReport::new();
-    scan_nel(&doc.to_grouped(), "$", &mut rep);
-    rep
-}
-
-fn scan_nel(node: &Value, path: &str, rep: &mut WriteReport) {
-    match node {
-        Value::Object(map) => {
-            for (label, child) in map {
-                if label.contains('\u{0085}') {
-                    rep.add(
-                        format!("{path}.{label}"),
-                        "string.line-break-char",
-                        "label contains U+0085 (NEL); written double-quoted to round-trip \
-                         correctly",
-                        Severity::Warning,
-                    );
-                }
-                match child {
-                    Value::Array(items) => {
-                        for (i, item) in items.iter().enumerate() {
-                            let p = if i == 0 {
-                                format!("{path}.{label}")
-                            } else {
-                                format!("{path}.{label}[{i}]")
-                            };
-                            scan_nel(item, &p, rep);
-                        }
-                    }
-                    other => scan_nel(other, &format!("{path}.{label}"), rep),
-                }
-            }
+    let grouped = doc.to_grouped();
+    let mut path = String::from("$");
+    crate::formats::visit_grouped(&grouped, &mut path, &mut |visited, path| match visited {
+        crate::formats::Visited::Edge { label } if label.contains('\u{0085}') => {
+            rep.add(
+                path,
+                "string.line-break-char",
+                "label contains U+0085 (NEL); written double-quoted to round-trip correctly",
+                Severity::Warning,
+            );
         }
-        Value::Str(s) if s.contains('\u{0085}') => {
+        crate::formats::Visited::Node {
+            value: Value::Str(s),
+        } if s.contains('\u{0085}') => {
             rep.add(
                 path,
                 "string.line-break-char",
@@ -858,7 +839,8 @@ fn scan_nel(node: &Value, path: &str, rep: &mut WriteReport) {
             );
         }
         _ => {}
-    }
+    });
+    rep
 }
 
 fn indent(out: &mut String, level: usize) {

--- a/omnist/src/materialize.rs
+++ b/omnist/src/materialize.rs
@@ -75,7 +75,12 @@ pub fn materialize(node: &RawNode, schema: Option<&Schema>) -> Result<RawNode, M
     };
     let mut res = ValidationResult::new();
     let root_ty = FieldType::Ref(schema.root().clone());
-    let out = materialize_type(node, schema, &root_ty, "$", &mut res);
+    // One path `String`, allocated once and reused for the whole walk (push
+    // a segment per edge, recurse, truncate back) rather than one `format!`
+    // per edge regardless of whether that edge ever reports anything --
+    // see issue #44.
+    let mut path = String::from("$");
+    let out = materialize_type(node, schema, &root_ty, &mut path, &mut res);
     if !res.ok() {
         return Err(MaterializeError(res));
     }
@@ -86,7 +91,7 @@ fn materialize_type(
     node: &RawNode,
     schema: &Schema,
     ty: &FieldType,
-    path: &str,
+    path: &mut String,
     res: &mut ValidationResult,
 ) -> RawNode {
     match schema.resolve(ty) {
@@ -102,12 +107,12 @@ fn materialize_record(
     node: &RawNode,
     schema: &Schema,
     rec: &crate::schema::Record,
-    path: &str,
+    path: &mut String,
     res: &mut ValidationResult,
 ) -> RawNode {
     let RawNode::Edges(edges) = node else {
         res.add(
-            path,
+            path.as_str(),
             "expected an object, got a value",
             ErrorCode::ShapeMismatch,
         );
@@ -118,27 +123,29 @@ fn materialize_record(
     for (label, child) in edges {
         let i = *counts.entry(label.as_str()).or_insert(0);
         counts.insert(label.as_str(), i + 1);
-        let p = if i == 0 {
-            format!("{path}.{label}")
-        } else {
-            format!("{path}.{label}[{i}]")
-        };
+        let base = path.len();
+        crate::report::push_child_path(path, label, i);
         match rec.field(label) {
             None => {
-                res.add(&p, "unexpected field", ErrorCode::UnexpectedField);
+                res.add(
+                    path.as_str(),
+                    "unexpected field",
+                    ErrorCode::UnexpectedField,
+                );
                 out.push((label.clone(), child.clone()));
             }
             Some(f) => {
-                let m = materialize_type(child, schema, &f.ty, &p, res);
+                let m = materialize_type(child, schema, &f.ty, path, res);
                 out.push((label.clone(), m));
             }
         }
+        path.truncate(base);
     }
     for f in rec.fields() {
         let c = counts.get(f.label.as_str()).copied().unwrap_or(0);
         if c < f.min || f.max.is_some_and(|max| c > max) {
             res.add(
-                path,
+                path.as_str(),
                 format!(
                     "field {:?} occurs {} time(s), expected {}",
                     f.label,

--- a/omnist/src/report.rs
+++ b/omnist/src/report.rs
@@ -22,6 +22,36 @@
 
 use crate::error::WriteError;
 
+/// The path-numbering rule every codec scanner applies to a same-label
+/// array's entries: the first occurrence gets the bare path
+/// (`"{path}.{label}"`), later ones are indexed (`"{path}.{label}[{i}]"`).
+/// Lives next to [`Adjustment`], whose `path` field this format feeds.
+///
+/// Used by scanners that build the full path eagerly (`toml.rs::strip_nulls`,
+/// `xml.rs::scan_xml_into`, whose own recursion doesn't fit the shared
+/// `formats::visit_grouped` walker -- see that function's doc comment). The
+/// grouped-`Value` walkers (`json`/`yaml`) instead reuse a single path buffer
+/// via [`push_child_path`], never allocating a `String` per edge.
+pub(crate) fn child_path(path: &str, label: &str, index: usize) -> String {
+    let mut s = String::with_capacity(path.len() + label.len() + 8);
+    s.push_str(path);
+    push_child_path(&mut s, label, index);
+    s
+}
+
+/// Same rule as [`child_path`], but writes into a caller-owned buffer instead
+/// of allocating a new `String`. Callers that walk a whole tree can push a
+/// segment, recurse, then `buf.truncate` back -- one buffer, reused for
+/// every edge, instead of one allocation per edge.
+pub(crate) fn push_child_path(buf: &mut String, label: &str, index: usize) {
+    use std::fmt::Write;
+    buf.push('.');
+    buf.push_str(label);
+    if index != 0 {
+        write!(buf, "[{index}]").expect("writing to a String never fails");
+    }
+}
+
 /// How surprising/lossy a single [`Adjustment`] is. `strict` mode raises on
 /// either severity; only [`WriteReport::is_ok`] (Python's `__bool__`)
 /// distinguishes them.

--- a/omnist/src/schema.rs
+++ b/omnist/src/schema.rs
@@ -627,7 +627,19 @@ impl Schema {
     /// the first.
     pub fn validate(&self, cursor: &document::Cursor<'_>) -> ValidationResult {
         let mut res = ValidationResult::new();
-        self.conform(cursor, &FieldType::Ref(self.root.clone()), &mut res);
+        // `path` is the one path `String` this walk allocates up front (the
+        // root); every deeper edge reuses this same buffer (push a segment,
+        // recurse, truncate back) rather than allocating its own -- see
+        // issue #44. `res.add` still copies out a path when an error is
+        // actually recorded (`impl Into<String>` on a `&str` allocates), but
+        // that only happens for edges that actually produce a problem.
+        let mut path = cursor.path.clone();
+        self.conform(
+            cursor,
+            &FieldType::Ref(self.root.clone()),
+            &mut res,
+            &mut path,
+        );
         res
     }
 
@@ -635,21 +647,33 @@ impl Schema {
         self.validate(cursor).ok()
     }
 
-    fn conform(&self, cursor: &document::Cursor<'_>, ty: &FieldType, res: &mut ValidationResult) {
+    fn conform(
+        &self,
+        cursor: &document::Cursor<'_>,
+        ty: &FieldType,
+        res: &mut ValidationResult,
+        path: &mut String,
+    ) {
         match self.resolve(ty) {
             // `any` accepts every legal Document value unchecked -- there is
             // nothing to conform against, mirroring Python's
             // `_conform`: `if isinstance(d, AnyType): return`.
             Resolved::Any => {}
-            Resolved::Scalar(s) => self.conform_scalar(cursor, s, res),
-            Resolved::Record(r) => self.conform_record(cursor, r, res),
+            Resolved::Scalar(s) => self.conform_scalar(cursor, s, res, path),
+            Resolved::Record(r) => self.conform_record(cursor, r, res, path),
         }
     }
 
-    fn conform_scalar(&self, cursor: &document::Cursor<'_>, s: Scalar, res: &mut ValidationResult) {
+    fn conform_scalar(
+        &self,
+        cursor: &document::Cursor<'_>,
+        s: Scalar,
+        res: &mut ValidationResult,
+        path: &str,
+    ) {
         if !cursor.is_leaf() {
             res.add(
-                &cursor.path,
+                path,
                 format!("expected a {} value, got an object", s.kind().as_str()),
                 ErrorCode::ShapeMismatch,
             );
@@ -660,17 +684,13 @@ impl Schema {
             .expect("is_leaf() true implies value() succeeds");
         if matches!(v, DocScalar::Null) {
             if !s.is_nullable() {
-                res.add(
-                    &cursor.path,
-                    "null not allowed here",
-                    ErrorCode::NullNotAllowed,
-                );
+                res.add(path, "null not allowed here", ErrorCode::NullNotAllowed);
             }
             return;
         }
         if !matches_kind(v, s.kind()) {
             res.add(
-                &cursor.path,
+                path,
                 format!(
                     "expected {}, got {} ({})",
                     s.kind().as_str(),
@@ -682,36 +702,56 @@ impl Schema {
         }
     }
 
+    /// Walks every edge without building a path `String` for it up front
+    /// (issue #44): `path` is a single buffer shared across the whole
+    /// `validate` walk. Each edge pushes its own segment (`.label` or
+    /// `.label[i]`, via [`crate::report::push_child_path`]) onto `path`,
+    /// recurses/reports using that borrowed `&str`, then truncates `path`
+    /// back before moving to the next edge -- so a document with no
+    /// unexpected fields, cardinality problems, or type mismatches never
+    /// allocates a path `String` per edge, only the one `res.add` actually
+    /// needs to keep (via `impl Into<String>`) when a problem is found.
     fn conform_record(
         &self,
         cursor: &document::Cursor<'_>,
         rec: &Record,
         res: &mut ValidationResult,
+        path: &mut String,
     ) {
         if cursor.is_leaf() {
             res.add(
-                &cursor.path,
+                path.as_str(),
                 "expected an object, got a value",
                 ErrorCode::ShapeMismatch,
             );
             return;
         }
         let edges = cursor
-            .edges()
-            .expect("is_leaf() false implies edges() succeeds");
+            .raw_edges()
+            .expect("is_leaf() false implies raw_edges() succeeds");
         let mut counts: IndexMap<&str, usize> = IndexMap::new();
-        for (label, child) in &edges {
-            *counts.entry(label.as_str()).or_insert(0) += 1;
+        for (label, i, child_id) in &edges {
+            *counts.entry(*label).or_insert(0) += 1;
+            let base = path.len();
+            crate::report::push_child_path(path, label, *i);
             match rec.field(label) {
-                None => res.add(&child.path, "unexpected field", ErrorCode::UnexpectedField),
-                Some(f) => self.conform(child, &f.ty, res),
+                None => res.add(
+                    path.as_str(),
+                    "unexpected field",
+                    ErrorCode::UnexpectedField,
+                ),
+                Some(f) => {
+                    let child = cursor.seek(*child_id);
+                    self.conform(&child, &f.ty, res, path);
+                }
             }
+            path.truncate(base);
         }
         for f in rec.fields() {
             let c = counts.get(f.label.as_str()).copied().unwrap_or(0);
             if c < f.min || f.max.is_some_and(|max| c > max) {
                 res.add(
-                    &cursor.path,
+                    path.as_str(),
                     format!(
                         "field {:?} occurs {} time(s), expected {}",
                         f.label,


### PR DESCRIPTION
## Summary

Combines issues #51 and #44 -- both flagged by review, and both touching
the identical five-line `if i == 0 { "{path}.{label}" } else { "{path}.{label}[{i}]" }`
block across json.rs/yaml.rs/toml.rs/xml.rs/document.rs/materialize.rs.

**#51 (structural refactor):**
- `report::child_path`/`push_child_path`: one place for the same-label
  array path-numbering rule (buffer-writing variant added for #44's use).
- `formats::visit_grouped`: shared traversal for the grouped-`Value`
  scanners; `json::check_json` and `yaml::check_yaml` now drive it
  instead of their own `collect_leaves`/`scan_nel` recursion.
- `toml::strip_nulls` (transforms, doesn't just visit) and
  `xml::scan_xml_into` (different tree type, `RawNode`) keep their own
  recursion per the issue's own scoping note, just calling `child_path`
  for the numbering rule.
- `xml.rs`'s occurrence counter: `HashMap` -> `IndexMap`, so the
  no-`HashMap`-for-canonical-output convention is local to the file
  rather than relying on an unstated determinism argument.

**#44 (perf fix):**
- `schema.rs`'s `conform`/`conform_record` and `materialize.rs`'s
  `materialize_type`/`materialize_record` now thread one reused path
  buffer through the whole tree walk (push a segment, recurse, truncate
  back) instead of allocating a fresh path `String` per edge
  unconditionally.
- `document.rs` gets `Cursor::raw_edges()`/`Cursor::seek()`, a
  no-path-building sibling to `edges()`, used by the validate hot path.
- `formats::visit_grouped` reuses the same buffer, so `check_json`/
  `check_yaml` only allocate a path `String` for the rare
  NaN/Infinity/NEL leaf that actually gets reported, not every leaf.

## Measured perf (issue #44)

5,000-field all-valid document, 200 iterations, release build:

| | before | after | change |
|---|---|---|---|
| validate | 2.62 ms/iter | 1.67 ms/iter | ~36% faster |
| materialize | 2.10 ms/iter | 1.53 ms/iter | ~27% faster |

(measured with an ad-hoc `examples/perf_probe.rs`, not committed --
built `--release`, ran against this branch and against `git stash`'d
main for the before/after comparison)

## No observable behavior change

Every `WriteReport`/`ValidationError` path, code, message, and
ordering is unchanged -- this is a representation/timing change only.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` -- all passing (591 lib tests + CLI/doc
      tests)
- [x] `cargo llvm-cov --workspace --fail-under-lines 100` -- 100% lines,
      exit 0 (added one test mirroring `edges_on_a_leaf_is_rejected`
      for the new `raw_edges` path)

Closes #51
Closes #44
