### PR TITLE
Fix S-3 builder-API gap and add a general node-count safety limit

### DIFF
--- a/omnist/src/document.rs
+++ b/omnist/src/document.rs
@@ -41,6 +41,16 @@ use crate::error::DocumentError;
 /// Maximum nesting depth for a Document node (matches Python's `_MAX_DEPTH`).
 pub const MAX_DEPTH: usize = 200;
 
+/// Maximum total node count for a single Document (matches the reference
+/// default in omnist-spec docs/02-document-model.md Sec2.4: a depth limit
+/// alone doesn't bound a shallow-but-enormous document, e.g. a million
+/// sibling edges at depth 1). Enforced once, in [`push`], the single arena
+/// choke point every construction path (`build_node`, `push_raw`) funnels
+/// through -- see omnist-rs#78: previously the only node-count guard in
+/// this crate was scoped narrowly to `formats::yaml`'s anchor/alias
+/// amplification defense, leaving every other construction path unbounded.
+pub const MAX_NODES: usize = 1_000_000;
+
 /// An index into a [`Doc`]'s arena. Opaque outside this module's crate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct NodeId(usize);
@@ -219,7 +229,7 @@ fn build_node(
                     edges.push((k.clone(), cid));
                 }
             }
-            Ok(push(arena, NodeData::Internal(edges), depth))
+            push(arena, NodeData::Internal(edges), depth, path)
         }
         Value::Array(_) => Err(DocumentError::new(
             path,
@@ -230,18 +240,31 @@ fn build_node(
         // catch-all) so every arm is a real, exhaustive possibility --
         // no `Value::Array(_) | Value::Object(_) => unreachable!()` arm
         // to justify, since those two variants are already handled above.
-        Value::Null => Ok(push(arena, NodeData::Leaf(Scalar::Null), depth)),
-        Value::Bool(b) => Ok(push(arena, NodeData::Leaf(Scalar::Bool(*b)), depth)),
-        Value::Int(i) => Ok(push(arena, NodeData::Leaf(Scalar::Int(*i)), depth)),
-        Value::Float(x) => Ok(push(arena, NodeData::Leaf(Scalar::Float(*x)), depth)),
-        Value::Str(s) => Ok(push(arena, NodeData::Leaf(Scalar::Str(s.clone())), depth)),
+        Value::Null => push(arena, NodeData::Leaf(Scalar::Null), depth, path),
+        Value::Bool(b) => push(arena, NodeData::Leaf(Scalar::Bool(*b)), depth, path),
+        Value::Int(i) => push(arena, NodeData::Leaf(Scalar::Int(*i)), depth, path),
+        Value::Float(x) => push(arena, NodeData::Leaf(Scalar::Float(*x)), depth, path),
+        Value::Str(s) => push(arena, NodeData::Leaf(Scalar::Str(s.clone())), depth, path),
     }
 }
 
-fn push(arena: &mut Vec<Entry>, data: NodeData, depth: usize) -> NodeId {
+/// The shared node-count guard, checked once here since every construction
+/// path (`build_node`, `push_raw`) funnels through this single function.
+fn push(
+    arena: &mut Vec<Entry>,
+    data: NodeData,
+    depth: usize,
+    path: &str,
+) -> Result<NodeId, DocumentError> {
+    if arena.len() >= MAX_NODES {
+        return Err(DocumentError::new(
+            path,
+            format!("document exceeds the maximum node count ({MAX_NODES})"),
+        ));
+    }
     let id = NodeId(arena.len());
     arena.push(Entry { data, depth });
-    id
+    Ok(id)
 }
 
 /// A guarded handle on a Document tree: an arena of nodes plus the root.
@@ -688,14 +711,14 @@ fn push_raw(arena: &mut Vec<Entry>, node: RawNode, depth: usize) -> Result<NodeI
     // path for depth violations anyway (see `check_write_depth`).
     check_write_depth(depth, "$")?;
     match node {
-        RawNode::Leaf(s) => Ok(push(arena, NodeData::Leaf(s), depth)),
+        RawNode::Leaf(s) => push(arena, NodeData::Leaf(s), depth, "$"),
         RawNode::Edges(edges) => {
             let mut out = Vec::with_capacity(edges.len());
             for (label, child) in edges {
                 let cid = push_raw(arena, child, depth + 1)?;
                 out.push((label, cid));
             }
-            Ok(push(arena, NodeData::Internal(out), depth))
+            push(arena, NodeData::Internal(out), depth, "$")
         }
     }
 }
@@ -792,6 +815,32 @@ mod tests {
         let v = nest(MAX_DEPTH + 1);
         let err = Doc::of(&v).unwrap_err();
         assert!(err.message.contains("maximum depth"));
+    }
+
+    // -- node-count guard: max-nodes boundary (omnist-rs#78) -------------
+    //
+    // A shallow document can still be enormous -- depth alone doesn't bound
+    // total memory, e.g. a single label repeated a million times is depth 1.
+    // `wide(n)` builds `{"a": [0, 0, ..., 0]}` with `n` array elements, for
+    // a total node count of `n + 1` (the root object, plus one leaf per
+    // array element -- the array itself desugars into repeated edges, not
+    // its own node).
+
+    fn wide(n: usize) -> Value {
+        obj(&[("a", Value::Array(vec![Value::Int(0); n]))])
+    }
+
+    #[test]
+    fn node_guard_accepts_exactly_max_nodes() {
+        let v = wide(MAX_NODES - 1);
+        assert!(Doc::of(&v).is_ok());
+    }
+
+    #[test]
+    fn node_guard_rejects_one_past_max_nodes() {
+        let v = wide(MAX_NODES);
+        let err = Doc::of(&v).unwrap_err();
+        assert!(err.message.contains("maximum node count"));
     }
 
     #[test]

--- a/omnist/src/schema.rs
+++ b/omnist/src/schema.rs
@@ -574,11 +574,36 @@ pub struct Schema {
 impl Schema {
     /// Builds a schema and immediately checks every `Ref` (the root's, and
     /// every field's) resolves within `env` -- mirrors Python's
-    /// `Schema.__init__` calling `check_refs()` unconditionally.
+    /// `Schema.__init__` calling `check_refs()` unconditionally. Also
+    /// enforces S-3 (omnist-spec docs/03-schema-model.md): no record may be
+    /// named after a scalar keyword or `any`, since a bare name in type
+    /// position always resolves to the builtin first and such a record could
+    /// never be referenced. `osd.rs`'s parser already enforces this; this is
+    /// the same check at the builder-API surface (omnist-rs#76).
     pub fn new(root: Ref, env: IndexMap<String, Record>) -> Result<Self, SchemaError> {
+        Self::check_reserved_names(&env)?;
         let schema = Schema { root, env };
         schema.check_refs()?;
         Ok(schema)
+    }
+
+    fn check_reserved_names(env: &IndexMap<String, Record>) -> Result<(), SchemaError> {
+        for name in env.keys() {
+            if name == "any" {
+                return Err(SchemaError::new(format!(
+                    "'any' is a reserved type name and cannot be used as a record name \
+                     (record {name:?})"
+                )));
+            }
+            if ScalarKind::ALL.iter().any(|k| k.as_str() == name) {
+                return Err(SchemaError::new(format!(
+                    "{name:?} is a reserved scalar name; a record cannot be defined with \
+                     this name, or it could never be referenced (a bare name in a type \
+                     position always means the builtin scalar)"
+                )));
+            }
+        }
+        Ok(())
     }
 
     pub fn root(&self) -> &Ref {
@@ -899,6 +924,35 @@ mod tests {
         let err = Schema::new(Ref::new("Root"), env).unwrap_err();
         assert!(err.to_string().contains("unknown type"));
         assert!(err.to_string().contains("Missing"));
+    }
+
+    #[test]
+    fn schema_rejects_a_record_named_after_a_scalar_keyword() {
+        // S-3 (omnist-spec docs/03-schema-model.md): a record named "string"
+        // could never be referenced, since a bare name in type position
+        // always resolves to the builtin scalar first. omnist-rs#76.
+        let mut env = Map::new();
+        env.insert(
+            "Root".to_string(),
+            Record::new(vec![Field::required("x", STRING).unwrap()]).unwrap(),
+        );
+        env.insert("string".to_string(), Record::new(vec![]).unwrap());
+        let err = Schema::new(Ref::new("Root"), env).unwrap_err();
+        assert!(err.to_string().contains("reserved scalar name"));
+        assert!(err.to_string().contains("\"string\""));
+    }
+
+    #[test]
+    fn schema_rejects_a_record_named_any() {
+        // S-3, the `any` half of the same constraint. omnist-rs#76.
+        let mut env = Map::new();
+        env.insert(
+            "Root".to_string(),
+            Record::new(vec![Field::required("x", STRING).unwrap()]).unwrap(),
+        );
+        env.insert("any".to_string(), Record::new(vec![]).unwrap());
+        let err = Schema::new(Ref::new("Root"), env).unwrap_err();
+        assert!(err.to_string().contains("reserved type name"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes two real bugs found in a spec-vs-implementation audit against omnist-spec, and retracts a third finding that turned out to be a spec bug, not a Rust one.

- Closes #76 (S-3 unenforced in the builder API)
- Closes #78 (no general node-count safety limit)
- #77 (lint duplicate-record finding shape) is closed separately as invalid -- see the issue for the full story; no change needed here because Rust's original code was already correct.

## Changes

**S-3**: `Schema::new` now rejects a record named after a scalar keyword (`string`, `integer`, ...) or `any`, matching `osd.rs`'s parser-level check. Previously a record named e.g. `string` was silently accepted and permanently unreachable by reference.

**General node-count limit**: added `MAX_NODES = 1_000_000`, checked once in `push` (the single arena choke point every construction path already funnels through), matching the spec's reference default and closing the gap where a document with one label repeated a million times (depth 1, unbounded node count) was accepted without limit. YAML's existing narrower `MAX_MATERIALIZED_NODES` guard is untouched -- unifying the two is a separate, non-blocking cleanup if wanted later.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (all suites: lib, cli, examples, fuzz incl. cross-implementation Python oracle, doc-guide, doc-cli, parity corpus)
- [x] `cargo llvm-cov --workspace --fail-under-lines 100` -- 100% line coverage maintained
- [x] New tests: two builder-level S-3 rejection tests in `schema.rs`, two node-count boundary tests (accept-at-limit, reject-one-past) in `document.rs`
