### PR TITLE
Canonicalize OML temporal literal text (fixes #90)

### DIFF
--- a/omnist/src/oml/scanner.rs
+++ b/omnist/src/oml/scanner.rs
@@ -15,12 +15,20 @@
 //! recognized-but-semantically-invalid literal (`2024-02-30`) is a
 //! `ParseError`, not silently accepted. [`crate::document::Scalar`] has no
 //! native date/time/datetime variant (see `document.rs`'s module doc), so a
-//! valid temporal literal becomes a `Scalar::Str` holding its exact source
-//! spelling, matching [`crate::schema::matches_kind`]'s own convention.
+//! valid temporal literal becomes a `Scalar::Str` holding its *canonical*
+//! form (issue #90) -- `time`/`datetime` literals have their omitted `:SS`
+//! defaulted to `:00` and any fractional-seconds part zero-padded to 6
+//! digits via
+//! [`crate::schema::canonicalize_iso_time`]/[`crate::schema::canonicalize_iso_datetime`],
+//! matching what Python's real `datetime` objects normalize to. `date`
+//! literals have no optional components, so their source spelling is
+//! already canonical.
 
 use crate::error::ParseError;
 use crate::formats::int_cap::{MAX_INT_DIGITS, out_of_range_message, over_cap_message};
-use crate::schema::{is_iso_date, is_iso_datetime, is_iso_time};
+use crate::schema::{
+    canonicalize_iso_datetime, canonicalize_iso_time, is_iso_date, is_iso_datetime, is_iso_time,
+};
 
 #[derive(Debug, Clone, PartialEq)]
 pub(super) enum TokKind {
@@ -462,7 +470,14 @@ impl<'a> Scanner<'a> {
             return Err(self.error_at(end, format!("invalid {label} {text:?}")));
         }
         self.pos = end;
-        Ok((TokKind::Temporal(text), start, end))
+        let canonical = match kind {
+            // `date` has no optional components in the grammar -- the
+            // source spelling is already canonical.
+            TemporalKind::Date => text,
+            TemporalKind::Time => canonicalize_iso_time(&text),
+            TemporalKind::Datetime => canonicalize_iso_datetime(&text),
+        };
+        Ok((TokKind::Temporal(canonical), start, end))
     }
 
     fn digits_from(&self, pos: usize) -> usize {

--- a/omnist/src/oml/tests.rs
+++ b/omnist/src/oml/tests.rs
@@ -100,6 +100,22 @@ fn date_round_trips() {
 }
 
 #[test]
+fn datetime_date_then_time_lookahead_canonicalizes_missing_seconds() {
+    // Regression test for issue #90: the DATE-then-TIME one-token lookahead
+    // merge in the scanner correctly produces a single DATETIME token, but
+    // was storing the raw source text ("2024-01-01T10:30") instead of the
+    // canonical form with seconds filled in, unlike Python's real
+    // `datetime` object (`datetime.datetime(2024, 1, 1, 10, 30).isoformat()
+    // == "2024-01-01T10:30:00"`).
+    let parsed = Doc::from_raw(read_oml("a: 2024-01-01T10:30\n").unwrap()).unwrap();
+    let value = parsed.root().child("a").unwrap().value().unwrap();
+    assert!(
+        matches!(value, crate::document::Scalar::Str(s) if s == "2024-01-01T10:30:00"),
+        "expected canonical '2024-01-01T10:30:00', got {value:?}"
+    );
+}
+
+#[test]
 fn time_round_trips_with_and_without_seconds_and_fraction() {
     roundtrip_value(&obj(&[
         ("a", Value::Str("12:00:00".into())),

--- a/omnist/src/oml/tests.rs
+++ b/omnist/src/oml/tests.rs
@@ -116,12 +116,37 @@ fn datetime_date_then_time_lookahead_canonicalizes_missing_seconds() {
 }
 
 #[test]
-fn time_round_trips_with_and_without_seconds_and_fraction() {
+fn time_round_trips_in_canonical_form() {
+    // Only already-canonical spellings round-trip identity-wise: a
+    // missing-seconds or under-padded-fraction source spelling is
+    // canonicalized on read (issue #90), so it deliberately does NOT
+    // round-trip back to the original `Value::Str` -- see
+    // `time_literal_without_seconds_canonicalizes_on_read` below for that
+    // behavior.
     roundtrip_value(&obj(&[
         ("a", Value::Str("12:00:00".into())),
-        ("b", Value::Str("12:00".into())),
-        ("c", Value::Str("12:00:00.123456".into())),
+        ("b", Value::Str("12:00:00.123456".into())),
     ]));
+}
+
+#[test]
+fn time_literal_without_seconds_canonicalizes_on_read() {
+    let parsed = Doc::from_raw(read_oml("a: 12:00\n").unwrap()).unwrap();
+    let value = parsed.root().child("a").unwrap().value().unwrap();
+    assert!(
+        matches!(value, crate::document::Scalar::Str(s) if s == "12:00:00"),
+        "expected canonical '12:00:00', got {value:?}"
+    );
+}
+
+#[test]
+fn time_literal_with_short_fraction_zero_pads_on_read() {
+    let parsed = Doc::from_raw(read_oml("a: 12:00:00.5\n").unwrap()).unwrap();
+    let value = parsed.root().child("a").unwrap().value().unwrap();
+    assert!(
+        matches!(value, crate::document::Scalar::Str(s) if s == "12:00:00.500000"),
+        "expected canonical '12:00:00.500000', got {value:?}"
+    );
 }
 
 #[test]
@@ -247,8 +272,14 @@ fn bare_time_literal_round_trips_as_a_time_not_a_quoted_string() {
     let text = write_oml(&raw, 2).unwrap();
     // Must write as a bare, unquoted time literal, not `"12:00"`.
     assert_eq!(text, "a: 12:00");
+    // Reading it back canonicalizes the missing seconds (issue #90), so the
+    // parsed value is "12:00:00", not a byte-identical round trip of `raw`.
+    let expected = RawNode::Edges(vec![(
+        "a".to_string(),
+        RawNode::Leaf(crate::document::Scalar::Str("12:00:00".to_string())),
+    )]);
     let parsed = read_oml(&text).unwrap();
-    assert_eq!(parsed, raw);
+    assert_eq!(parsed, expected);
 }
 
 // omnist-ts#36-equivalent: writer escaping must be all-occurrences, not

--- a/omnist/src/schema.rs
+++ b/omnist/src/schema.rs
@@ -185,6 +185,64 @@ pub(crate) fn is_iso_datetime(s: &str) -> bool {
     ok_date && is_valid_time_captures(&caps)
 }
 
+/// Canonicalizes an already-`is_iso_time`-validated time string to its
+/// normalized form: a missing `:SS` defaults to `:00`, and a present
+/// fractional-seconds part is zero-padded to 6 digits (matching Python's
+/// real `datetime.time`/`datetime.datetime` `.isoformat()` output, which is
+/// what the OML temporal grammar's canonical form is defined against). Any
+/// UTC offset is carried through unchanged -- it's already in the
+/// grammar's canonical `+HH:MM`/`-HH:MM` shape.
+///
+/// # Panics
+/// Panics if `s` doesn't match `TIME_RE` -- callers must validate with
+/// `is_iso_time` first.
+pub(crate) fn canonicalize_iso_time(s: &str) -> String {
+    let caps = TIME_RE
+        .captures(s)
+        .expect("caller must validate with is_iso_time first");
+    canonicalize_time_captures(&caps)
+}
+
+/// Canonicalizes an already-`is_iso_datetime`-validated datetime string the
+/// same way as [`canonicalize_iso_time`], with the date portion (already
+/// fully-specified by the grammar -- `YYYY-MM-DD` has no optional parts)
+/// carried through unchanged.
+///
+/// # Panics
+/// Panics if `s` doesn't match `DATETIME_RE` -- callers must validate with
+/// `is_iso_datetime` first.
+pub(crate) fn canonicalize_iso_datetime(s: &str) -> String {
+    let caps = DATETIME_RE
+        .captures(s)
+        .expect("caller must validate with is_iso_datetime first");
+    let y = caps.name("y").expect("mandatory group").as_str();
+    let mo = caps.name("mo").expect("mandatory group").as_str();
+    let da = caps.name("da").expect("mandatory group").as_str();
+    format!("{y}-{mo}-{da}T{}", canonicalize_time_captures(&caps))
+}
+
+/// Shared canonicalization of the `h`/`m`/`s`/`f`/`off` capture groups that
+/// `TIME_RE` and `DATETIME_RE` both define identically for the time
+/// portion.
+fn canonicalize_time_captures(caps: &regex::Captures<'_>) -> String {
+    let h = caps.name("h").expect("mandatory group").as_str();
+    let m = caps.name("m").expect("mandatory group").as_str();
+    let s = caps.name("s").map_or("00", |c| c.as_str());
+    let mut out = format!("{h}:{m}:{s}");
+    if let Some(f) = caps.name("f") {
+        out.push('.');
+        let digits = f.as_str();
+        out.push_str(digits);
+        for _ in digits.len()..6 {
+            out.push('0');
+        }
+    }
+    if let Some(off) = caps.name("off") {
+        out.push_str(off.as_str());
+    }
+    out
+}
+
 // ---------------------------------------------------------------------------
 // Scalar
 // ---------------------------------------------------------------------------

--- a/tools/conformance/src/bin/vector_runner.rs
+++ b/tools/conformance/src/bin/vector_runner.rs
@@ -785,7 +785,7 @@ mod tests {
         let (passed, failed, skipped) = run_all(&suite_dir());
         assert_eq!(
             (passed, failed, skipped),
-            (112, 5, 22),
+            (113, 4, 22),
             "vector pass/fail/skip counts changed -- if this is an intentional fix or a new \
              vector, update the pinned baseline; if not, something regressed"
         );


### PR DESCRIPTION
## Summary

- The OML scanner's DATE-then-TIME lookahead merge (`try_datetime`) already produced one spec-compliant `DATETIME` token, but `finish_temporal` stored the raw source slice verbatim instead of canonicalizing it, so `2024-01-01T10:30` parsed to `Scalar::Str("2024-01-01T10:30")` instead of the canonical `"2024-01-01T10:30:00"` that Python's real `datetime` object produces.
- Added `canonicalize_iso_time`/`canonicalize_iso_datetime` to `omnist/src/schema.rs`, reusing the existing `TIME_RE`/`DATETIME_RE` shared regexes that `is_iso_time`/`is_iso_datetime` already validate against (no second parser). Missing `:SS` defaults to `:00`; a present fractional-seconds part is zero-padded to 6 digits, matching Python's `.isoformat()`. `Date` tokens are untouched (no optional components in the grammar). UTC offsets pass through unchanged.
- Confirmed against the Python reference venv for 8 cases (missing seconds, explicit UTC offset, short/full fractional seconds, bare time, bare date, offset without seconds) -- all match exactly.

## Vector suite

Full `vector_runner` baseline: **112 pass / 5 fail / 22 skip → 113 pass / 4 fail / 22 skip**. The newly-passing vector: `oml-grammar/temporals/date-then-time-lookahead-yields-one-datetime-token`. No other vector's status changed. Track 1 fixture runner: 19/19 passed, unchanged.

## Test plan

- [x] Red-before-green: added `datetime_date_then_time_lookahead_canonicalizes_missing_seconds`, confirmed it failed against pre-fix code (`got Str("2024-01-01T10:30")`), then confirmed it passes post-fix.
- [x] Updated two pre-existing OML tests whose asserted behavior was the bug's own symptom (`bare_time_literal_round_trips_as_a_time_not_a_quoted_string`, `time_round_trips_with_and_without_seconds_and_fraction` → `time_round_trips_in_canonical_form`), and added two new tests for missing-seconds and short-fraction canonicalization on bare `TIME` literals.
- [x] `cargo run -p conformance --bin vector_runner`: target vector FAIL → PASS, baseline updated and pinned.
- [x] `cargo run -p conformance --bin runner`: 19 passed, 0 failed (Track 1, unaffected).
- [x] `cargo fmt --all -- --check`: clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- [x] `cargo test --workspace`: all passing (616 in the main `omnist` lib suite, plus all other crates).
- [x] `cargo llvm-cov --workspace --fail-under-lines 100`: 100.00% lines, exit 0.

Closes #90
