### PR TITLE
docs, version: report conformance results, correct stale claim, bump to 0.1.0-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "check-doc-examples"
-version = "0.0.1-alpha"
+version = "0.1.0-alpha"
 dependencies = [
  "tempfile",
 ]
@@ -155,7 +155,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "conformance"
-version = "0.0.1-alpha"
+version = "0.1.0-alpha"
 dependencies = [
  "omnist",
  "serde_json",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "omnist"
-version = "0.0.1-alpha"
+version = "0.1.0-alpha"
 dependencies = [
  "indexmap",
  "proptest",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "omnist-cli"
-version = "0.0.1-alpha"
+version = "0.1.0-alpha"
 dependencies = [
  "clap",
  "indexmap",

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -1,0 +1,111 @@
+# Conformance against omnist-spec
+
+This port has its own conformance-test harness (`tools/conformance/`)
+against [omnist-spec](https://github.com/omnist-dev/omnist-spec), the
+language-agnostic upstream specification. It vendors omnist-spec as a
+pinned git submodule (`vendor/omnist-spec`, currently `v0.1.0-alpha`) and
+runs entirely against this crate's own library code -- it does not depend
+on the Python or TypeScript ports' implementations.
+
+Two tracks, both wired into CI as a dedicated `conformance` job
+(`.github/workflows/ci.yml`), gated on real fail count only, never on
+skip count, per the spec's [section
+8.5.5](https://github.com/omnist-dev/omnist-spec/blob/main/docs/08-conformance-and-errors.md#855-reporting)
+reporting rule:
+
+- **Track 1** (`vendor/omnist-spec/conformance/fixtures/`, directory-per-fixture,
+  11 operations): **19 passed, 0 failed, 0 skipped**.
+- **Track 2** (`vendor/omnist-spec/test-suite/`, JSON-vector suite, 14-operation
+  vocabulary): **117 passed, 0 failed, 22 skipped** (of 139 vectors).
+
+Zero real fails on either track as of this writing. Run it yourself:
+
+```
+cargo run -p conformance --bin self-test
+cargo run -p conformance --bin runner
+cargo run -p conformance --bin vector_runner
+```
+<!-- doc-illustrative -->
+
+## Every Track 2 skip, and why
+
+Every skip below is cited in `tools/conformance/src/bin/vector_runner.rs`'s
+own source (either "not yet implemented" or a numbered entry in the
+spec's [divergence
+ledger](https://github.com/omnist-dev/omnist-spec/blob/main/docs/09-divergence-ledger.md)
+section 9.4), per section 8.5.5's requirement that no skip go unexplained.
+The two structural categories:
+
+- **6 `limits.json` vectors**: each expects a *vector-local* configurable
+  limit (a specific max-nodes/max-depth/max-int-digits value scoped to
+  that one test case). This port's `MAX_NODES`/`MAX_DEPTH` are general,
+  crate-wide constants (`omnist::document`), not something the harness can
+  override per-vector -- there is no representational path to make these
+  pass without adding a runtime-configurable limits API this port doesn't
+  otherwise need. Distinct from the divergence ledger's D-1 entry in the
+  specific reason (a vector-local knob, not a fixed-ceiling-value
+  mismatch), even though both are filed under the same general "limits"
+  heading.
+- **~16 remaining skips**: OSD-grammar and OML-grammar/format-specific
+  vectors exercising syntax this port's parsers don't yet accept, each
+  cited individually in-source with the specific grammar gap.
+
+## Where this port's real ceiling differs from Python's/TypeScript's --
+not implied parity
+
+- **Divergence ledger D-6** (integer/number-kind-collapse) is
+  **TypeScript-only** and does not apply to this port -- confirmed
+  empirically, not assumed: `Scalar::Int(i64)`/`Scalar::Float(f64)` are
+  separate enum variants here, unlike TypeScript's shared `number`, so the
+  collapse D-6 describes structurally cannot happen in Rust.
+- This port's `ParseError { line, col, message }` is **structured**
+  (unlike TypeScript's message-only `ParseError`), which let most
+  syntax-failure vectors run for real here instead of blanket-skipping --
+  a genuinely favorable per-language difference, found empirically while
+  building the harness, not assumed going in.
+- Diagnostics are compared in **code-agnostic mode** (path-set only, not
+  exact error-code string) -- `ErrorCode::as_str()` produces bare codes
+  (`"type-mismatch"`) while the spec's vectors expect
+  operation-prefixed codes (`"validate.type-mismatch"`). Same mismatch
+  found independently on the TypeScript port; not Rust-specific.
+
+## Real bugs this harness found and fixed
+
+Building this harness against the real spec (rather than trusting the
+Python/TypeScript ports as ground truth) found five real product bugs,
+all fixed before this port's `0.1.0-alpha`:
+
+- **XML reader was type-coercing leaf text** (int/float/bool) at parse
+  time, contradicting the spec -- XML has no typed literals. Fixed:
+  `read_xml` always produces string leaves now; see
+  [XML](formats/xml.md).
+- **YAML's implicit-int resolver was missing the legacy sexagesimal
+  form** -- `12:00:00` stayed a string instead of resolving to `43200`.
+  Fixed; see [YAML](formats/yaml.md).
+- **YAML mapping keys were never run through the implicit-type
+  resolver** (the "Norway problem") -- `on:` wasn't rejected as YAML 1.1
+  requires. Fixed to match Python's reference behavior exactly (any
+  non-string key is rejected, not just bool/null-shaped ones); see
+  [YAML](formats/yaml.md).
+- **OML's tokenizer wasn't canonicalizing temporal literal text** --
+  missing seconds got dropped instead of filled to `:00`, and sub-second
+  fractions weren't zero-padded to 6 digits; see [OML](formats/oml.md).
+- One harness-side false fail: a JSON temporal-write-report vector is
+  structurally unreachable given this port's `any`-scoping decision (see
+  [`limitations.md`](limitations.md#the-any-type-scoping-gap-deferred-not-forgotten));
+  reclassified from fail to a cited skip rather than a product fix.
+
+None of these required filing against omnist-spec, Python, or
+TypeScript -- every real fail traced back to an omnist-rs bug when
+checked against a live Python run first, per this project's own
+cross-implementation triage rule.
+
+## Known non-blocking gap in the CI gate itself
+
+`cargo llvm-cov --workspace --fail-under-lines 100`, this project's
+coverage gate, has an open, unexplained discrepancy where its exit code
+doesn't reliably correlate with its own printed Lines% column across
+commits -- see
+[omnist-rs#95](https://github.com/omnist-dev/omnist-rs/issues/95). Not
+specific to the conformance work; noted here because it surfaced while
+landing it.

--- a/docs/formats/oml.md
+++ b/docs/formats/oml.md
@@ -41,7 +41,7 @@ spelling, only to an equivalent Core one.
 existing -- so `read_oml`/`write_oml` work over `RawNode`'s literal edge
 list, never `Value`.
 
-## Temporal literals: shape-checked, then validated
+## Temporal literals: shape-checked, then validated, then canonicalized
 
 `date`/`time`/`datetime` literals are recognized by shape in this module's
 own scanner, then validated by the same shared
@@ -49,7 +49,17 @@ own scanner, then validated by the same shared
 `schema.rs` and every other codec use. A recognized-but-invalid literal
 (`2024-02-30`) is a `ParseError`, never silently accepted. Like every other
 codec, `Scalar` has no native temporal variant, so a valid literal becomes
-a `Scalar::Str` holding its exact source spelling.
+a `Scalar::Str`.
+
+**`time`/`datetime` literal text is canonicalized on read** (issue #90,
+fixed while building the [conformance harness](../conformance.md) against
+omnist-spec): a missing `:SS` is filled to `:00`, and an under-padded
+fractional-second component is zero-padded to 6 digits. `date` literals
+have no optional grammar components and pass through unchanged. This
+means a bare `12:00` reads as `Scalar::Str("12:00:00")`, **not**
+`"12:00"` -- see the corrected note in [Python
+divergences](../python-divergences.md#bare-time-literal-round-tripping-oml-pr-11)
+for what changed from this port's earlier, stronger byte-for-byte claim.
 
 ## Integer digit cap and `i64`
 

--- a/docs/formats/yaml.md
+++ b/docs/formats/yaml.md
@@ -59,6 +59,31 @@ The only adjustment `check_yaml` ever records is forcing double-quoted
 style for a string containing U+0085 (NEL), which PyYAML's default styles
 would otherwise normalize away as a line break.
 
+## Legacy sexagesimal integers (`H:M:S`-shaped)
+
+YAML 1.1's implicit-int resolver also recognizes a colon-separated
+sexagesimal form -- `12:00:00` resolves to `Scalar::Int(43200)`, not a
+string. This module's resolver folds each `:`-separated group as
+`acc*60 + group` (checked arithmetic; overflow reports the same
+out-of-range `ParseError` as an oversized plain integer), requires no
+leading zero on the first group, and constrains later groups to `0..=59`
+-- so `01:20`, `1:60`, and `0:0:1` all stay plain strings (each violates
+one of those rules), matching PyYAML's own grammar. Confirmed by omnist-rs
+issue #87, found while building the conformance harness against
+[omnist-spec](../conformance.md).
+
+## Mapping keys are implicitly typed too (the "Norway problem")
+
+Every mapping key is run through the same implicit-type resolver as
+values, matching PyYAML: a key like `on:` is rejected (it resolves to
+`Bool(true)`, not a string), and so is any other non-string-resolving key
+shape (int-, float-, sexagesimal-shaped, `null`-shaped). The rejection is
+a `DocumentError` at path `"$"` with a Python-parity message (e.g.
+`object key True is not a string`, `object key 1.0 is not a string` --
+including keeping the `.0` on whole-number floats). Ordinary string keys,
+and non-boolean words like bare `y`/`n`, are unaffected. Confirmed by
+omnist-rs issue #88, found and fixed alongside #87 above.
+
 ## Integer digit cap
 
 Same 4300-digit cap as `json.rs`/`oml.rs`/`toml.rs`, applied to a plain

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,15 +1,18 @@
 # Limitations & stability
 
-## Alpha status: `0.0.x`, per this project's versioning rule
+## Alpha status: `0.1.0-alpha`, per this project's versioning rule
 
-This is the Rust port's first feature-complete milestone -- all library
-modules, all five format codecs, the CLI, a fuzzing/oracle harness, and
-this documentation are now in place (issue #28, the last port-order item
-per `docs/workflow-playbook.md` §4). It still ships as `0.0.x`. There is
-**no beta** until the project's maintainer explicitly signs off on the
-scoping decisions below; accumulating features or fixes alone never moves
-the version past `0.0.x`. Treat every public API in this crate as subject
-to change without a deprecation cycle until that sign-off happens.
+The Rust port's first feature-complete milestone (issue #28) plus its own
+conformance-test harness against
+[omnist-spec](https://github.com/omnist-dev/omnist-spec) (issue #82 --
+see [Conformance against omnist-spec](conformance.md) for the real,
+measured results) are both now in place, and the maintainer has signed
+off on moving past `0.0.x` to mark that milestone. It still ships
+`-alpha`, though: there is **no beta** until the maintainer explicitly
+signs off on the scoping decisions below (the `any`-type gap chief among
+them); accumulating further features or fixes alone never moves it past
+`-alpha` on its own. Treat every public API in this crate as subject to
+change without a deprecation cycle until that further sign-off happens.
 
 ## The `any`-type scoping gap (deferred, not forgotten)
 

--- a/docs/python-divergences.md
+++ b/docs/python-divergences.md
@@ -97,23 +97,30 @@ Permanent: yes, unless/until `Scalar` grows a native temporal variant --
 which PR #11 and #17 both treat as an open, not-yet-decided
 architectural question rather than a near-term plan.
 
-## Bare time literal round-tripping (OML, PR #11)
+## Bare time literal round-tripping (OML, PR #11; corrected by issue #90)
 
 **Python**: parses a bare time literal like `12:00` into a real
 `datetime.time` object, then always writes it back via
 `isoformat()`, which normalizes to `12:00:00` (seconds always present).
 
-**Rust**: `Scalar` stores the literal's exact source spelling and
-round-trips it byte-for-byte, so `12:00` stays `12:00`.
+**Rust, as of PR #11**: `Scalar` stored the literal's exact source
+spelling and round-tripped it byte-for-byte, so `12:00` stayed `12:00` --
+characterized at the time as "a *stronger* round-trip guarantee than
+Python's own, not a bug against Python's docs," no upstream issue filed.
 
-PR #11's live Python cross-check (19 OML source strings, every scalar
-kind) found this as the *only* difference between Rust and Python
-output, and characterized it deliberately as "a *stronger* round-trip
-guarantee than Python's own, not a bug against Python's docs" -- no
-upstream issue was filed.
+**Rust, as of issue #90** (found while building the [conformance
+harness](conformance.md) against omnist-spec): that stronger guarantee
+was itself a spec violation -- omnist-spec's OML grammar treats
+`time`/`datetime` literal text as canonicalized on read, the same way
+Python's `isoformat()` normalizes it. `read_oml`'s scanner now fills a
+missing `:SS` to `:00` and zero-pads under-padded fractional seconds to 6
+digits, so `12:00` now reads as `Scalar::Str("12:00:00")` -- matching
+Python's output exactly, not diverging from it. `date` literals (no
+optional grammar components) are unaffected.
 
-Permanent: yes, and arguably a Rust-side improvement rather than a gap to
-close.
+Permanent: yes, but now in the sense of "matches Python," not "diverges
+from it" -- this entry is kept for history; the actual current behavior
+is *not* a divergence.
 
 ## OML's UTC-offset preservation (PR #11) / TOML's identical case (PR #21)
 
@@ -225,7 +232,7 @@ Two structural gaps referenced above are covered in full in
 | `i64` vs arbitrary-precision `int` | Permanent | #5, #11, #17, #23 |
 | TOML hex/octal/binary uncapped in Python, capped here | Permanent | #21 |
 | Date-shaped string becomes native literal on write (TOML/YAML) | Permanent (pending a temporal `Scalar` variant) | #19, #21 |
-| Bare time literal round-trips exactly instead of normalizing | Permanent (stronger guarantee, not a gap) | #11 |
+| Bare time literal round-trips exactly instead of normalizing | **No longer a divergence** -- corrected by #90 to match Python | #11, #90 |
 | `infer()`/`infer_with_report()` split vs single `allow_any` kwarg | Revisitable | #15, #33 |
 | XML coercion: over-`i64` numeral falls to float | Permanent | #23 |
 | XML coercion: ASCII-only digit recognition | Permanent | #23 |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,7 +2,7 @@
 
 ```toml
 [dependencies]
-omnist = "0.0.1-alpha"
+omnist = "0.1.0-alpha"
 ```
 <!-- doc-illustrative -->
 

--- a/omnist-cli/Cargo.toml
+++ b/omnist-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnist-cli"
-version = "0.0.1-alpha"
+version = "0.1.0-alpha"
 edition = "2024"
 description = "CLI for omnist (Rust port)."
 license = "Apache-2.0"

--- a/omnist/Cargo.toml
+++ b/omnist/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnist"
-version = "0.0.1-alpha"
+version = "0.1.0-alpha"
 edition = "2024"
 description = "One data model, many formats: read, validate, and write JSON, YAML, TOML, XML, and OML. (Rust port of https://github.com/omnist-dev/omnist)"
 license = "Apache-2.0"

--- a/omnist/src/tests.rs
+++ b/omnist/src/tests.rs
@@ -11,7 +11,7 @@ use super::*;
 
 #[test]
 fn version_matches_cargo_toml() {
-    assert_eq!(VERSION, "0.0.1-alpha");
+    assert_eq!(VERSION, "0.1.0-alpha");
 }
 
 // -- cross-op characterization: infer + materialize (issue #14) ------------

--- a/src/README.md
+++ b/src/README.md
@@ -14,5 +14,7 @@ documents one codec's specific round-trip behavior.
 
 This is the Rust port of [omnist](https://github.com/omnist-dev/omnist).
 See [Python divergences](./python-divergences.md) for where the two
-implementations differ, and [Limitations & stability](./limitations.md)
-for the current alpha-status caveats.
+implementations differ, [Conformance against
+omnist-spec](./conformance.md) for this port's real, measured pass/fail/
+skip numbers against the upstream spec, and [Limitations &
+stability](./limitations.md) for the current alpha-status caveats.

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -12,4 +12,5 @@
   - [XML](./formats/xml.md)
   - [OML](./formats/oml.md)
 - [Python divergences](./python-divergences.md)
+- [Conformance against omnist-spec](./conformance.md)
 - [Limitations & stability](./limitations.md)

--- a/src/conformance.md
+++ b/src/conformance.md
@@ -1,0 +1,111 @@
+# Conformance against omnist-spec
+
+This port has its own conformance-test harness (`tools/conformance/`)
+against [omnist-spec](https://github.com/omnist-dev/omnist-spec), the
+language-agnostic upstream specification. It vendors omnist-spec as a
+pinned git submodule (`vendor/omnist-spec`, currently `v0.1.0-alpha`) and
+runs entirely against this crate's own library code -- it does not depend
+on the Python or TypeScript ports' implementations.
+
+Two tracks, both wired into CI as a dedicated `conformance` job
+(`.github/workflows/ci.yml`), gated on real fail count only, never on
+skip count, per the spec's [section
+8.5.5](https://github.com/omnist-dev/omnist-spec/blob/main/docs/08-conformance-and-errors.md#855-reporting)
+reporting rule:
+
+- **Track 1** (`vendor/omnist-spec/conformance/fixtures/`, directory-per-fixture,
+  11 operations): **19 passed, 0 failed, 0 skipped**.
+- **Track 2** (`vendor/omnist-spec/test-suite/`, JSON-vector suite, 14-operation
+  vocabulary): **117 passed, 0 failed, 22 skipped** (of 139 vectors).
+
+Zero real fails on either track as of this writing. Run it yourself:
+
+```
+cargo run -p conformance --bin self-test
+cargo run -p conformance --bin runner
+cargo run -p conformance --bin vector_runner
+```
+<!-- doc-illustrative -->
+
+## Every Track 2 skip, and why
+
+Every skip below is cited in `tools/conformance/src/bin/vector_runner.rs`'s
+own source (either "not yet implemented" or a numbered entry in the
+spec's [divergence
+ledger](https://github.com/omnist-dev/omnist-spec/blob/main/docs/09-divergence-ledger.md)
+section 9.4), per section 8.5.5's requirement that no skip go unexplained.
+The two structural categories:
+
+- **6 `limits.json` vectors**: each expects a *vector-local* configurable
+  limit (a specific max-nodes/max-depth/max-int-digits value scoped to
+  that one test case). This port's `MAX_NODES`/`MAX_DEPTH` are general,
+  crate-wide constants (`omnist::document`), not something the harness can
+  override per-vector -- there is no representational path to make these
+  pass without adding a runtime-configurable limits API this port doesn't
+  otherwise need. Distinct from the divergence ledger's D-1 entry in the
+  specific reason (a vector-local knob, not a fixed-ceiling-value
+  mismatch), even though both are filed under the same general "limits"
+  heading.
+- **~16 remaining skips**: OSD-grammar and OML-grammar/format-specific
+  vectors exercising syntax this port's parsers don't yet accept, each
+  cited individually in-source with the specific grammar gap.
+
+## Where this port's real ceiling differs from Python's/TypeScript's --
+not implied parity
+
+- **Divergence ledger D-6** (integer/number-kind-collapse) is
+  **TypeScript-only** and does not apply to this port -- confirmed
+  empirically, not assumed: `Scalar::Int(i64)`/`Scalar::Float(f64)` are
+  separate enum variants here, unlike TypeScript's shared `number`, so the
+  collapse D-6 describes structurally cannot happen in Rust.
+- This port's `ParseError { line, col, message }` is **structured**
+  (unlike TypeScript's message-only `ParseError`), which let most
+  syntax-failure vectors run for real here instead of blanket-skipping --
+  a genuinely favorable per-language difference, found empirically while
+  building the harness, not assumed going in.
+- Diagnostics are compared in **code-agnostic mode** (path-set only, not
+  exact error-code string) -- `ErrorCode::as_str()` produces bare codes
+  (`"type-mismatch"`) while the spec's vectors expect
+  operation-prefixed codes (`"validate.type-mismatch"`). Same mismatch
+  found independently on the TypeScript port; not Rust-specific.
+
+## Real bugs this harness found and fixed
+
+Building this harness against the real spec (rather than trusting the
+Python/TypeScript ports as ground truth) found five real product bugs,
+all fixed before this port's `0.1.0-alpha`:
+
+- **XML reader was type-coercing leaf text** (int/float/bool) at parse
+  time, contradicting the spec -- XML has no typed literals. Fixed:
+  `read_xml` always produces string leaves now; see
+  [XML](formats/xml.md).
+- **YAML's implicit-int resolver was missing the legacy sexagesimal
+  form** -- `12:00:00` stayed a string instead of resolving to `43200`.
+  Fixed; see [YAML](formats/yaml.md).
+- **YAML mapping keys were never run through the implicit-type
+  resolver** (the "Norway problem") -- `on:` wasn't rejected as YAML 1.1
+  requires. Fixed to match Python's reference behavior exactly (any
+  non-string key is rejected, not just bool/null-shaped ones); see
+  [YAML](formats/yaml.md).
+- **OML's tokenizer wasn't canonicalizing temporal literal text** --
+  missing seconds got dropped instead of filled to `:00`, and sub-second
+  fractions weren't zero-padded to 6 digits; see [OML](formats/oml.md).
+- One harness-side false fail: a JSON temporal-write-report vector is
+  structurally unreachable given this port's `any`-scoping decision (see
+  [`limitations.md`](limitations.md#the-any-type-scoping-gap-deferred-not-forgotten));
+  reclassified from fail to a cited skip rather than a product fix.
+
+None of these required filing against omnist-spec, Python, or
+TypeScript -- every real fail traced back to an omnist-rs bug when
+checked against a live Python run first, per this project's own
+cross-implementation triage rule.
+
+## Known non-blocking gap in the CI gate itself
+
+`cargo llvm-cov --workspace --fail-under-lines 100`, this project's
+coverage gate, has an open, unexplained discrepancy where its exit code
+doesn't reliably correlate with its own printed Lines% column across
+commits -- see
+[omnist-rs#95](https://github.com/omnist-dev/omnist-rs/issues/95). Not
+specific to the conformance work; noted here because it surfaced while
+landing it.

--- a/src/formats/oml.md
+++ b/src/formats/oml.md
@@ -41,7 +41,7 @@ spelling, only to an equivalent Core one.
 existing -- so `read_oml`/`write_oml` work over `RawNode`'s literal edge
 list, never `Value`.
 
-## Temporal literals: shape-checked, then validated
+## Temporal literals: shape-checked, then validated, then canonicalized
 
 `date`/`time`/`datetime` literals are recognized by shape in this module's
 own scanner, then validated by the same shared
@@ -49,7 +49,17 @@ own scanner, then validated by the same shared
 `schema.rs` and every other codec use. A recognized-but-invalid literal
 (`2024-02-30`) is a `ParseError`, never silently accepted. Like every other
 codec, `Scalar` has no native temporal variant, so a valid literal becomes
-a `Scalar::Str` holding its exact source spelling.
+a `Scalar::Str`.
+
+**`time`/`datetime` literal text is canonicalized on read** (issue #90,
+fixed while building the [conformance harness](../conformance.md) against
+omnist-spec): a missing `:SS` is filled to `:00`, and an under-padded
+fractional-second component is zero-padded to 6 digits. `date` literals
+have no optional grammar components and pass through unchanged. This
+means a bare `12:00` reads as `Scalar::Str("12:00:00")`, **not**
+`"12:00"` -- see the corrected note in [Python
+divergences](../python-divergences.md#bare-time-literal-round-tripping-oml-pr-11)
+for what changed from this port's earlier, stronger byte-for-byte claim.
 
 ## Integer digit cap and `i64`
 

--- a/src/formats/yaml.md
+++ b/src/formats/yaml.md
@@ -59,6 +59,31 @@ The only adjustment `check_yaml` ever records is forcing double-quoted
 style for a string containing U+0085 (NEL), which PyYAML's default styles
 would otherwise normalize away as a line break.
 
+## Legacy sexagesimal integers (`H:M:S`-shaped)
+
+YAML 1.1's implicit-int resolver also recognizes a colon-separated
+sexagesimal form -- `12:00:00` resolves to `Scalar::Int(43200)`, not a
+string. This module's resolver folds each `:`-separated group as
+`acc*60 + group` (checked arithmetic; overflow reports the same
+out-of-range `ParseError` as an oversized plain integer), requires no
+leading zero on the first group, and constrains later groups to `0..=59`
+-- so `01:20`, `1:60`, and `0:0:1` all stay plain strings (each violates
+one of those rules), matching PyYAML's own grammar. Confirmed by omnist-rs
+issue #87, found while building the conformance harness against
+[omnist-spec](../conformance.md).
+
+## Mapping keys are implicitly typed too (the "Norway problem")
+
+Every mapping key is run through the same implicit-type resolver as
+values, matching PyYAML: a key like `on:` is rejected (it resolves to
+`Bool(true)`, not a string), and so is any other non-string-resolving key
+shape (int-, float-, sexagesimal-shaped, `null`-shaped). The rejection is
+a `DocumentError` at path `"$"` with a Python-parity message (e.g.
+`object key True is not a string`, `object key 1.0 is not a string` --
+including keeping the `.0` on whole-number floats). Ordinary string keys,
+and non-boolean words like bare `y`/`n`, are unaffected. Confirmed by
+omnist-rs issue #88, found and fixed alongside #87 above.
+
 ## Integer digit cap
 
 Same 4300-digit cap as `json.rs`/`oml.rs`/`toml.rs`, applied to a plain

--- a/src/limitations.md
+++ b/src/limitations.md
@@ -1,15 +1,18 @@
 # Limitations & stability
 
-## Alpha status: `0.0.x`, per this project's versioning rule
+## Alpha status: `0.1.0-alpha`, per this project's versioning rule
 
-This is the Rust port's first feature-complete milestone -- all library
-modules, all five format codecs, the CLI, a fuzzing/oracle harness, and
-this documentation are now in place (issue #28, the last port-order item
-per `docs/workflow-playbook.md` §4). It still ships as `0.0.x`. There is
-**no beta** until the project's maintainer explicitly signs off on the
-scoping decisions below; accumulating features or fixes alone never moves
-the version past `0.0.x`. Treat every public API in this crate as subject
-to change without a deprecation cycle until that sign-off happens.
+The Rust port's first feature-complete milestone (issue #28) plus its own
+conformance-test harness against
+[omnist-spec](https://github.com/omnist-dev/omnist-spec) (issue #82 --
+see [Conformance against omnist-spec](conformance.md) for the real,
+measured results) are both now in place, and the maintainer has signed
+off on moving past `0.0.x` to mark that milestone. It still ships
+`-alpha`, though: there is **no beta** until the maintainer explicitly
+signs off on the scoping decisions below (the `any`-type gap chief among
+them); accumulating further features or fixes alone never moves it past
+`-alpha` on its own. Treat every public API in this crate as subject to
+change without a deprecation cycle until that further sign-off happens.
 
 ## The `any`-type scoping gap (deferred, not forgotten)
 

--- a/src/python-divergences.md
+++ b/src/python-divergences.md
@@ -97,23 +97,30 @@ Permanent: yes, unless/until `Scalar` grows a native temporal variant --
 which PR #11 and #17 both treat as an open, not-yet-decided
 architectural question rather than a near-term plan.
 
-## Bare time literal round-tripping (OML, PR #11)
+## Bare time literal round-tripping (OML, PR #11; corrected by issue #90)
 
 **Python**: parses a bare time literal like `12:00` into a real
 `datetime.time` object, then always writes it back via
 `isoformat()`, which normalizes to `12:00:00` (seconds always present).
 
-**Rust**: `Scalar` stores the literal's exact source spelling and
-round-trips it byte-for-byte, so `12:00` stays `12:00`.
+**Rust, as of PR #11**: `Scalar` stored the literal's exact source
+spelling and round-tripped it byte-for-byte, so `12:00` stayed `12:00` --
+characterized at the time as "a *stronger* round-trip guarantee than
+Python's own, not a bug against Python's docs," no upstream issue filed.
 
-PR #11's live Python cross-check (19 OML source strings, every scalar
-kind) found this as the *only* difference between Rust and Python
-output, and characterized it deliberately as "a *stronger* round-trip
-guarantee than Python's own, not a bug against Python's docs" -- no
-upstream issue was filed.
+**Rust, as of issue #90** (found while building the [conformance
+harness](conformance.md) against omnist-spec): that stronger guarantee
+was itself a spec violation -- omnist-spec's OML grammar treats
+`time`/`datetime` literal text as canonicalized on read, the same way
+Python's `isoformat()` normalizes it. `read_oml`'s scanner now fills a
+missing `:SS` to `:00` and zero-pads under-padded fractional seconds to 6
+digits, so `12:00` now reads as `Scalar::Str("12:00:00")` -- matching
+Python's output exactly, not diverging from it. `date` literals (no
+optional grammar components) are unaffected.
 
-Permanent: yes, and arguably a Rust-side improvement rather than a gap to
-close.
+Permanent: yes, but now in the sense of "matches Python," not "diverges
+from it" -- this entry is kept for history; the actual current behavior
+is *not* a divergence.
 
 ## OML's UTC-offset preservation (PR #11) / TOML's identical case (PR #21)
 
@@ -225,7 +232,7 @@ Two structural gaps referenced above are covered in full in
 | `i64` vs arbitrary-precision `int` | Permanent | #5, #11, #17, #23 |
 | TOML hex/octal/binary uncapped in Python, capped here | Permanent | #21 |
 | Date-shaped string becomes native literal on write (TOML/YAML) | Permanent (pending a temporal `Scalar` variant) | #19, #21 |
-| Bare time literal round-trips exactly instead of normalizing | Permanent (stronger guarantee, not a gap) | #11 |
+| Bare time literal round-trips exactly instead of normalizing | **No longer a divergence** -- corrected by #90 to match Python | #11, #90 |
 | `infer()`/`infer_with_report()` split vs single `allow_any` kwarg | Revisitable | #15, #33 |
 | XML coercion: over-`i64` numeral falls to float | Permanent | #23 |
 | XML coercion: ASCII-only digit recognition | Permanent | #23 |

--- a/src/quickstart.md
+++ b/src/quickstart.md
@@ -2,7 +2,7 @@
 
 ```toml
 [dependencies]
-omnist = "0.0.1-alpha"
+omnist = "0.1.0-alpha"
 ```
 <!-- doc-illustrative -->
 

--- a/tools/check-doc-examples/Cargo.toml
+++ b/tools/check-doc-examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "check-doc-examples"
-version = "0.0.1-alpha"
+version = "0.1.0-alpha"
 edition = "2024"
 description = "CI gate: every new/changed fenced code block in docs/*.md needs a verified-by or doc-illustrative marker."
 license = "Apache-2.0"

--- a/tools/conformance/Cargo.toml
+++ b/tools/conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conformance"
-version = "0.0.1-alpha"
+version = "0.1.0-alpha"
 edition = "2024"
 description = "omnist-rs's own conformance-test harness against omnist-spec (issue #82): referee + Track 1 fixture runner + Track 2 vector runner, consuming the pinned vendor/omnist-spec submodule directly, never depending on Python's or TypeScript's implementation."
 license = "Apache-2.0"


### PR DESCRIPTION
Adds docs/conformance.md reporting the real conformance-harness results from issue #82 (Track 1: 19/0/0, Track 2: 117/0/22, every skip cited). Updates YAML/OML format docs for new behaviors (#87/#88/#90). Corrects python-divergences.md's bare-time-literal entry, now stale after #90's canonicalization fix. Bumps every workspace crate to 0.1.0-alpha.