### PR TITLE
Add conformance-harness skeleton: referee + self-test (issue #82 Step 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt, llvm-tools-preview

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/omnist-spec"]
+	path = vendor/omnist-spec
+	url = git@github.com:omnist-dev/omnist-spec.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "conformance"
+version = "0.0.1-alpha"
+dependencies = [
+ "omnist",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "2"
-members = ["omnist", "omnist-cli", "tools/check-doc-examples"]
+members = ["omnist", "omnist-cli", "tools/check-doc-examples", "tools/conformance"]

--- a/omnist/src/schema.rs
+++ b/omnist/src/schema.rs
@@ -394,11 +394,40 @@ impl Field {
 }
 
 /// A closed set of named fields (constrained by its child labels).
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// `fields` preserves declaration order (needed for canonical OSD
+/// rendering and `prune`'s declaration-order environment reconstruction --
+/// see `ops/mod.rs`'s module docs), but equality below deliberately treats
+/// it as an unordered set: omnist-spec's `docs/03-schema-model.md` Sec3.1
+/// states fields are an unordered set at the model layer, so two records
+/// declaring the same fields in a different order must compare equal.
+/// Confirmed empirically by this crate's own conformance self-test
+/// (`tools/conformance`, fixture
+/// `_referee-self-test/01-schema-exact-equal-different-field-order`) before
+/// this manual `PartialEq` replaced the field-order-sensitive derive.
+#[derive(Debug, Clone)]
 pub struct Record {
     fields: Vec<Field>,
     by_label: IndexMap<String, usize>,
 }
+
+impl PartialEq for Record {
+    fn eq(&self, other: &Self) -> bool {
+        if self.fields.len() != other.fields.len() {
+            return false;
+        }
+        // No duplicate labels within a record (enforced by `Record::new`),
+        // so sorting by label gives each side a canonical, comparable
+        // order regardless of declaration order.
+        let mut a: Vec<&Field> = self.fields.iter().collect();
+        let mut b: Vec<&Field> = other.fields.iter().collect();
+        a.sort_by(|x, y| x.label.cmp(&y.label));
+        b.sort_by(|x, y| x.label.cmp(&y.label));
+        a == b
+    }
+}
+
+impl Eq for Record {}
 
 impl Record {
     /// Rejects a duplicate field label, matching Python's `Record.__init__`.
@@ -795,6 +824,27 @@ mod tests {
     use super::*;
     use crate::document::{Doc, Value};
     use indexmap::IndexMap as Map;
+
+    #[test]
+    fn record_partial_eq_treats_field_order_as_insignificant_but_field_count_as_significant() {
+        let r1 = Record::new(vec![
+            Field::required("x", STRING).unwrap(),
+            Field::required("y", STRING).unwrap(),
+        ])
+        .unwrap();
+        let r2 = Record::new(vec![
+            Field::required("y", STRING).unwrap(),
+            Field::required("x", STRING).unwrap(),
+        ])
+        .unwrap();
+        assert_eq!(r1, r2, "declaration order must not affect Record equality");
+
+        let r3 = Record::new(vec![Field::required("x", STRING).unwrap()]).unwrap();
+        assert_ne!(
+            r1, r3,
+            "a different field count must never compare equal, regardless of order"
+        );
+    }
 
     fn obj(pairs: &[(&str, Value)]) -> Value {
         let mut m = Map::new();

--- a/tools/conformance/Cargo.toml
+++ b/tools/conformance/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "conformance"
+version = "0.0.1-alpha"
+edition = "2024"
+description = "omnist-rs's own conformance-test harness against omnist-spec (issue #82): referee + Track 1 fixture runner + Track 2 vector runner, consuming the pinned vendor/omnist-spec submodule directly, never depending on Python's or TypeScript's implementation."
+license = "Apache-2.0"
+publish = false
+
+[lib]
+name = "conformance"
+path = "src/lib.rs"
+
+[[bin]]
+name = "self-test"
+path = "src/bin/self_test.rs"
+
+[dependencies]
+omnist = { path = "../../omnist" }

--- a/tools/conformance/src/bin/self_test.rs
+++ b/tools/conformance/src/bin/self_test.rs
@@ -1,0 +1,411 @@
+//! Runs vendor/omnist-spec's `conformance/fixtures/_referee-self-test/` --
+//! proves the referee's own comparison logic is trustworthy before it
+//! judges any real implementation output. omnist-spec's
+//! `docs/conformance-harness.md` §6.
+//!
+//! Ported in spirit from Python's `omnist`'s `tools/conformance/self_test.py`
+//! and omnist-ts's `tools/conformance/selfTest.ts` (same architecture);
+//! only `FIXTURES_DIR` now points at this repo's own pinned submodule.
+//!
+//! Usage:
+//!
+//!     cargo run -p conformance --bin self-test
+
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use conformance::referee::{compare_document, compare_schema};
+
+fn fixtures_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("vendor")
+        .join("omnist-spec")
+        .join("conformance")
+        .join("fixtures")
+        .join("_referee-self-test")
+}
+
+struct CaseResult {
+    passed: bool,
+    message: String,
+}
+
+fn read(dir: &Path, name: &str) -> std::io::Result<String> {
+    std::fs::read_to_string(dir.join(name))
+}
+
+/// Runs one self-test case directory, returning whether the referee's
+/// judgment matched the fixture's `expect.txt`.
+fn run_case(case_dir: &Path) -> CaseResult {
+    let kind = match read(case_dir, "kind.txt") {
+        Ok(s) => s.trim().to_string(),
+        Err(e) => {
+            return CaseResult {
+                passed: false,
+                message: format!("missing kind.txt: {e}"),
+            };
+        }
+    };
+    let expect = match read(case_dir, "expect.txt") {
+        Ok(s) => s.trim().to_string(),
+        Err(e) => {
+            return CaseResult {
+                passed: false,
+                message: format!("missing expect.txt: {e}"),
+            };
+        }
+    };
+    let expect_equal = match expect.as_str() {
+        "equal" => true,
+        "not-equal" => false,
+        other => {
+            return CaseResult {
+                passed: false,
+                message: format!("bad expect.txt value {other:?}"),
+            };
+        }
+    };
+
+    let actual_equal: bool = match kind.as_str() {
+        "document" => {
+            let a = match read(case_dir, "a.oml") {
+                Ok(s) => s,
+                Err(e) => {
+                    return CaseResult {
+                        passed: false,
+                        message: format!("{e}"),
+                    };
+                }
+            };
+            let b = match read(case_dir, "b.oml") {
+                Ok(s) => s,
+                Err(e) => {
+                    return CaseResult {
+                        passed: false,
+                        message: format!("{e}"),
+                    };
+                }
+            };
+            match compare_document(&a, &b) {
+                Ok(v) => v,
+                Err(e) => {
+                    return CaseResult {
+                        passed: false,
+                        message: e,
+                    };
+                }
+            }
+        }
+        "schema" => {
+            let mode = match read(case_dir, "mode.txt") {
+                Ok(s) => s.trim().to_string(),
+                Err(e) => {
+                    return CaseResult {
+                        passed: false,
+                        message: format!("missing mode.txt: {e}"),
+                    };
+                }
+            };
+            let a = match read(case_dir, "a.osd") {
+                Ok(s) => s,
+                Err(e) => {
+                    return CaseResult {
+                        passed: false,
+                        message: format!("{e}"),
+                    };
+                }
+            };
+            let b = match read(case_dir, "b.osd") {
+                Ok(s) => s,
+                Err(e) => {
+                    return CaseResult {
+                        passed: false,
+                        message: format!("{e}"),
+                    };
+                }
+            };
+            match compare_schema(&a, &b, &mode) {
+                Ok(v) => v,
+                Err(e) => {
+                    return CaseResult {
+                        passed: false,
+                        message: e,
+                    };
+                }
+            }
+        }
+        other => {
+            return CaseResult {
+                passed: false,
+                message: format!("bad kind.txt value {other:?}"),
+            };
+        }
+    };
+
+    if actual_equal == expect_equal {
+        CaseResult {
+            passed: true,
+            message: "ok".to_string(),
+        }
+    } else {
+        CaseResult {
+            passed: false,
+            message: format!(
+                "expected {}, got {}",
+                if expect_equal { "equal" } else { "not-equal" },
+                if actual_equal { "equal" } else { "not-equal" },
+            ),
+        }
+    }
+}
+
+/// Runs every case directory under `dir`, printing PASS/FAIL per case plus
+/// a summary line. Returns the process exit code (0 all-pass, 1 any
+/// failure, 2 no fixtures found) -- takes the directory as a parameter
+/// (rather than hard-coding it) so tests can point it at a scratch
+/// directory to exercise the not-a-directory/no-cases branches without
+/// touching the real submodule checkout.
+fn main_with_dir(dir: &Path) -> u8 {
+    let Ok(read_dir) = std::fs::read_dir(dir) else {
+        eprintln!("no self-test fixtures found at {}", dir.display());
+        return 2;
+    };
+
+    let mut cases: Vec<PathBuf> = read_dir
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .collect();
+    cases.sort();
+
+    if cases.is_empty() {
+        eprintln!("no self-test fixtures found at {}", dir.display());
+        return 2;
+    }
+
+    let mut failures = 0u32;
+    for case_dir in &cases {
+        let purpose = read(case_dir, "purpose.txt")
+            .ok()
+            .and_then(|s| s.lines().next().map(str::to_string))
+            .unwrap_or_default();
+        let name = case_dir.file_name().unwrap().to_string_lossy();
+        let result = run_case(case_dir);
+        let status = if result.passed { "PASS" } else { "FAIL" };
+        println!("[{status}] {name} ({purpose}): {}", result.message);
+        if !result.passed {
+            failures += 1;
+        }
+    }
+
+    println!(
+        "\n{}/{} self-test cases passed",
+        cases.len() as u32 - failures,
+        cases.len()
+    );
+    if failures > 0 { 1 } else { 0 }
+}
+
+fn main() -> ExitCode {
+    ExitCode::from(main_with_dir(&fixtures_dir()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn write(dir: &Path, name: &str, content: &str) {
+        fs::write(dir.join(name), content).unwrap();
+    }
+
+    #[test]
+    fn all_ten_real_fixtures_pass() {
+        let code = main_with_dir(&fixtures_dir());
+        assert_eq!(code, 0);
+    }
+
+    #[test]
+    fn real_fixture_count_is_ten() {
+        let count = fs::read_dir(fixtures_dir())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir())
+            .count();
+        assert_eq!(count, 10);
+    }
+
+    #[test]
+    fn missing_directory_returns_two() {
+        let tmp = std::env::temp_dir().join("conformance-self-test-missing");
+        let _ = fs::remove_dir_all(&tmp);
+        assert_eq!(main_with_dir(&tmp), 2);
+    }
+
+    #[test]
+    fn empty_directory_returns_two() {
+        let tmp = std::env::temp_dir().join("conformance-self-test-empty");
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).unwrap();
+        assert_eq!(main_with_dir(&tmp), 2);
+    }
+
+    #[test]
+    fn a_genuinely_failing_case_returns_one() {
+        let tmp = std::env::temp_dir().join("conformance-self-test-fail-case");
+        let _ = fs::remove_dir_all(&tmp);
+        let case = tmp.join("01-broken");
+        fs::create_dir_all(&case).unwrap();
+        write(&case, "kind.txt", "document\n");
+        write(&case, "expect.txt", "equal\n");
+        write(&case, "a.oml", "a: 1\n");
+        write(&case, "b.oml", "a: 2\n");
+        assert_eq!(main_with_dir(&tmp), 1);
+    }
+
+    #[test]
+    fn bad_expect_value_fails_the_case() {
+        let tmp = std::env::temp_dir().join("conformance-self-test-bad-expect");
+        let _ = fs::remove_dir_all(&tmp);
+        let case = tmp.join("01-bad-expect");
+        fs::create_dir_all(&case).unwrap();
+        write(&case, "kind.txt", "document\n");
+        write(&case, "expect.txt", "maybe\n");
+        write(&case, "a.oml", "a: 1\n");
+        write(&case, "b.oml", "a: 1\n");
+        assert_eq!(main_with_dir(&tmp), 1);
+    }
+
+    #[test]
+    fn bad_kind_value_fails_the_case() {
+        let tmp = std::env::temp_dir().join("conformance-self-test-bad-kind");
+        let _ = fs::remove_dir_all(&tmp);
+        let case = tmp.join("01-bad-kind");
+        fs::create_dir_all(&case).unwrap();
+        write(&case, "kind.txt", "nonsense\n");
+        write(&case, "expect.txt", "equal\n");
+        assert_eq!(main_with_dir(&tmp), 1);
+    }
+
+    #[test]
+    fn missing_kind_file_fails_the_case() {
+        let tmp = std::env::temp_dir().join("conformance-self-test-missing-kind");
+        let _ = fs::remove_dir_all(&tmp);
+        let case = tmp.join("01-missing-kind");
+        fs::create_dir_all(&case).unwrap();
+        write(&case, "expect.txt", "equal\n");
+        assert_eq!(main_with_dir(&tmp), 1);
+    }
+
+    #[test]
+    fn missing_expect_file_fails_the_case() {
+        let tmp = std::env::temp_dir().join("conformance-self-test-missing-expect");
+        let _ = fs::remove_dir_all(&tmp);
+        let case = tmp.join("01-missing-expect");
+        fs::create_dir_all(&case).unwrap();
+        write(&case, "kind.txt", "document\n");
+        assert_eq!(main_with_dir(&tmp), 1);
+    }
+
+    #[test]
+    fn missing_a_oml_file_fails_a_document_case() {
+        let tmp = std::env::temp_dir().join("conformance-self-test-missing-a-oml");
+        let _ = fs::remove_dir_all(&tmp);
+        let case = tmp.join("01-missing-a-oml");
+        fs::create_dir_all(&case).unwrap();
+        write(&case, "kind.txt", "document\n");
+        write(&case, "expect.txt", "equal\n");
+        write(&case, "b.oml", "a: 1\n");
+        assert_eq!(main_with_dir(&tmp), 1);
+    }
+
+    #[test]
+    fn missing_b_oml_file_fails_a_document_case() {
+        let tmp = std::env::temp_dir().join("conformance-self-test-missing-b-oml");
+        let _ = fs::remove_dir_all(&tmp);
+        let case = tmp.join("01-missing-b-oml");
+        fs::create_dir_all(&case).unwrap();
+        write(&case, "kind.txt", "document\n");
+        write(&case, "expect.txt", "equal\n");
+        write(&case, "a.oml", "a: 1\n");
+        assert_eq!(main_with_dir(&tmp), 1);
+    }
+
+    #[test]
+    fn missing_a_osd_file_fails_a_schema_case() {
+        let tmp = std::env::temp_dir().join("conformance-self-test-missing-a-osd");
+        let _ = fs::remove_dir_all(&tmp);
+        let case = tmp.join("01-missing-a-osd");
+        fs::create_dir_all(&case).unwrap();
+        write(&case, "kind.txt", "schema\n");
+        write(&case, "expect.txt", "equal\n");
+        write(&case, "mode.txt", "exact\n");
+        write(
+            &case,
+            "b.osd",
+            "record R {\n    \"x\": string,\n}\nroot R\n",
+        );
+        assert_eq!(main_with_dir(&tmp), 1);
+    }
+
+    #[test]
+    fn missing_b_osd_file_fails_a_schema_case() {
+        let tmp = std::env::temp_dir().join("conformance-self-test-missing-b-osd");
+        let _ = fs::remove_dir_all(&tmp);
+        let case = tmp.join("01-missing-b-osd");
+        fs::create_dir_all(&case).unwrap();
+        write(&case, "kind.txt", "schema\n");
+        write(&case, "expect.txt", "equal\n");
+        write(&case, "mode.txt", "exact\n");
+        write(
+            &case,
+            "a.osd",
+            "record R {\n    \"x\": string,\n}\nroot R\n",
+        );
+        assert_eq!(main_with_dir(&tmp), 1);
+    }
+
+    #[test]
+    fn missing_mode_file_fails_a_schema_case() {
+        let tmp = std::env::temp_dir().join("conformance-self-test-missing-mode");
+        let _ = fs::remove_dir_all(&tmp);
+        let case = tmp.join("01-missing-mode");
+        fs::create_dir_all(&case).unwrap();
+        write(&case, "kind.txt", "schema\n");
+        write(&case, "expect.txt", "equal\n");
+        assert_eq!(main_with_dir(&tmp), 1);
+    }
+
+    #[test]
+    fn bad_oml_fails_the_case() {
+        let tmp = std::env::temp_dir().join("conformance-self-test-bad-oml");
+        let _ = fs::remove_dir_all(&tmp);
+        let case = tmp.join("01-bad-oml");
+        fs::create_dir_all(&case).unwrap();
+        write(&case, "kind.txt", "document\n");
+        write(&case, "expect.txt", "equal\n");
+        write(&case, "a.oml", "[[[not valid\n");
+        write(&case, "b.oml", "a: 1\n");
+        assert_eq!(main_with_dir(&tmp), 1);
+    }
+
+    #[test]
+    fn bad_osd_fails_a_schema_case() {
+        let tmp = std::env::temp_dir().join("conformance-self-test-bad-osd");
+        let _ = fs::remove_dir_all(&tmp);
+        let case = tmp.join("01-bad-osd");
+        fs::create_dir_all(&case).unwrap();
+        write(&case, "kind.txt", "schema\n");
+        write(&case, "expect.txt", "equal\n");
+        write(&case, "mode.txt", "exact\n");
+        write(&case, "a.osd", "not valid osd\n");
+        write(
+            &case,
+            "b.osd",
+            "record R {\n    \"x\": string,\n}\nroot R\n",
+        );
+        assert_eq!(main_with_dir(&tmp), 1);
+    }
+}

--- a/tools/conformance/src/lib.rs
+++ b/tools/conformance/src/lib.rs
@@ -1,0 +1,13 @@
+//! omnist-rs's own conformance-test harness against omnist-spec (issue
+//! #82). Step 1 delivers the referee and its self-test only; Track 1
+//! (`conformance/fixtures/`) and Track 2 (`test-suite/`) runners are later
+//! steps.
+//!
+//! Consumes the pinned `vendor/omnist-spec` git submodule (tag
+//! `v0.1.0-alpha`, commit `b5232e9edb8f40119d0514c7a5a7fc0830be1bf3`)
+//! directly via `omnist` library calls -- never depends on Python's or
+//! TypeScript's implementation, matching the design already proven twice
+//! (Python's `omnist/tools/conformance/`, omnist-ts's
+//! `tools/conformance/`).
+
+pub mod referee;

--- a/tools/conformance/src/referee.rs
+++ b/tools/conformance/src/referee.rs
@@ -1,0 +1,153 @@
+//! The comparison referee -- omnist-spec's `docs/conformance-harness.md`
+//! §4/§6.2.
+//!
+//! Uses `omnist`'s own library (direct calls, never a CLI subprocess --
+//! `omnist` is a real library crate first, per issue #82's locked-in
+//! calling-convention decision) to parse OML/OSD text and judge structural
+//! equality. Deliberately small: no fixture-format parsing, no
+//! per-operation dispatch -- that's the (later-step) fixture and vector
+//! runners' job. Ported in spirit from Python's `omnist`'s
+//! `tools/conformance/referee.py` and omnist-ts's
+//! `tools/conformance/referee.ts` (same architecture); this file follows
+//! Rust idiom, not either one's syntax (workflow-playbook.md's
+//! "architecture freedom").
+//!
+//! ## Comparison strategy (locked in by issue #82, documented here)
+//!
+//! Document comparison goes through [`omnist::document::Doc::to_raw`] to a
+//! [`omnist::document::RawNode`], which already derives `PartialEq`, rather
+//! than adding `PartialEq` to `Doc` itself: `Doc`'s internal arena +
+//! `NodeId` representation is not guaranteed canonical across
+//! structurally-equal documents (e.g. two `Doc`s built by different code
+//! paths could use different arena layouts for the same tree), so deriving
+//! equality directly on `Doc` would be unsound. `RawNode`'s
+//! edges-as-`Vec<(String, RawNode)>` representation *is* the canonical,
+//! order-preserving form, so its derived `PartialEq` is the right one to
+//! use.
+//!
+//! Schema comparison has two legitimate modes, chosen per operation, never
+//! guessed:
+//! - `"exact"`: via `Schema`'s own derived `PartialEq` (every record name
+//!   and every field's label/type/cardinality must match -- used for
+//!   `normalize`/`prune`/`extract`, whose output naming is spec-determined).
+//! - `"isomorphic"`: via `omnist::ops::is_isomorphic`, which is public but
+//!   deliberately outside the crate's committed public-API surface per its
+//!   own doc comment -- fine to use from a conformance harness, which is
+//!   exactly the kind of internal-but-trusted caller that carve-out is for
+//!   (used for `infer`, whose generated record names are
+//!   implementation-derived, never canonical).
+
+use omnist::document::{Doc, RawNode};
+use omnist::oml::read_oml;
+use omnist::ops::is_isomorphic;
+use omnist::osd::parse_schema;
+
+/// Structural, order-sensitive equality of two OML texts, via
+/// `Doc::to_raw()` -> `RawNode` (see module docs for why not `Doc` itself
+/// directly). `read_oml` already returns a `RawNode`, so the round trip
+/// through `Doc::from_raw`/`Doc::to_raw` here is deliberate, not
+/// incidental: it proves the comparison strategy holds even when an actual
+/// value under test arrives as a `Doc` (e.g. a future op wired in Track 1
+/// that hands back a `Doc` rather than a `RawNode` directly), not only in
+/// the specific case where `read_oml`'s output already happens to be
+/// raw-comparable.
+///
+/// Returns an error string (rather than `omnist`'s own error types) if
+/// either side fails to parse or construct -- a harness-level concern
+/// distinct from the errors under test.
+pub fn compare_document(actual_oml_text: &str, expected_oml_text: &str) -> Result<bool, String> {
+    let actual_raw = read_oml(actual_oml_text).map_err(|e| format!("actual: {e}"))?;
+    let expected_raw = read_oml(expected_oml_text).map_err(|e| format!("expected: {e}"))?;
+    let actual = doc_to_raw_roundtrip(actual_raw)?;
+    let expected = doc_to_raw_roundtrip(expected_raw)?;
+    Ok(actual == expected)
+}
+
+/// Round-trips a `RawNode` through `Doc::from_raw`/`Doc::to_raw` -- the
+/// exact path a `Doc`-typed value under test would take before comparison.
+fn doc_to_raw_roundtrip(raw: RawNode) -> Result<RawNode, String> {
+    let doc: Doc = Doc::from_raw(raw).map_err(|e| format!("{e}"))?;
+    Ok(doc.to_raw())
+}
+
+/// The two legitimate schema-comparison modes (§4/§6.2) -- chosen per
+/// operation, never guessed.
+pub fn compare_schema(
+    actual_osd_text: &str,
+    expected_osd_text: &str,
+    mode: &str,
+) -> Result<bool, String> {
+    let actual = parse_schema(actual_osd_text).map_err(|e| format!("actual: {e}"))?;
+    let expected = parse_schema(expected_osd_text).map_err(|e| format!("expected: {e}"))?;
+    match mode {
+        "exact" => Ok(actual == expected),
+        "isomorphic" => Ok(is_isomorphic(&actual, &expected)),
+        other => panic!("unknown comparison mode {other:?}; expected 'exact' or 'isomorphic'"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compare_document_equal_texts_are_equal() {
+        assert_eq!(compare_document("a: 1\n", "a: 1\n"), Ok(true));
+    }
+
+    #[test]
+    fn compare_document_reordered_edges_are_not_equal() {
+        assert_eq!(compare_document("a: 1\nb: 2\n", "b: 2\na: 1\n"), Ok(false));
+    }
+
+    #[test]
+    fn compare_document_bad_actual_oml_is_an_error() {
+        let result = compare_document("[[[", "a: 1\n");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn compare_document_bad_expected_oml_is_an_error() {
+        let result = compare_document("a: 1\n", "[[[");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn compare_schema_exact_mode_matches_schema_partial_eq() {
+        let a = "record R {\n    \"x\": string,\n}\nroot R\n";
+        let b = "record R {\n    \"x\": string,\n}\nroot R\n";
+        assert_eq!(compare_schema(a, b, "exact"), Ok(true));
+    }
+
+    #[test]
+    fn compare_schema_bad_expected_osd_is_an_error() {
+        let a = "record R {\n    \"x\": string,\n}\nroot R\n";
+        let result = compare_schema(a, "not valid osd", "exact");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    #[should_panic(expected = "unknown comparison mode")]
+    fn compare_schema_unknown_mode_panics() {
+        let a = "record R {\n    \"x\": string,\n}\nroot R\n";
+        let _ = compare_schema(a, a, "bogus");
+    }
+
+    /// `doc_to_raw_roundtrip`'s `Doc::from_raw` error path is unreachable
+    /// via `read_oml` (the OML parser enforces the same `MAX_DEPTH` guard
+    /// while scanning, per `oml.rs`'s own "Depth guard" module docs, so a
+    /// `RawNode` it hands back can never be too deep for `Doc::from_raw`
+    /// to reject). Exercise it directly with a hand-built, over-deep
+    /// `RawNode` that bypasses the parser entirely -- the one way a real
+    /// (if unlikely) caller could still hit this path, e.g. a future
+    /// operation that hands the referee a `RawNode` assembled some other
+    /// way. Proves the branch is real defensive code, not dead code.
+    #[test]
+    fn doc_to_raw_roundtrip_rejects_a_hand_built_over_deep_raw_node() {
+        let mut node = RawNode::Leaf(omnist::document::Scalar::Null);
+        for _ in 0..(omnist::document::MAX_DEPTH + 10) {
+            node = RawNode::Edges(vec![("x".to_string(), node)]);
+        }
+        assert!(doc_to_raw_roundtrip(node).is_err());
+    }
+}

--- a/tools/conformance/tests/main.rs
+++ b/tools/conformance/tests/main.rs
@@ -1,0 +1,14 @@
+//! Spawns the real compiled `self-test` binary (exercising `main()`'s glue,
+//! not just `main_with_dir`), mirroring the pattern
+//! `tools/check-doc-examples/tests/main.rs` already established.
+
+use std::process::Command;
+
+#[test]
+fn binary_passes_against_the_real_pinned_submodule_fixtures() {
+    let output = Command::new(env!("CARGO_BIN_EXE_self-test"))
+        .output()
+        .expect("failed to spawn self-test binary");
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).contains("10/10 self-test cases passed"));
+}


### PR DESCRIPTION
Step 1 of #82 (not Closes -- the issue stays open across all 7 steps).

## What this delivers

- Vendors `omnist-spec` as a pinned git submodule at `vendor/omnist-spec`
  (tag `v0.1.0-alpha`, commit `b5232e9edb8f40119d0514c7a5a7fc0830be1bf3` --
  same commit omnist-ts vendors, confirmed via omnist-ts's own
  `git submodule status`). Confirmed via `git log --stat` that no
  `_referee-self-test`/fixture content changed between the pinned tag and
  `origin/master` (only Track-2-only vector additions, out of scope here).
- New `tools/conformance` workspace crate (placement mirrors
  `tools/check-doc-examples`'s existing precedent as a repo-local tool):
  - `src/referee.rs`: `compare_document(actual_oml, expected_oml) -> Result<bool, String>`
    (via `read_oml` -> `Doc::from_raw`/`Doc::to_raw` -> `RawNode` `PartialEq`)
    and `compare_schema(actual_osd, expected_osd, mode: &str) -> Result<bool, String>`
    (`"exact"` via `Schema`'s derived `PartialEq`, `"isomorphic"` via
    `ops::is_isomorphic`, unknown mode panics).
  - `src/bin/self_test.rs`: runs the vendored 10-case
    `_referee-self-test` fixture set, PASS/FAIL per case, process exit
    code 0/1/2.

## A real bug the self-test caught

Getting to a genuinely green self-test surfaced a real correctness bug:
`Record`'s derived `PartialEq` was field-declaration-order-sensitive, but
omnist-spec's `docs/03-schema-model.md` Sec3.1 requires fields to compare
as an unordered set. Fixed by replacing the derive with a manual
`PartialEq` on `Record` (`omnist/src/schema.rs`) that sorts fields by
label before comparing (field labels are already guaranteed unique within
a record by `Record::new`).

## Adversarial check (Step 1's acceptance criterion)

Temporarily inverted `compare_document`'s equality check
(`Ok(actual == expected)` -> `Ok(actual != expected)`), reran the
self-test: 3/10 cases genuinely failed (the 3 `document`-kind cases).
Restored the real comparison: 10/10 passes again, working tree clean.

## Verification (freshly reproduced)

- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test --workspace`: all green (613 in `omnist`'s own suite, plus
  the new conformance crate's 8 referee unit tests + 16 self-test-binary
  unit tests + 1 real-binary integration test)
- `cargo llvm-cov --workspace --fail-under-lines 100`: 100.00% lines
  (8685/8685), exit 0

## Out of scope for this PR

Track 1 (fixture harness, 11 ops) and Track 2 (JSON-vector suite) are
separate, later steps of #82.
