### PR TITLE
Refactor: a Codec trait for the five builtins (issue #52)

### DIFF
--- a/omnist/src/formats/json.rs
+++ b/omnist/src/formats/json.rs
@@ -132,6 +132,30 @@ pub fn check_json(doc: &Doc) -> WriteReport {
     rep
 }
 
+/// Marker type implementing [`crate::formats::Codec`] for JSON -- adapts
+/// [`read_json`]/[`write_json`]/[`check_json`] to the registry's uniform
+/// shape with the documented defaults (`indent: None`, `strict: false`, no
+/// report). See the trait's doc comment for why `write_json`'s `strict`-
+/// dependent content (NaN/Infinity substitution) ruled out a richer
+/// `scan`/`emit`-splitting trait.
+pub(crate) struct Json;
+
+impl crate::formats::Codec for Json {
+    const NAME: &'static str = "json";
+
+    fn read(text: &str) -> Result<Doc, OmnistError> {
+        read_json(text)
+    }
+
+    fn write(doc: &Doc) -> Result<String, OmnistError> {
+        write_json(doc, None, false, None).map_err(Into::into)
+    }
+
+    fn check(doc: &Doc) -> WriteReport {
+        check_json(doc)
+    }
+}
+
 /// Lenient-mode substitution: a NaN/Infinity leaf becomes `Null` so the
 /// written text is always valid JSON. Mirrors Python's `_prepare_json`.
 fn prepare(node: Value) -> Value {

--- a/omnist/src/formats/mod.rs
+++ b/omnist/src/formats/mod.rs
@@ -22,7 +22,52 @@ pub mod toml;
 pub mod xml;
 pub mod yaml;
 
-use crate::document::Value;
+use crate::document::{Doc, Value};
+use crate::error::OmnistError;
+use crate::report::WriteReport;
+
+/// The (read, write, check) contract every builtin format codec already
+/// implements as a naming convention -- expressed once (issue #52).
+///
+/// `read`/`write`/`check` intentionally match the registry's
+/// [`crate::registry::ReadFn`]/[`crate::registry::WriteFn`]/
+/// [`crate::registry::CheckFn`] signatures exactly: no `strict`, no
+/// `report`, no format-specific options (`write_json`'s `indent`,
+/// `write_oml`'s `RawNode`/`indent` shape). Each format's richer public
+/// `read_X`/`write_X(doc, ..., strict, report)`/`check_X` functions are
+/// unchanged and remain the actual public API -- a `Codec` impl is thin
+/// `pub(crate)` plumbing that calls them with the registry's documented
+/// defaults (`indent: None`, `strict: false`, no report requested; OML's
+/// `Doc::from_raw`/`to_raw` bridging), exactly what the hand-written
+/// wrapper closures in `registry::builtins` did before this issue -- see
+/// `registry.rs`'s module doc for why those defaults are the right ones
+/// and why the registry's signatures are simpler than the public
+/// functions'.
+///
+/// A richer trait sketch (scan/emit split, `strict`/`report`-aware
+/// `write`) was considered and rejected: `write_json` needs `strict` to
+/// pick lenient vs. strict *content* (NaN/Infinity substitution), not just
+/// whether `finish_write` raises, so a `strict`-unaware `emit` provided
+/// method would be wrong for JSON specifically and each impl would have to
+/// override `write` anyway -- collapsing the supposed savings. This
+/// leaner shape captures the actual duplication (the registry's adapter
+/// closures) without forcing an artificial decomposition that fights each
+/// format's real differences.
+pub(crate) trait Codec: 'static {
+    /// The name this codec is registered under (`"json"`, `"yaml"`, ...).
+    const NAME: &'static str;
+
+    fn read(text: &str) -> Result<Doc, OmnistError>;
+    fn write(doc: &Doc) -> Result<String, OmnistError>;
+    fn check(doc: &Doc) -> WriteReport;
+
+    /// Build this codec's [`crate::registry::Format`] entry -- the
+    /// wrapper-closure boilerplate `registry::builtins` used to hand-write
+    /// once per format, now written once here instead.
+    fn format() -> crate::registry::Format {
+        crate::registry::Format::new(Self::NAME, Self::read, Self::write).with_check(Self::check)
+    }
+}
 
 /// One position `visit_grouped` reaches, passed to its callback alongside
 /// the current path. Kept as a single enum (rather than two separate

--- a/omnist/src/formats/toml.rs
+++ b/omnist/src/formats/toml.rs
@@ -403,6 +403,30 @@ pub fn check_toml(doc: &Doc) -> WriteReport {
     rep
 }
 
+/// Marker type implementing [`crate::formats::Codec`] for TOML -- adapts
+/// [`read_toml`]/[`write_toml`]/[`check_toml`] to the registry's uniform
+/// shape with the documented defaults (`strict: false`, no report). The
+/// root-shape error `write_toml` raises for a non-object root fires from
+/// inside `write_toml` itself, outside `finish_write`, exactly as before --
+/// this impl only calls `write_toml`, it doesn't reimplement it.
+pub(crate) struct Toml;
+
+impl crate::formats::Codec for Toml {
+    const NAME: &'static str = "toml";
+
+    fn read(text: &str) -> Result<Doc, OmnistError> {
+        read_toml(text)
+    }
+
+    fn write(doc: &Doc) -> Result<String, OmnistError> {
+        write_toml(doc, false, None).map_err(Into::into)
+    }
+
+    fn check(doc: &Doc) -> WriteReport {
+        check_toml(doc)
+    }
+}
+
 /// Drops every null-valued field/array-item, recording a `null.omitted`
 /// warning for each (TOML has no null at all) -- see this module's doc
 /// comment. Mirrors Python's `_strip_nulls` path-numbering exactly:

--- a/omnist/src/formats/xml.rs
+++ b/omnist/src/formats/xml.rs
@@ -469,6 +469,31 @@ pub fn check_xml(doc: &Doc) -> WriteReport {
     rep
 }
 
+/// Marker type implementing [`crate::formats::Codec`] for XML -- adapts
+/// [`read_xml`]/[`write_xml`]/[`check_xml`] to the registry's uniform
+/// shape with the documented defaults (`strict: false`, no report). The
+/// single-document-element root-shape error `write_xml` raises fires from
+/// inside `write_xml` itself, outside `finish_write` and before any
+/// scanning, exactly as before -- this impl only calls `write_xml`, it
+/// doesn't reimplement it.
+pub(crate) struct Xml;
+
+impl crate::formats::Codec for Xml {
+    const NAME: &'static str = "xml";
+
+    fn read(text: &str) -> Result<Doc, OmnistError> {
+        read_xml(text)
+    }
+
+    fn write(doc: &Doc) -> Result<String, OmnistError> {
+        write_xml(doc, false, None).map_err(Into::into)
+    }
+
+    fn check(doc: &Doc) -> WriteReport {
+        check_xml(doc)
+    }
+}
+
 fn scan_xml_into(node: &RawNode, path: &str, rep: &mut WriteReport) {
     match node {
         RawNode::Edges(edges) => {

--- a/omnist/src/formats/yaml.rs
+++ b/omnist/src/formats/yaml.rs
@@ -844,6 +844,27 @@ pub fn check_yaml(doc: &Doc) -> WriteReport {
     rep
 }
 
+/// Marker type implementing [`crate::formats::Codec`] for YAML -- adapts
+/// [`read_yaml`]/[`write_yaml`]/[`check_yaml`] to the registry's uniform
+/// shape with the documented defaults (`strict: false`, no report).
+pub(crate) struct Yaml;
+
+impl crate::formats::Codec for Yaml {
+    const NAME: &'static str = "yaml";
+
+    fn read(text: &str) -> Result<Doc, OmnistError> {
+        read_yaml(text)
+    }
+
+    fn write(doc: &Doc) -> Result<String, OmnistError> {
+        write_yaml(doc, false, None).map_err(Into::into)
+    }
+
+    fn check(doc: &Doc) -> WriteReport {
+        check_yaml(doc)
+    }
+}
+
 fn indent(out: &mut String, level: usize) {
     for _ in 0..level {
         out.push_str("  ");

--- a/omnist/src/oml.rs
+++ b/omnist/src/oml.rs
@@ -1021,6 +1021,32 @@ pub fn check_oml(_doc: &crate::document::Doc) -> crate::report::WriteReport {
     crate::report::WriteReport::new()
 }
 
+/// Marker type implementing [`crate::formats::Codec`] for OML -- adapts
+/// [`read_oml`]/[`write_oml`]/[`check_oml`] to the registry's uniform
+/// `Doc`-in/`Doc`-out shape, exactly as `registry::builtins` did by hand
+/// before this issue: `read` bridges `read_oml`'s [`RawNode`] result
+/// through [`crate::document::Doc::from_raw`], and `write` bridges the
+/// other way through `Doc::to_raw` before calling `write_oml` with its
+/// documented default indent (2).
+pub(crate) struct Oml;
+
+impl crate::formats::Codec for Oml {
+    const NAME: &'static str = "oml";
+
+    fn read(text: &str) -> Result<document::Doc, crate::error::OmnistError> {
+        let raw: RawNode = read_oml(text)?;
+        document::Doc::from_raw(raw).map_err(Into::into)
+    }
+
+    fn write(doc: &document::Doc) -> Result<String, crate::error::OmnistError> {
+        write_oml(&doc.to_raw(), 2).map_err(Into::into)
+    }
+
+    fn check(doc: &document::Doc) -> crate::report::WriteReport {
+        check_oml(doc)
+    }
+}
+
 /// `node_depth` is *this edges list's own* depth, matching
 /// `document.rs`'s `push_raw`/`build_node` convention exactly: the guard is
 /// checked for every node (container *and* leaf) at its own depth, with a

--- a/omnist/src/registry.rs
+++ b/omnist/src/registry.rs
@@ -115,40 +115,23 @@ fn registry() -> &'static RwLock<IndexMap<String, Format>> {
 }
 
 fn builtins() -> IndexMap<String, Format> {
-    use crate::document::RawNode;
-    use crate::formats::{json, toml, xml, yaml};
-    use crate::oml;
+    use crate::formats::Codec;
+    use crate::formats::json::Json;
+    use crate::formats::toml::Toml;
+    use crate::formats::xml::Xml;
+    use crate::formats::yaml::Yaml;
+    use crate::oml::Oml;
 
     let mut m = IndexMap::new();
     let mut add = |fmt: Format| {
         m.insert(fmt.name.clone(), fmt);
     };
 
-    add(Format::new("json", json::read_json, |doc| {
-        json::write_json(doc, None, false, None).map_err(Into::into)
-    })
-    .with_check(json::check_json));
-    add(Format::new("yaml", yaml::read_yaml, |doc| {
-        yaml::write_yaml(doc, false, None).map_err(Into::into)
-    })
-    .with_check(yaml::check_yaml));
-    add(Format::new("toml", toml::read_toml, |doc| {
-        toml::write_toml(doc, false, None).map_err(Into::into)
-    })
-    .with_check(toml::check_toml));
-    add(Format::new("xml", xml::read_xml, |doc| {
-        xml::write_xml(doc, false, None).map_err(Into::into)
-    })
-    .with_check(xml::check_xml));
-    add(Format::new(
-        "oml",
-        |text| {
-            let raw: RawNode = oml::read_oml(text)?;
-            Doc::from_raw(raw).map_err(Into::into)
-        },
-        |doc| oml::write_oml(&doc.to_raw(), 2).map_err(Into::into),
-    )
-    .with_check(oml::check_oml));
+    add(Json::format());
+    add(Yaml::format());
+    add(Toml::format());
+    add(Xml::format());
+    add(Oml::format());
 
     m
 }


### PR DESCRIPTION
## Summary

- `registry::builtins()` hand-wrote five wrapper closures adapting each format's differently-shaped `read_X`/`write_X`/`check_X` to the registry's uniform `ReadFn`/`WriteFn`/`CheckFn` signatures. Adds a `pub(crate) Codec` trait (in `formats/mod.rs`) capturing that adapter once, with a provided `format()` method; `builtins()` becomes five `add(X::format())` lines.
- Each format's existing `pub fn read_X`/`write_X`/`check_X` are untouched and remain the real public API (still called directly by `omnist-cli` and `omnist/tests/{parity,fuzz}.rs`). A `Codec` impl (`Json`/`Yaml`/`Toml`/`Xml`/`Oml`, one per format module) just calls them with the same default arguments (`indent: None`, `strict: false`, no report; OML's `Doc::from_raw`/`to_raw` bridging) the old closures used.
- toml's/xml's root-shape errors still fire from inside `write_toml`/`write_xml` themselves, outside `finish_write`, unconditionally -- this refactor never touches those function bodies, only how `registry.rs` wires to them.

## Design note: scope narrower than the issue's sketch

The issue sketched a richer `scan`/`emit`-splitting trait with a provided `write(strict, report)`. I built and then backed out of that shape: `write_json` needs `strict` to choose lenient-vs-strict *content* (NaN/Infinity substitution), not just whether `finish_write` raises -- a `strict`-unaware `emit` provided method is wrong for JSON specifically, and every impl (json, oml at minimum) would end up overriding `write` anyway, which erases the supposed savings. The `Codec` trait implemented here matches the registry's actual (simpler) signatures -- no `strict`/`report` -- and captures the real duplication (the registry's adapter closures) without forcing a decomposition that fights each format's differences. See `formats/mod.rs`'s trait doc comment for the full reasoning.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` -- 742 passed, 0 failed (same count as main)
- [x] `cargo llvm-cov --workspace --fail-under-lines 100` -- 100.00% line coverage, gate passes
- [x] Confirmed toml/xml root-shape-error ordering unchanged (function bodies untouched)

Closes #52
