### PR TITLE
Refactor: one shared table-driven string escaper

### DIFF
--- a/omnist/src/formats/json.rs
+++ b/omnist/src/formats/json.rs
@@ -48,6 +48,7 @@ use crate::document::{Doc, Value};
 use crate::error::{OmnistError, ParseError};
 use crate::formats::float_fmt;
 use crate::formats::int_cap::{MAX_INT_DIGITS, out_of_range_message, over_cap_message};
+use crate::formats::string_escape::{JSON_ESCAPES, write_quoted};
 use crate::formats::textpos::line_col_bytes;
 use crate::report::{Severity, WriteReport};
 use indexmap::IndexMap;
@@ -224,21 +225,7 @@ fn write_float(x: f64, out: &mut String) {
 }
 
 fn write_json_string(s: &str, out: &mut String) {
-    out.push('"');
-    for c in s.chars() {
-        match c {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            '\u{08}' => out.push_str("\\b"),
-            '\u{0c}' => out.push_str("\\f"),
-            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
-            c => out.push(c),
-        }
-    }
-    out.push('"');
+    write_quoted(s, &JSON_ESCAPES, out);
 }
 
 // ---------------------------------------------------------------- Reader

--- a/omnist/src/formats/mod.rs
+++ b/omnist/src/formats/mod.rs
@@ -16,6 +16,7 @@
 pub(crate) mod float_fmt;
 pub(crate) mod int_cap;
 pub mod json;
+pub(crate) mod string_escape;
 pub(crate) mod textpos;
 pub mod toml;
 pub mod xml;

--- a/omnist/src/formats/string_escape.rs
+++ b/omnist/src/formats/string_escape.rs
@@ -1,0 +1,365 @@
+//! Shared table-driven quoted-string escaper, factored out of
+//! `oml.rs`, `formats/json.rs`, `formats/toml.rs`, and `formats/yaml.rs`
+//! (issue #50) -- those four modules each hand-rolled the same
+//! `for c in s.chars() { match c { ... } }` escape loop, differing only in
+//! which characters get named escapes, what a bare control character's
+//! escape looks like (`\u{04x}` vs `\x{02x}`), and (TOML only) one extra
+//! non-C0 character that also needs escaping.
+//!
+//! This is a pure refactor: no observable behavior change. Each format's
+//! `EscapeSpec` below reproduces that format's previous arm-by-arm behavior
+//! exactly -- see the equivalence tests in this module and in each format's
+//! own test module.
+//!
+//! ## All-occurrences invariant (omnist-ts#36-class guard)
+//!
+//! [`write_quoted`] is a single `for c in s.chars()` loop that inspects and
+//! emits every character in turn -- it can never under-sanitize by only
+//! touching the first match of an illegal character, the same property each
+//! of the four original per-format loops had individually (and the same
+//! property `formats/xml.rs`'s separate, structurally different
+//! entity-escaper -- out of scope for this refactor -- maintains via its own
+//! `chars().map()`). This module's tests assert that multiple, including
+//! adjacent, occurrences of the same escapable character are *all* escaped,
+//! for every format's spec.
+
+/// How a bare control character (one with no named escape) is rendered.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum ControlStyle {
+    /// `\u{04x}` -- JSON, TOML, OML.
+    HexU,
+    /// `\x{02x}` -- YAML.
+    HexX,
+}
+
+/// A format's escaping rules for [`write_quoted`].
+pub(crate) struct EscapeSpec {
+    /// Named escapes, checked in order before falling back to `control`.
+    /// Every spec includes `"` and `\`; formats differ in which of
+    /// `\n`/`\r`/`\t`/`\b`/`\f` (and, for YAML, `U+0085` -> `\N`) they add.
+    pub named: &'static [(char, &'static str)],
+    /// Rendering for any other C0 control character (or `also_escape`
+    /// member) that isn't covered by `named`.
+    pub control: ControlStyle,
+    /// Characters that must be escaped via `control` even though they
+    /// aren't C0 (`< 0x20`). Only TOML uses this, for `U+007F`.
+    pub also_escape: &'static [char],
+}
+
+/// `formats/json.rs::write_json_string`'s previous escape table.
+pub(crate) const JSON_ESCAPES: EscapeSpec = EscapeSpec {
+    named: &[
+        ('"', "\\\""),
+        ('\\', "\\\\"),
+        ('\n', "\\n"),
+        ('\r', "\\r"),
+        ('\t', "\\t"),
+        ('\u{08}', "\\b"),
+        ('\u{0c}', "\\f"),
+    ],
+    control: ControlStyle::HexU,
+    also_escape: &[],
+};
+
+/// `formats/toml.rs::write_toml_string`'s previous escape table -- identical
+/// to JSON's except `U+007F` is also escaped.
+pub(crate) const TOML_ESCAPES: EscapeSpec = EscapeSpec {
+    named: JSON_ESCAPES.named,
+    control: ControlStyle::HexU,
+    also_escape: &['\u{7f}'],
+};
+
+/// `oml.rs::write_string`'s previous escape table -- like JSON's but without
+/// the `\b`/`\f` named escapes (those C0 chars fall through to `control`).
+pub(crate) const OML_ESCAPES: EscapeSpec = EscapeSpec {
+    named: &[
+        ('"', "\\\""),
+        ('\\', "\\\\"),
+        ('\n', "\\n"),
+        ('\r', "\\r"),
+        ('\t', "\\t"),
+    ],
+    control: ControlStyle::HexU,
+    also_escape: &[],
+};
+
+/// `formats/yaml.rs::write_yaml_string`'s previous escape table (the
+/// quoted-branch loop only -- `needs_quoting`'s plain-vs-quoted decision is
+/// untouched). No named `\r` (a literal `\r` falls through to `control` and
+/// renders as `\x0d`, matching the original arm-less behavior), and
+/// `U+0085` gets the YAML-specific `\N` escape.
+pub(crate) const YAML_ESCAPES: EscapeSpec = EscapeSpec {
+    named: &[
+        ('"', "\\\""),
+        ('\\', "\\\\"),
+        ('\n', "\\n"),
+        ('\t', "\\t"),
+        ('\u{0085}', "\\N"),
+    ],
+    control: ControlStyle::HexX,
+    also_escape: &[],
+};
+
+/// Writes `s` as a double-quoted, escaped string into `out`, per `spec`.
+///
+/// A single per-char loop: every character is inspected and emitted exactly
+/// once, so an illegal/escapable character can never be under-sanitized by
+/// only having its first occurrence touched (the omnist-ts#36 class of bug
+/// -- see this module's doc comment).
+pub(crate) fn write_quoted(s: &str, spec: &EscapeSpec, out: &mut String) {
+    out.push('"');
+    for c in s.chars() {
+        if let Some((_, escaped)) = spec.named.iter().find(|(named_c, _)| *named_c == c) {
+            out.push_str(escaped);
+        } else if (c as u32) < 0x20 || spec.also_escape.contains(&c) {
+            match spec.control {
+                ControlStyle::HexU => out.push_str(&format!("\\u{:04x}", c as u32)),
+                ControlStyle::HexX => out.push_str(&format!("\\x{:02x}", c as u32)),
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out.push('"');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---------------------------------------------------- old implementations
+    //
+    // Kept here only long enough to run the exhaustive equivalence checks
+    // below against the new table-driven `write_quoted`, then deleted --
+    // per issue #50's requirement to check before removing any original.
+
+    fn old_json(s: &str) -> String {
+        let mut out = String::new();
+        out.push('"');
+        for c in s.chars() {
+            match c {
+                '"' => out.push_str("\\\""),
+                '\\' => out.push_str("\\\\"),
+                '\n' => out.push_str("\\n"),
+                '\r' => out.push_str("\\r"),
+                '\t' => out.push_str("\\t"),
+                '\u{08}' => out.push_str("\\b"),
+                '\u{0c}' => out.push_str("\\f"),
+                c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+                c => out.push(c),
+            }
+        }
+        out.push('"');
+        out
+    }
+
+    fn old_toml(s: &str) -> String {
+        let mut out = String::new();
+        out.push('"');
+        for c in s.chars() {
+            match c {
+                '"' => out.push_str("\\\""),
+                '\\' => out.push_str("\\\\"),
+                '\n' => out.push_str("\\n"),
+                '\r' => out.push_str("\\r"),
+                '\t' => out.push_str("\\t"),
+                '\u{08}' => out.push_str("\\b"),
+                '\u{0c}' => out.push_str("\\f"),
+                c if (c as u32) < 0x20 || c == '\u{7f}' => {
+                    out.push_str(&format!("\\u{:04x}", c as u32));
+                }
+                c => out.push(c),
+            }
+        }
+        out.push('"');
+        out
+    }
+
+    fn old_oml(s: &str) -> String {
+        let mut out = String::with_capacity(s.len() + 2);
+        out.push('"');
+        for ch in s.chars() {
+            match ch {
+                '"' => out.push_str("\\\""),
+                '\\' => out.push_str("\\\\"),
+                '\n' => out.push_str("\\n"),
+                '\r' => out.push_str("\\r"),
+                '\t' => out.push_str("\\t"),
+                c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+                c => out.push(c),
+            }
+        }
+        out.push('"');
+        out
+    }
+
+    fn old_yaml_quoted_branch(s: &str) -> String {
+        let mut out = String::new();
+        out.push('"');
+        for c in s.chars() {
+            match c {
+                '"' => out.push_str("\\\""),
+                '\\' => out.push_str("\\\\"),
+                '\n' => out.push_str("\\n"),
+                '\t' => out.push_str("\\t"),
+                '\u{0085}' => out.push_str("\\N"),
+                c if (c as u32) < 0x20 => out.push_str(&format!("\\x{:02x}", c as u32)),
+                c => out.push(c),
+            }
+        }
+        out.push('"');
+        out
+    }
+
+    fn new_out(s: &str, spec: &EscapeSpec) -> String {
+        let mut out = String::new();
+        write_quoted(s, spec, &mut out);
+        out
+    }
+
+    /// Every `char` in `0..=0x10FFFF` (skipping the surrogate range, which
+    /// isn't a valid Rust `char`), as a single-character string, plus a
+    /// handful of multi-char / multi-byte-Unicode / repeated-illegal-char
+    /// strings -- the exhaustive corpus issue #50 asks for.
+    fn exhaustive_single_char_corpus() -> Vec<String> {
+        let mut v = Vec::new();
+        for cp in 0u32..=0x10FFFF {
+            if let Some(c) = char::from_u32(cp) {
+                v.push(c.to_string());
+            }
+        }
+        v
+    }
+
+    fn extra_corpus() -> Vec<String> {
+        vec![
+            String::new(),
+            "plain ascii, nothing to escape".to_string(),
+            "quote\"quote\"quote\"".to_string(),
+            "back\\slash\\back\\slash".to_string(),
+            "\r\r\r\r".to_string(),
+            "\n\n\n\n".to_string(),
+            "\t\t\t\t".to_string(),
+            "\u{08}\u{08}\u{0c}\u{0c}".to_string(),
+            "\u{01}\u{01}\u{01}".to_string(),
+            "\u{7f}\u{7f}\u{7f}".to_string(),
+            "\u{0085}\u{0085}".to_string(),
+            "mixed \" \\ \n \r \t \u{08} \u{0c} \u{01} \u{7f} \u{0085} end".to_string(),
+            "unicode: héllo wörld 日本語 🎉🎉🎉".to_string(),
+            "\u{1}\"\\\n\r\t\u{1}\"\\\n\r\t".to_string(),
+        ]
+    }
+
+    #[test]
+    fn json_equivalence_exhaustive_and_extra_corpus() {
+        let mut checked = 0usize;
+        for s in exhaustive_single_char_corpus()
+            .into_iter()
+            .chain(extra_corpus())
+        {
+            assert_eq!(
+                old_json(&s),
+                new_out(&s, &JSON_ESCAPES),
+                "mismatch for {s:?}"
+            );
+            checked += 1;
+        }
+        assert!(checked > 1_100_000, "expected >1.1M cases, got {checked}");
+    }
+
+    #[test]
+    fn toml_equivalence_exhaustive_and_extra_corpus() {
+        let mut checked = 0usize;
+        for s in exhaustive_single_char_corpus()
+            .into_iter()
+            .chain(extra_corpus())
+        {
+            assert_eq!(
+                old_toml(&s),
+                new_out(&s, &TOML_ESCAPES),
+                "mismatch for {s:?}"
+            );
+            checked += 1;
+        }
+        assert!(checked > 1_100_000, "expected >1.1M cases, got {checked}");
+    }
+
+    #[test]
+    fn oml_equivalence_exhaustive_and_extra_corpus() {
+        let mut checked = 0usize;
+        for s in exhaustive_single_char_corpus()
+            .into_iter()
+            .chain(extra_corpus())
+        {
+            assert_eq!(old_oml(&s), new_out(&s, &OML_ESCAPES), "mismatch for {s:?}");
+            checked += 1;
+        }
+        assert!(checked > 1_100_000, "expected >1.1M cases, got {checked}");
+    }
+
+    #[test]
+    fn yaml_equivalence_exhaustive_and_extra_corpus() {
+        let mut checked = 0usize;
+        for s in exhaustive_single_char_corpus()
+            .into_iter()
+            .chain(extra_corpus())
+        {
+            assert_eq!(
+                old_yaml_quoted_branch(&s),
+                new_out(&s, &YAML_ESCAPES),
+                "mismatch for {s:?}"
+            );
+            checked += 1;
+        }
+        assert!(checked > 1_100_000, "expected >1.1M cases, got {checked}");
+    }
+
+    // ------------------------------------------------ all-occurrences guard
+    //
+    // Explicit, per-format check that *every* occurrence of an escapable
+    // character is escaped, not just the first -- the omnist-ts#36 class of
+    // bug this refactor must not reintroduce in any of the four formats.
+
+    #[test]
+    fn json_escapes_every_occurrence_not_just_the_first() {
+        let out = new_out("a\"b\"c\\d\\e\u{01}f\u{01}", &JSON_ESCAPES);
+        assert_eq!(out, "\"a\\\"b\\\"c\\\\d\\\\e\\u0001f\\u0001\"");
+    }
+
+    #[test]
+    fn toml_escapes_every_occurrence_not_just_the_first() {
+        let out = new_out("a\u{7f}b\u{7f}c\"d\"e", &TOML_ESCAPES);
+        assert_eq!(out, "\"a\\u007fb\\u007fc\\\"d\\\"e\"");
+    }
+
+    #[test]
+    fn oml_escapes_every_occurrence_not_just_the_first() {
+        let out = new_out("a\rb\rc\nd\ne", &OML_ESCAPES);
+        assert_eq!(out, "\"a\\rb\\rc\\nd\\ne\"");
+    }
+
+    #[test]
+    fn yaml_escapes_every_occurrence_not_just_the_first() {
+        let out = new_out("a\u{0085}b\u{0085}c\"d\"e", &YAML_ESCAPES);
+        assert_eq!(out, "\"a\\Nb\\Nc\\\"d\\\"e\"");
+    }
+
+    #[test]
+    fn adjacent_repeats_of_the_same_illegal_char_are_all_escaped() {
+        // Adjacent (not just non-adjacent) repeats -- the shape a
+        // first-match-only regression would be most likely to miss.
+        assert_eq!(
+            new_out("\u{01}\u{01}\u{01}", &JSON_ESCAPES),
+            "\"\\u0001\\u0001\\u0001\""
+        );
+        assert_eq!(
+            new_out("\u{7f}\u{7f}\u{7f}", &TOML_ESCAPES),
+            "\"\\u007f\\u007f\\u007f\""
+        );
+        assert_eq!(new_out("\r\r\r", &OML_ESCAPES), "\"\\r\\r\\r\"");
+        assert_eq!(
+            new_out("\u{0085}\u{0085}\u{0085}", &YAML_ESCAPES),
+            "\"\\N\\N\\N\""
+        );
+    }
+}

--- a/omnist/src/formats/toml.rs
+++ b/omnist/src/formats/toml.rs
@@ -209,6 +209,7 @@ use crate::document::{Doc, Value};
 use crate::error::{OmnistError, ParseError};
 use crate::formats::float_fmt;
 use crate::formats::int_cap::{MAX_INT_DIGITS, out_of_range_message, over_cap_message};
+use crate::formats::string_escape::{TOML_ESCAPES, write_quoted};
 use crate::formats::textpos::line_col_bytes;
 use crate::report::{Severity, WriteReport};
 use crate::schema::{is_iso_date, is_iso_datetime, is_iso_time};
@@ -552,23 +553,7 @@ fn is_bare_key(k: &str) -> bool {
 }
 
 fn write_toml_string(s: &str, out: &mut String) {
-    out.push('"');
-    for c in s.chars() {
-        match c {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            '\u{08}' => out.push_str("\\b"),
-            '\u{0c}' => out.push_str("\\f"),
-            c if (c as u32) < 0x20 || c == '\u{7f}' => {
-                out.push_str(&format!("\\u{:04x}", c as u32));
-            }
-            c => out.push(c),
-        }
-    }
-    out.push('"');
+    write_quoted(s, &TOML_ESCAPES, out);
 }
 
 #[cfg(test)]

--- a/omnist/src/formats/yaml.rs
+++ b/omnist/src/formats/yaml.rs
@@ -99,6 +99,7 @@ use crate::document::{Doc, Value};
 use crate::error::{OmnistError, ParseError};
 use crate::formats::float_fmt;
 use crate::formats::int_cap::{MAX_INT_DIGITS, out_of_range_message, over_cap_message};
+use crate::formats::string_escape::{YAML_ESCAPES, write_quoted};
 use crate::report::{Severity, WriteReport};
 use indexmap::IndexMap;
 
@@ -962,19 +963,7 @@ fn write_float(x: f64, out: &mut String) {
 /// leading/embedded punctuation) -- otherwise written plain.
 fn write_yaml_string(s: &str, out: &mut String) {
     if needs_quoting(s) {
-        out.push('"');
-        for c in s.chars() {
-            match c {
-                '"' => out.push_str("\\\""),
-                '\\' => out.push_str("\\\\"),
-                '\n' => out.push_str("\\n"),
-                '\t' => out.push_str("\\t"),
-                '\u{0085}' => out.push_str("\\N"),
-                c if (c as u32) < 0x20 => out.push_str(&format!("\\x{:02x}", c as u32)),
-                c => out.push(c),
-            }
-        }
-        out.push('"');
+        write_quoted(s, &YAML_ESCAPES, out);
     } else {
         out.push_str(s);
     }

--- a/omnist/src/oml.rs
+++ b/omnist/src/oml.rs
@@ -63,6 +63,7 @@
 use crate::document::{self, RawNode, Scalar, check_write_depth};
 use crate::error::{ParseError, WriteError};
 use crate::formats::int_cap::{MAX_INT_DIGITS, out_of_range_message, over_cap_message};
+use crate::formats::string_escape::{OML_ESCAPES, write_quoted};
 use crate::schema::{is_iso_date, is_iso_datetime, is_iso_time};
 
 // Same security guard as Python's `_MAX_INT_DIGITS`: reject an integer
@@ -1150,19 +1151,7 @@ fn write_float(v: f64) -> String {
 /// issue #10's omnist-ts#36-equivalent note).
 fn write_string(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 2);
-    out.push('"');
-    for ch in s.chars() {
-        match ch {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
-            c => out.push(c),
-        }
-    }
-    out.push('"');
+    write_quoted(s, &OML_ESCAPES, &mut out);
     out
 }
 


### PR DESCRIPTION
Closes #50

## Summary

`formats/json.rs`, `formats/toml.rs`, `formats/yaml.rs`, and `oml.rs` each
hand-rolled the same `for c in s.chars() { match c { ... } }` quoted-string
escape loop. `json.rs`'s and `toml.rs`'s bodies differed by exactly one
arm: TOML additionally matches `c == '\u{7f}'` in its control-char guard
(`c if (c as u32) < 0x20 || c == '\u{7f}'` vs JSON's `c if (c as u32) <
0x20`) — everything else in the two loops, including the `\b`/`\f` named
arms and the `\u{:04x}` control rendering, is byte-for-byte identical.

This factors all four into one `write_quoted(s, spec, out)` in the new
`omnist/src/formats/string_escape.rs`, with a per-format `EscapeSpec`
const table (`JSON_ESCAPES`, `TOML_ESCAPES`, `OML_ESCAPES`,
`YAML_ESCAPES`) describing named escapes, the control-char rendering style
(`\u{04x}` vs YAML's `\x{02x}`), and TOML's one extra `also_escape` char.
`yaml.rs`'s `needs_quoting`/plain-vs-quoted decision is untouched — only
the escape loop inside the quoted branch was replaced.

Note: `formats/xml.rs` also carries an omnist-ts#36-class guard
(`xml_sanitize`/`xml_escape_text`), but it's a structurally different
entity-escaper (`chars().map()` character substitution, not a
backslash-quoted-string loop) and isn't one of the four loops issue #50
describes — left untouched.

## Exhaustive old-vs-new equivalence (issue #50's hard requirement)

Before deleting any of the four original implementations, the old bodies
were kept as private helpers in `string_escape.rs`'s test module
(`old_json`, `old_toml`, `old_oml`, `old_yaml_quoted_branch`) and checked
against the new `write_quoted` over:

- every `char` in `0..=0x10FFFF` (surrogate range skipped, not a valid
  `char`) as a single-char string — 1,112,064 cases
- a 14-case corpus of multi-byte Unicode, empty string, and strings with
  multiple/adjacent occurrences of the same escapable character

**Result: 1,112,078 cases checked per format (4,448,312 total), zero
discrepancies.** Only after these four tests (`json_equivalence_exhaustive_and_extra_corpus`,
`toml_...`, `oml_...`, `yaml_...`) passed were the four original loop
bodies deleted from `json.rs`/`toml.rs`/`yaml.rs`/`oml.rs` and replaced
with calls to `write_quoted`.

## All-occurrences guarantee, confirmed for all four formats

`write_quoted` is a single per-char loop — it inspects and emits every
character once, so it structurally cannot under-sanitize by only touching
the first match (the omnist-ts#36 class of bug, PR #23). Previously this
was asserted only in `oml.rs`'s own doc comment/tests; this PR adds an
explicit per-format test with multiple occurrences of the same
escapable character (`json_escapes_every_occurrence_not_just_the_first`,
`toml_...`, `oml_...`, `yaml_...`), plus an
`adjacent_repeats_of_the_same_illegal_char_are_all_escaped` test covering
back-to-back repeats for all four specs. All pass.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — all passing (600 lib tests including the 9
  new equivalence/all-occurrences tests, plus all pre-existing per-format
  writer tests unmodified)
- `cargo llvm-cov --workspace --fail-under-lines 100` — 100.00% line
  coverage on every file, including the new `string_escape.rs`
