### PR TITLE
fix(oml): track genuine temporal provenance instead of shape-guessing on write (#99)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "check-doc-examples"
-version = "0.1.0-alpha"
+version = "0.1.1-alpha"
 dependencies = [
  "tempfile",
 ]
@@ -155,7 +155,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "conformance"
-version = "0.1.0-alpha"
+version = "0.1.1-alpha"
 dependencies = [
  "omnist",
  "serde_json",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "omnist"
-version = "0.1.0-alpha"
+version = "0.1.1-alpha"
 dependencies = [
  "indexmap",
  "proptest",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "omnist-cli"
-version = "0.1.0-alpha"
+version = "0.1.1-alpha"
 dependencies = [
  "clap",
  "indexmap",

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -3,7 +3,7 @@
 This port has its own conformance-test harness (`tools/conformance/`)
 against [omnist-spec](https://github.com/omnist-dev/omnist-spec), the
 language-agnostic upstream specification. It vendors omnist-spec as a
-pinned git submodule (`vendor/omnist-spec`, currently `v0.1.0-alpha`) and
+pinned git submodule (`vendor/omnist-spec`, currently `v0.1.1-alpha`) and
 runs entirely against this crate's own library code -- it does not depend
 on the Python or TypeScript ports' implementations.
 
@@ -16,7 +16,7 @@ reporting rule:
 - **Track 1** (`vendor/omnist-spec/conformance/fixtures/`, directory-per-fixture,
   11 operations): **19 passed, 0 failed, 0 skipped**.
 - **Track 2** (`vendor/omnist-spec/test-suite/`, JSON-vector suite, 14-operation
-  vocabulary): **117 passed, 0 failed, 22 skipped** (of 139 vectors).
+  vocabulary): **124 passed, 0 failed, 22 skipped** (of 146 vectors).
 
 Zero real fails on either track as of this writing. Run it yourself:
 
@@ -72,8 +72,8 @@ not implied parity
 ## Real bugs this harness found and fixed
 
 Building this harness against the real spec (rather than trusting the
-Python/TypeScript ports as ground truth) found five real product bugs,
-all fixed before this port's `0.1.0-alpha`:
+Python/TypeScript ports as ground truth) found six real product bugs,
+all fixed across this port's `0.1.0-alpha`/`0.1.1-alpha`:
 
 - **XML reader was type-coercing leaf text** (int/float/bool) at parse
   time, contradicting the spec -- XML has no typed literals. Fixed:
@@ -90,6 +90,18 @@ all fixed before this port's `0.1.0-alpha`:
 - **OML's tokenizer wasn't canonicalizing temporal literal text** --
   missing seconds got dropped instead of filled to `:00`, and sub-second
   fractions weren't zero-padded to 6 digits; see [OML](formats/oml.md).
+- **OML's writer shape-guessed date/time/datetime from string content**
+  to decide bare-vs-quoted, since `Scalar` has no temporal variant (issue
+  #16) and thus no real provenance signal -- a plain JSON string that
+  merely looked date-shaped got silently promoted to a genuine OML
+  temporal literal on write. Found while directly verifying, not just
+  trusting, this suite's own reported numbers: the bug had a fully-green
+  117/0/22 run despite existing, because no vector at the time tested it.
+  Fixed by tagging genuine provenance (OML's own bare-literal grammar, or
+  a schema-directed `materialize` upgrade) on `RawNode` instead of
+  guessing from shape; see [OML](formats/oml.md#bare-vs-quoted-on-write-rawnodetemporalleaf-not-shape-guessing).
+  omnist-spec's own `v0.1.1-alpha` adds the 6 vectors
+  (`formats-oml/oml.json`) this fix now passes for real.
 - One harness-side false fail: a JSON temporal-write-report vector is
   structurally unreachable given this port's `any`-scoping decision (see
   [`limitations.md`](limitations.md#the-any-type-scoping-gap-deferred-not-forgotten));

--- a/docs/formats/oml.md
+++ b/docs/formats/oml.md
@@ -61,6 +61,35 @@ means a bare `12:00` reads as `Scalar::Str("12:00:00")`, **not**
 divergences](../python-divergences.md#bare-time-literal-round-tripping-oml-pr-11)
 for what changed from this port's earlier, stronger byte-for-byte claim.
 
+## Bare vs. quoted on write: `RawNode::TemporalLeaf`, not shape-guessing
+
+A leaf writes bare (no quotes) only when it's a
+[`RawNode::TemporalLeaf`](../../omnist/src/document.rs) -- never by
+guessing from a `Scalar::Str`'s shape (issue #99). The pre-#99 writer
+wrote *any* date/time/datetime-*shaped* string bare, regardless of
+provenance: a plain JSON string like `"2024-01-01"` got silently promoted
+to a genuine OML temporal literal on write, corrupting it on the next
+read (a different Document, per [ch.4's grammar](https://github.com/omnist-dev/omnist-spec/blob/main/docs/04-oml-grammar.md)). Confirmed live and
+fixed.
+
+`Scalar` still has no temporal variant (issue #16, closed) -- the
+provenance tag lives one level up, on `RawNode`, from exactly two real
+sources:
+
+- **OML's own bare-literal grammar.** `read_oml`'s parser tags a
+  genuinely-read bare `date`/`time`/`datetime` token as
+  `TemporalLeaf`; an ordinary quoted string (however it's shaped) stays
+  a plain `Leaf`.
+- **Schema-directed `materialize`.** Upgrading a field to a
+  Date/Time/Datetime-kinded schema produces `TemporalLeaf` too, so a
+  materialized document writes its temporal fields bare through OML.
+
+Both wrap the identical `Scalar::Str` -- the tag never changes document
+*equality* (`Doc::eq_doc`/conformance's `compare_document`): a
+`TemporalLeaf` and a `Leaf` holding the same value compare equal, since
+the tag is purely a write-hint. It's OML-write-only: JSON/YAML/TOML/XML
+never construct or consult it.
+
 ## Integer digit cap and `i64`
 
 Same 4300-digit cap (`MAX_INT_DIGITS`) as `json.rs`/`yaml.rs`/`toml.rs`, and

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,7 +2,7 @@
 
 ```toml
 [dependencies]
-omnist = "0.1.0-alpha"
+omnist = "0.1.1-alpha"
 ```
 <!-- doc-illustrative -->
 

--- a/omnist-cli/Cargo.toml
+++ b/omnist-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnist-cli"
-version = "0.1.0-alpha"
+version = "0.1.1-alpha"
 edition = "2024"
 description = "CLI for omnist (Rust port)."
 license = "Apache-2.0"

--- a/omnist/Cargo.toml
+++ b/omnist/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnist"
-version = "0.1.0-alpha"
+version = "0.1.1-alpha"
 edition = "2024"
 description = "One data model, many formats: read, validate, and write JSON, YAML, TOML, XML, and OML. (Rust port of https://github.com/omnist-dev/omnist)"
 license = "Apache-2.0"

--- a/omnist/src/document.rs
+++ b/omnist/src/document.rs
@@ -138,6 +138,18 @@ struct Entry {
     /// writer that had the same reset bug because the guard lived in one
     /// place, not one shared helper called from every entry point).
     depth: usize,
+    /// Mirrors [`RawNode::TemporalLeaf`] for a leaf entry (always `false`
+    /// for `NodeData::Internal`) -- kept as a flag alongside `NodeData`
+    /// rather than doubling `NodeData` itself into a matching third
+    /// variant, so every existing `NodeData::Leaf`/`NodeData::Internal`
+    /// match in this module (equality, mutation guards, `Value`
+    /// conversion) stays exhaustive and untouched by issue #99; only
+    /// `raw_at`/`push_raw`, the `RawNode` <-> arena boundary, need to
+    /// read/set it. See issue #99's plan comment on the issue itself for
+    /// why this is intentionally *not* symmetric with `RawNode`'s own
+    /// variant-based design -- `RawNode` has no such "single choke point"
+    /// arena to hang a side flag off of, so it needs the real variant.
+    is_temporal: bool,
 }
 
 /// The shared depth guard. Every construction/mutation path that can grow
@@ -256,6 +268,18 @@ fn push(
     depth: usize,
     path: &str,
 ) -> Result<NodeId, DocumentError> {
+    push_entry(arena, data, depth, path, false)
+}
+
+/// As [`push`], but for a leaf entry mirroring [`RawNode::TemporalLeaf`]
+/// (see issue #99) -- only `push_raw` ever passes `is_temporal: true`.
+fn push_entry(
+    arena: &mut Vec<Entry>,
+    data: NodeData,
+    depth: usize,
+    path: &str,
+    is_temporal: bool,
+) -> Result<NodeId, DocumentError> {
     if arena.len() >= MAX_NODES {
         return Err(DocumentError::new(
             path,
@@ -263,7 +287,11 @@ fn push(
         ));
     }
     let id = NodeId(arena.len());
-    arena.push(Entry { data, depth });
+    arena.push(Entry {
+        data,
+        depth,
+        is_temporal,
+    });
     Ok(id)
 }
 
@@ -622,10 +650,43 @@ impl<'a> Cursor<'a> {
 /// arbitrary interleaving losslessly (per its own docs: "no adjustment ever
 /// needed"), so its reader/writer (`crate::oml`) builds/walks a `Doc`
 /// through this type instead of going through `Value`.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub enum RawNode {
     Leaf(Scalar),
+    /// A leaf genuinely known to be date/time/datetime-kinded -- by OML's
+    /// own bare-literal grammar on read (`crate::oml`), or by a
+    /// schema-directed `crate::materialize` upgrade to a Date/Time/
+    /// Datetime-kinded field. Write-hint only, consumed solely by
+    /// `crate::oml::write_oml` (bare vs quoted) -- see issue #99. Never
+    /// constructed by JSON/YAML/TOML/XML's readers/writers, none of which
+    /// have OML's grammar-level way to know this; XML in particular has no
+    /// native temporal literals at all (see `docs/formats/xml.md`).
+    /// [`Scalar`] itself deliberately stays without a temporal variant
+    /// (issue #16, closed) -- this tag lives one level up instead.
+    TemporalLeaf(Scalar),
     Edges(Vec<(String, RawNode)>),
+}
+
+impl PartialEq for RawNode {
+    /// `TemporalLeaf` and `Leaf` holding the same [`Scalar`] compare
+    /// equal -- the tag is a writer hint, not a value difference, so two
+    /// otherwise-identical documents that differ only in whether one leaf
+    /// happens to be schema-upgraded (or was read as a bare OML temporal
+    /// literal) must still be the same Document. A derived `PartialEq`
+    /// would get this wrong (see this type's own doc comment); this
+    /// mirrors the same "a derive silently encodes an irrelevant
+    /// distinction as inequality" fix already applied to
+    /// `crate::schema::Record`'s field-order bug.
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                RawNode::Leaf(a) | RawNode::TemporalLeaf(a),
+                RawNode::Leaf(b) | RawNode::TemporalLeaf(b),
+            ) => a == b,
+            (RawNode::Edges(a), RawNode::Edges(b)) => a == b,
+            _ => false,
+        }
+    }
 }
 
 impl Doc {
@@ -648,7 +709,9 @@ impl Doc {
     }
 
     fn raw_at(&self, id: NodeId) -> RawNode {
-        match &self.entry(id).data {
+        let entry = self.entry(id);
+        match &entry.data {
+            NodeData::Leaf(s) if entry.is_temporal => RawNode::TemporalLeaf(s.clone()),
             NodeData::Leaf(s) => RawNode::Leaf(s.clone()),
             NodeData::Internal(edges) => RawNode::Edges(
                 edges
@@ -712,6 +775,7 @@ fn push_raw(arena: &mut Vec<Entry>, node: RawNode, depth: usize) -> Result<NodeI
     check_write_depth(depth, "$")?;
     match node {
         RawNode::Leaf(s) => push(arena, NodeData::Leaf(s), depth, "$"),
+        RawNode::TemporalLeaf(s) => push_entry(arena, NodeData::Leaf(s), depth, "$", true),
         RawNode::Edges(edges) => {
             let mut out = Vec::with_capacity(edges.len());
             for (label, child) in edges {

--- a/omnist/src/formats/xml.rs
+++ b/omnist/src/formats/xml.rs
@@ -443,7 +443,12 @@ fn scan_xml_into(node: &RawNode, path: &str, rep: &mut WriteReport) {
                 scan_xml_into(child, &p, rep);
             }
         }
-        RawNode::Leaf(scalar) => scan_leaf(scalar, path, rep),
+        // XML has no native temporal literals (see this module's own
+        // docs), so `TemporalLeaf` never arrives here in practice -- but
+        // if it did (e.g. a `RawNode` built by another format's writer
+        // path being fed to XML), it must still write out identically to
+        // an ordinary leaf; issue #99's tag is OML-write-only.
+        RawNode::Leaf(scalar) | RawNode::TemporalLeaf(scalar) => scan_leaf(scalar, path, rep),
     }
 }
 
@@ -510,7 +515,7 @@ fn write_element(tag: &str, content: &RawNode, level: usize, out: &mut String) {
             out.push_str(">\n");
         }
         RawNode::Edges(_) => out.push_str(" />\n"),
-        RawNode::Leaf(scalar) => {
+        RawNode::Leaf(scalar) | RawNode::TemporalLeaf(scalar) => {
             let text = xml_sanitize(&xml_text(scalar));
             if text.is_empty() {
                 out.push_str(" />\n");

--- a/omnist/src/materialize.rs
+++ b/omnist/src/materialize.rs
@@ -166,13 +166,21 @@ fn materialize_scalar(
     path: &str,
     res: &mut ValidationResult,
 ) -> RawNode {
-    let RawNode::Leaf(value) = node else {
-        res.add(
-            path,
-            format!("expected a {} value, got an object", kind.as_str()),
-            ErrorCode::ShapeMismatch,
-        );
-        return node.clone();
+    // `RawNode::TemporalLeaf` (issue #99) is accepted as input on equal
+    // footing with `Leaf` -- e.g. re-materializing an already-upgraded
+    // document, or a document read directly from OML's own bare temporal
+    // grammar -- both hold the identical `DocScalar`, just with a
+    // writer-hint tag `materialize` doesn't need to distinguish here.
+    let value = match node {
+        RawNode::Leaf(v) | RawNode::TemporalLeaf(v) => v,
+        RawNode::Edges(_) => {
+            res.add(
+                path,
+                format!("expected a {} value, got an object", kind.as_str()),
+                ErrorCode::ShapeMismatch,
+            );
+            return node.clone();
+        }
     };
     if matches!(value, DocScalar::Null) {
         if !nullable {
@@ -181,7 +189,7 @@ fn materialize_scalar(
         return RawNode::Leaf(DocScalar::Null);
     }
     if let Some(upgraded) = try_upgrade(value, kind) {
-        return RawNode::Leaf(upgraded);
+        return wrap_upgraded(kind, upgraded);
     }
     res.add(
         path,
@@ -192,6 +200,18 @@ fn materialize_scalar(
         ErrorCode::TypeMismatch,
     );
     node.clone()
+}
+
+/// A value materialize just upgraded to `kind` is wrapped as a
+/// [`RawNode::TemporalLeaf`] when `kind` is Date/Time/Datetime -- the
+/// "schema-directed materialize" provenance source issue #99's own vector
+/// comments name, alongside OML's own bare-literal grammar
+/// (`crate::oml::parser`). Every other kind stays a plain `Leaf`.
+fn wrap_upgraded(kind: ScalarKind, value: DocScalar) -> RawNode {
+    match kind {
+        ScalarKind::Date | ScalarKind::Time | ScalarKind::Datetime => RawNode::TemporalLeaf(value),
+        _ => RawNode::Leaf(value),
+    }
 }
 
 /// Value-exact upgrade table -- `None` means the value cannot become

--- a/omnist/src/oml.rs
+++ b/omnist/src/oml.rs
@@ -69,7 +69,7 @@ mod writer;
 
 use parser::Parser;
 use scanner::Scanner;
-use writer::{write_edges, write_edges_compact, write_scalar};
+use writer::{write_edges, write_edges_compact, write_scalar, write_temporal_leaf};
 
 /// Parse OML source into a canonical [`RawNode`] (edge-list or leaf).
 ///
@@ -93,6 +93,7 @@ pub fn read_oml(text: &str) -> Result<RawNode, ParseError> {
 pub fn write_oml(node: &RawNode, indent: usize) -> Result<String, WriteError> {
     match node {
         RawNode::Leaf(s) => Ok(write_scalar(s)),
+        RawNode::TemporalLeaf(s) => Ok(write_temporal_leaf(s)),
         RawNode::Edges(edges) => write_edges(edges, 0, indent, 0),
     }
 }
@@ -103,6 +104,7 @@ pub fn write_oml(node: &RawNode, indent: usize) -> Result<String, WriteError> {
 pub fn write_oml_compact(node: &RawNode) -> Result<String, WriteError> {
     match node {
         RawNode::Leaf(s) => Ok(write_scalar(s)),
+        RawNode::TemporalLeaf(s) => Ok(write_temporal_leaf(s)),
         RawNode::Edges(edges) => write_edges_compact(edges, 0),
     }
 }

--- a/omnist/src/oml/parser.rs
+++ b/omnist/src/oml/parser.rs
@@ -59,7 +59,7 @@ impl<'a> Parser<'a> {
         } else if self.looks_like_edge() {
             RawNode::Edges(self.parse_node_edges(0)?)
         } else {
-            RawNode::Leaf(self.parse_scalar()?)
+            self.parse_scalar()?
         };
         self.skip_sep()?;
         if !matches!(self.kind, TokKind::Eof) {
@@ -168,7 +168,7 @@ impl<'a> Parser<'a> {
         if matches!(self.kind, TokKind::LBrace) {
             self.parse_brace_value(depth)
         } else {
-            Ok(RawNode::Leaf(self.parse_scalar()?))
+            self.parse_scalar()
         }
     }
 
@@ -246,16 +246,27 @@ impl<'a> Parser<'a> {
         Ok(elements)
     }
 
-    fn parse_scalar(&mut self) -> Result<Scalar, ParseError> {
+    /// Returns a [`RawNode`] leaf, not a bare [`Scalar`] -- `TokKind::
+    /// Temporal` (a genuinely bare, grammar-validated date/time/datetime
+    /// literal) becomes [`RawNode::TemporalLeaf`], distinct from
+    /// `TokKind::Str` (an ordinary quoted string that merely holds
+    /// date/time/datetime-*shaped* text), which becomes a plain
+    /// [`RawNode::Leaf`]. Both wrap the identical `Scalar::Str(s)` --
+    /// `document::Scalar` has no separate temporal variant (issue #16) --
+    /// so this distinction is exactly the provenance tag issue #99 needs
+    /// `write_oml` to see, and would be lost immediately if this returned
+    /// a bare `Scalar` for both.
+    fn parse_scalar(&mut self) -> Result<RawNode, ParseError> {
         let (kind, start, end) = self.advance()?;
         match kind {
-            TokKind::Str(s) | TokKind::Temporal(s) => Ok(Scalar::Str(s)),
-            TokKind::Int(i) => Ok(Scalar::Int(i)),
-            TokKind::Float(f) => Ok(Scalar::Float(f)),
+            TokKind::Str(s) => Ok(RawNode::Leaf(Scalar::Str(s))),
+            TokKind::Temporal(s) => Ok(RawNode::TemporalLeaf(Scalar::Str(s))),
+            TokKind::Int(i) => Ok(RawNode::Leaf(Scalar::Int(i))),
+            TokKind::Float(f) => Ok(RawNode::Leaf(Scalar::Float(f))),
             TokKind::Ident(text) => match text.as_str() {
-                "null" => Ok(Scalar::Null),
-                "true" => Ok(Scalar::Bool(true)),
-                "false" => Ok(Scalar::Bool(false)),
+                "null" => Ok(RawNode::Leaf(Scalar::Null)),
+                "true" => Ok(RawNode::Leaf(Scalar::Bool(true))),
+                "false" => Ok(RawNode::Leaf(Scalar::Bool(false))),
                 _ => Err(self.sc.error_at(
                     start,
                     format!("bare word {text:?} is not a valid value here; strings must be quoted"),

--- a/omnist/src/oml/tests.rs
+++ b/omnist/src/oml/tests.rs
@@ -262,24 +262,109 @@ fn write_oml_preserves_datetime_utc_offset_exactly() {
 }
 
 // omnist-ts#52: a bare TIME literal did not round-trip (became a quoted
-// string on write-then-read).
+// string on write-then-read). Now expressed via `RawNode::TemporalLeaf`
+// (issue #99) -- a genuinely temporal value, not a plain string that
+// merely looks like one; see `plain_string_shaped_like_a_time_stays_quoted`
+// below for the case this variant exists to distinguish from.
 #[test]
 fn bare_time_literal_round_trips_as_a_time_not_a_quoted_string() {
     let raw = RawNode::Edges(vec![(
         "a".to_string(),
-        RawNode::Leaf(crate::document::Scalar::Str("12:00".to_string())),
+        RawNode::TemporalLeaf(crate::document::Scalar::Str("12:00".to_string())),
     )]);
     let text = write_oml(&raw, 2).unwrap();
     // Must write as a bare, unquoted time literal, not `"12:00"`.
     assert_eq!(text, "a: 12:00");
-    // Reading it back canonicalizes the missing seconds (issue #90), so the
-    // parsed value is "12:00:00", not a byte-identical round trip of `raw`.
+    // Reading it back canonicalizes the missing seconds (issue #90) and
+    // is itself a genuinely-read bare literal, so the parsed value is a
+    // `TemporalLeaf("12:00:00")`, not a byte-identical round trip of `raw`.
     let expected = RawNode::Edges(vec![(
         "a".to_string(),
-        RawNode::Leaf(crate::document::Scalar::Str("12:00:00".to_string())),
+        RawNode::TemporalLeaf(crate::document::Scalar::Str("12:00:00".to_string())),
     )]);
     let parsed = read_oml(&text).unwrap();
     assert_eq!(parsed, expected);
+}
+
+// issue #99: a plain string that merely *looks* like a time must stay
+// quoted on write -- writing it bare would silently promote it to a
+// genuine temporal literal on the next read (a different Document).
+#[test]
+fn plain_string_shaped_like_a_time_stays_quoted() {
+    let raw = RawNode::Edges(vec![(
+        "a".to_string(),
+        RawNode::Leaf(crate::document::Scalar::Str("12:00:00".to_string())),
+    )]);
+    let text = write_oml(&raw, 2).unwrap();
+    assert_eq!(text, "a: \"12:00:00\"");
+    // Reading it back must reproduce the identical plain string, not a
+    // `TemporalLeaf`.
+    let parsed = read_oml(&text).unwrap();
+    assert_eq!(parsed, raw);
+}
+
+// issue #99's own repro: a JSON-shaped plain string that looks like a
+// date must not become a genuine bare temporal literal through OML.
+#[test]
+fn plain_string_shaped_like_a_date_stays_quoted() {
+    let raw = RawNode::Edges(vec![(
+        "d".to_string(),
+        RawNode::Leaf(crate::document::Scalar::Str("2024-01-01".to_string())),
+    )]);
+    let text = write_oml(&raw, 2).unwrap();
+    assert_eq!(text, "d: \"2024-01-01\"");
+    let parsed = read_oml(&text).unwrap();
+    assert_eq!(parsed, raw);
+}
+
+// The companion case: a genuinely date-kinded value (e.g. read from OML's
+// own bare grammar) writes bare, no quotes.
+#[test]
+fn genuine_temporal_leaf_writes_bare_for_date_and_datetime_too() {
+    let raw = RawNode::Edges(vec![
+        (
+            "d".to_string(),
+            RawNode::TemporalLeaf(crate::document::Scalar::Str("2024-01-01".to_string())),
+        ),
+        (
+            "dt".to_string(),
+            RawNode::TemporalLeaf(crate::document::Scalar::Str(
+                "2024-01-01T12:30:00".to_string(),
+            )),
+        ),
+    ]);
+    let text = write_oml(&raw, 2).unwrap();
+    assert_eq!(text, "d: 2024-01-01\ndt: 2024-01-01T12:30:00");
+}
+
+// A `TemporalLeaf`/`Leaf` pair holding the same `Scalar` must compare
+// equal -- the tag is a write-hint, not a value difference (issue #99's
+// manual `PartialEq`, replacing the derive).
+#[test]
+fn temporal_leaf_and_leaf_with_the_same_scalar_are_equal() {
+    let a = RawNode::Leaf(crate::document::Scalar::Str("2024-01-01".to_string()));
+    let b = RawNode::TemporalLeaf(crate::document::Scalar::Str("2024-01-01".to_string()));
+    assert_eq!(a, b);
+}
+
+// A schema-directed materialize upgrade to a Date-kinded field is the
+// other real provenance source (alongside OML's own bare-literal
+// grammar) -- confirm it also produces bare OML output, per issue #99's
+// vector comment naming this exact case.
+#[test]
+fn materialize_upgraded_date_writes_bare_through_oml() {
+    use crate::schema::{DATE, Field, Record, Ref, Schema};
+    let root = Record::new(vec![Field::required("d", DATE).unwrap()]).unwrap();
+    let mut env = IndexMap::new();
+    env.insert("Root".to_string(), root);
+    let schema = Schema::new(Ref::new("Root"), env).unwrap();
+    let input = RawNode::Edges(vec![(
+        "d".to_string(),
+        RawNode::Leaf(crate::document::Scalar::Str("2024-01-01".to_string())),
+    )]);
+    let materialized = crate::materialize::materialize(&input, Some(&schema)).unwrap();
+    let text = write_oml(&materialized, 2).unwrap();
+    assert_eq!(text, "d: 2024-01-01");
 }
 
 // omnist-ts#36-equivalent: writer escaping must be all-occurrences, not

--- a/omnist/src/oml/writer.rs
+++ b/omnist/src/oml/writer.rs
@@ -5,14 +5,21 @@
 //!
 //! ## Temporal literals
 //!
-//! A `Scalar::Str` shaped like a valid date/time/datetime writes bare,
-//! matching the reader's own convention that a temporal literal *is* a
-//! `Scalar::Str` holding its exact spelling (`document::Scalar` has no
-//! separate temporal variant). This is the omnist-ts#52 fix:
-//! `read_oml("a: 12:00")` produces `Scalar::Str("12:00")`, and writing that
-//! value back must reproduce the bare `12:00` spelling, not `"12:00"`
-//! (which would silently turn a time into a plain string on the next
-//! read). See [`write_str_scalar`] below.
+//! A leaf writes bare (no quotes) only when it's a
+//! [`RawNode::TemporalLeaf`], never by guessing from a `Scalar::Str`'s
+//! shape -- issue #99. Shape-guessing (any date/time/datetime-*shaped*
+//! string writes bare, regardless of provenance) was the pre-#99
+//! behavior, matching the omnist-ts#52 fix's original intent
+//! (`read_oml("a: 12:00")` producing `Scalar::Str("12:00")` must write
+//! back bare, not `"12:00"`) -- but it silently over-applied: an ordinary
+//! JSON/YAML string that merely *looks* like a date got promoted to a
+//! genuine temporal literal on write, corrupting it on the next read
+//! (confirmed live, filed as #99). `RawNode::TemporalLeaf` (`document.rs`)
+//! now carries that provenance explicitly instead: `crate::oml`'s own
+//! parser tags a genuinely-read bare literal, and
+//! `crate::materialize`'s Date/Time/Datetime schema upgrades tag their
+//! result the same way. Every other `Scalar::Str`, however shaped,
+//! always quotes.
 //!
 //! `.0` on integer-valued floats: [`write_float`] renders so the value
 //! always re-tokenizes as `NUMDEC`/`NEGINF`/`NANLIT`/`POSINF` on read,
@@ -24,7 +31,6 @@
 use crate::document::{RawNode, Scalar, check_write_depth};
 use crate::error::WriteError;
 use crate::formats::string_escape::{OML_ESCAPES, write_quoted};
-use crate::schema::{is_iso_date, is_iso_datetime, is_iso_time};
 
 use super::parser::RESERVED;
 
@@ -61,6 +67,10 @@ pub(super) fn write_edges(
                 check_write_depth(node_depth + 1, "$")?;
                 lines.push(format!("{pad}{lab}: {}", write_scalar(s)));
             }
+            RawNode::TemporalLeaf(s) => {
+                check_write_depth(node_depth + 1, "$")?;
+                lines.push(format!("{pad}{lab}: {}", write_temporal_leaf(s)));
+            }
         }
     }
     Ok(lines.join("\n"))
@@ -86,6 +96,10 @@ pub(super) fn write_edges_compact(
             RawNode::Leaf(s) => {
                 check_write_depth(node_depth + 1, "$")?;
                 parts.push(format!("{lab}: {}", write_scalar(s)));
+            }
+            RawNode::TemporalLeaf(s) => {
+                check_write_depth(node_depth + 1, "$")?;
+                parts.push(format!("{lab}: {}", write_temporal_leaf(s)));
             }
         }
     }
@@ -122,15 +136,24 @@ pub(super) fn write_scalar(v: &Scalar) -> String {
         Scalar::Bool(b) => b.to_string(),
         Scalar::Int(i) => i.to_string(),
         Scalar::Float(f) => write_float(*f),
-        Scalar::Str(s) => write_str_scalar(s),
+        // Always quoted -- no shape-guessing (issue #99). A
+        // `RawNode::TemporalLeaf` is the only way to get a bare temporal
+        // spelling; see `write_temporal_leaf` below.
+        Scalar::Str(s) => write_string(s),
     }
 }
 
-fn write_str_scalar(s: &str) -> String {
-    if is_iso_datetime(s) || is_iso_date(s) || is_iso_time(s) {
-        s.to_string()
-    } else {
-        write_string(s)
+/// Writes a [`RawNode::TemporalLeaf`]'s scalar bare (no quotes). By
+/// construction (see that variant's own doc comment) this is always a
+/// `Scalar::Str` holding an already-validated date/time/datetime
+/// spelling -- nothing in this crate ever wraps a non-`Str` scalar in
+/// `TemporalLeaf`. Falls back to the ordinary [`write_scalar`] for any
+/// other variant rather than panicking, since that's still a safe,
+/// correct rendering even though it should never be reached in practice.
+pub(super) fn write_temporal_leaf(v: &Scalar) -> String {
+    match v {
+        Scalar::Str(s) => s.to_string(),
+        other => write_scalar(other),
     }
 }
 

--- a/omnist/src/tests.rs
+++ b/omnist/src/tests.rs
@@ -11,7 +11,7 @@ use super::*;
 
 #[test]
 fn version_matches_cargo_toml() {
-    assert_eq!(VERSION, "0.1.0-alpha");
+    assert_eq!(VERSION, "0.1.1-alpha");
 }
 
 // -- cross-op characterization: infer + materialize (issue #14) ------------

--- a/src/conformance.md
+++ b/src/conformance.md
@@ -3,7 +3,7 @@
 This port has its own conformance-test harness (`tools/conformance/`)
 against [omnist-spec](https://github.com/omnist-dev/omnist-spec), the
 language-agnostic upstream specification. It vendors omnist-spec as a
-pinned git submodule (`vendor/omnist-spec`, currently `v0.1.0-alpha`) and
+pinned git submodule (`vendor/omnist-spec`, currently `v0.1.1-alpha`) and
 runs entirely against this crate's own library code -- it does not depend
 on the Python or TypeScript ports' implementations.
 
@@ -16,7 +16,7 @@ reporting rule:
 - **Track 1** (`vendor/omnist-spec/conformance/fixtures/`, directory-per-fixture,
   11 operations): **19 passed, 0 failed, 0 skipped**.
 - **Track 2** (`vendor/omnist-spec/test-suite/`, JSON-vector suite, 14-operation
-  vocabulary): **117 passed, 0 failed, 22 skipped** (of 139 vectors).
+  vocabulary): **124 passed, 0 failed, 22 skipped** (of 146 vectors).
 
 Zero real fails on either track as of this writing. Run it yourself:
 
@@ -72,8 +72,8 @@ not implied parity
 ## Real bugs this harness found and fixed
 
 Building this harness against the real spec (rather than trusting the
-Python/TypeScript ports as ground truth) found five real product bugs,
-all fixed before this port's `0.1.0-alpha`:
+Python/TypeScript ports as ground truth) found six real product bugs,
+all fixed across this port's `0.1.0-alpha`/`0.1.1-alpha`:
 
 - **XML reader was type-coercing leaf text** (int/float/bool) at parse
   time, contradicting the spec -- XML has no typed literals. Fixed:
@@ -90,6 +90,18 @@ all fixed before this port's `0.1.0-alpha`:
 - **OML's tokenizer wasn't canonicalizing temporal literal text** --
   missing seconds got dropped instead of filled to `:00`, and sub-second
   fractions weren't zero-padded to 6 digits; see [OML](formats/oml.md).
+- **OML's writer shape-guessed date/time/datetime from string content**
+  to decide bare-vs-quoted, since `Scalar` has no temporal variant (issue
+  #16) and thus no real provenance signal -- a plain JSON string that
+  merely looked date-shaped got silently promoted to a genuine OML
+  temporal literal on write. Found while directly verifying, not just
+  trusting, this suite's own reported numbers: the bug had a fully-green
+  117/0/22 run despite existing, because no vector at the time tested it.
+  Fixed by tagging genuine provenance (OML's own bare-literal grammar, or
+  a schema-directed `materialize` upgrade) on `RawNode` instead of
+  guessing from shape; see [OML](formats/oml.md#bare-vs-quoted-on-write-rawnodetemporalleaf-not-shape-guessing).
+  omnist-spec's own `v0.1.1-alpha` adds the 6 vectors
+  (`formats-oml/oml.json`) this fix now passes for real.
 - One harness-side false fail: a JSON temporal-write-report vector is
   structurally unreachable given this port's `any`-scoping decision (see
   [`limitations.md`](limitations.md#the-any-type-scoping-gap-deferred-not-forgotten));

--- a/src/formats/oml.md
+++ b/src/formats/oml.md
@@ -61,6 +61,35 @@ means a bare `12:00` reads as `Scalar::Str("12:00:00")`, **not**
 divergences](../python-divergences.md#bare-time-literal-round-tripping-oml-pr-11)
 for what changed from this port's earlier, stronger byte-for-byte claim.
 
+## Bare vs. quoted on write: `RawNode::TemporalLeaf`, not shape-guessing
+
+A leaf writes bare (no quotes) only when it's a
+[`RawNode::TemporalLeaf`](../../omnist/src/document.rs) -- never by
+guessing from a `Scalar::Str`'s shape (issue #99). The pre-#99 writer
+wrote *any* date/time/datetime-*shaped* string bare, regardless of
+provenance: a plain JSON string like `"2024-01-01"` got silently promoted
+to a genuine OML temporal literal on write, corrupting it on the next
+read (a different Document, per [ch.4's grammar](https://github.com/omnist-dev/omnist-spec/blob/main/docs/04-oml-grammar.md)). Confirmed live and
+fixed.
+
+`Scalar` still has no temporal variant (issue #16, closed) -- the
+provenance tag lives one level up, on `RawNode`, from exactly two real
+sources:
+
+- **OML's own bare-literal grammar.** `read_oml`'s parser tags a
+  genuinely-read bare `date`/`time`/`datetime` token as
+  `TemporalLeaf`; an ordinary quoted string (however it's shaped) stays
+  a plain `Leaf`.
+- **Schema-directed `materialize`.** Upgrading a field to a
+  Date/Time/Datetime-kinded schema produces `TemporalLeaf` too, so a
+  materialized document writes its temporal fields bare through OML.
+
+Both wrap the identical `Scalar::Str` -- the tag never changes document
+*equality* (`Doc::eq_doc`/conformance's `compare_document`): a
+`TemporalLeaf` and a `Leaf` holding the same value compare equal, since
+the tag is purely a write-hint. It's OML-write-only: JSON/YAML/TOML/XML
+never construct or consult it.
+
 ## Integer digit cap and `i64`
 
 Same 4300-digit cap (`MAX_INT_DIGITS`) as `json.rs`/`yaml.rs`/`toml.rs`, and

--- a/src/quickstart.md
+++ b/src/quickstart.md
@@ -2,7 +2,7 @@
 
 ```toml
 [dependencies]
-omnist = "0.1.0-alpha"
+omnist = "0.1.1-alpha"
 ```
 <!-- doc-illustrative -->
 

--- a/tools/check-doc-examples/Cargo.toml
+++ b/tools/check-doc-examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "check-doc-examples"
-version = "0.1.0-alpha"
+version = "0.1.1-alpha"
 edition = "2024"
 description = "CI gate: every new/changed fenced code block in docs/*.md needs a verified-by or doc-illustrative marker."
 license = "Apache-2.0"

--- a/tools/conformance/Cargo.toml
+++ b/tools/conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conformance"
-version = "0.1.0-alpha"
+version = "0.1.1-alpha"
 edition = "2024"
 description = "omnist-rs's own conformance-test harness against omnist-spec (issue #82): referee + Track 1 fixture runner + Track 2 vector runner, consuming the pinned vendor/omnist-spec submodule directly, never depending on Python's or TypeScript's implementation."
 license = "Apache-2.0"

--- a/tools/conformance/src/bin/vector_runner.rs
+++ b/tools/conformance/src/bin/vector_runner.rs
@@ -119,7 +119,7 @@ use omnist::formats::xml::{read_xml, write_xml};
 use omnist::formats::yaml::{read_yaml, write_yaml};
 use omnist::infer::infer_with_report;
 use omnist::materialize::materialize;
-use omnist::oml::read_oml;
+use omnist::oml::{read_oml, write_oml};
 use omnist::ops::{compatible_with, equivalent, extract, is_empty, lint};
 use omnist::osd::{parse_schema, to_osd};
 use omnist::report::WriteReport;
@@ -178,16 +178,25 @@ fn skip(message: impl Into<String>) -> VResult {
 
 /// Decodes one canonical-encoding node (`{"scalar": {kind, value}}` or
 /// `{"edges": [[label, node], ...]}`) into a `RawNode`. `date`/`time`/
-/// `datetime` all decode to `Scalar::Str` -- `omnist::document::Scalar` has
-/// no temporal variant, and `materialize.rs`'s own upgrade rules confirm a
-/// materialized date/time/datetime leaf stays `Scalar::Str` (just a value
-/// that has passed an ISO-shape check), so this is the correct (not just
-/// convenient) decoding, not a simplification.
+/// `datetime` all decode to the same underlying `Scalar::Str` a
+/// `"string"`-kind value would -- `omnist::document::Scalar` has no
+/// temporal variant -- but wrapped as `RawNode::TemporalLeaf`, not plain
+/// `Leaf`, since that's exactly the provenance issue #99's OML writer
+/// needs to tell a genuinely-kinded value apart from a plain string that
+/// merely looks like one. See `vendor/omnist-spec/test-suite/formats-oml/
+/// oml.json`'s `date-shaped-string-stays-quoted-on-write` /
+/// `genuine-date-writes-bare` vector pair, which is unrepresentable
+/// without this distinction.
 fn decode_document(node: &Json) -> RawNode {
     if let Some(scalar) = node.get("scalar") {
         let kind = scalar.get("kind").and_then(Json::as_str);
         let value = scalar.get("value").unwrap_or(&Json::Null);
-        return RawNode::Leaf(decode_scalar(kind, value));
+        let decoded = decode_scalar(kind, value);
+        return if matches!(kind, Some("date") | Some("time") | Some("datetime")) {
+            RawNode::TemporalLeaf(decoded)
+        } else {
+            RawNode::Leaf(decoded)
+        };
     }
     let edges = node
         .get("edges")
@@ -527,6 +536,14 @@ fn run_write(v: &Json) -> VResult {
         "toml" => write_toml(&doc, strict, Some(&mut report)),
         "xml" => write_xml(&doc, strict, Some(&mut report)),
         "yaml" => write_yaml(&doc, strict, Some(&mut report)),
+        // OML has no `strict`/report machinery -- it's lossless for every
+        // Document, so there's never an adjustment to report (see
+        // `oml.rs`'s own module doc). `doc.to_raw()` round-trips through
+        // the arena, exercising the same `is_temporal` flag preservation
+        // (`document.rs`) the real CLI's `convert` path relies on --
+        // see omnist-rs#99, the first OML write vectors this suite has
+        // ever had.
+        "oml" => write_oml(&doc.to_raw(), 2),
         other => return fail(format!("unknown format {other:?}")),
     };
     match result {
@@ -868,35 +885,44 @@ mod tests {
     use super::*;
 
     #[test]
-    fn vector_count_is_139() {
+    fn vector_count_is_146() {
+        // 139 -> 146 via vendor/omnist-spec v0.1.0-alpha -> v0.1.1-alpha
+        // (issue #99): 6 new `formats-oml/oml.json` vectors testing a
+        // plain string that merely looks temporal-shaped staying quoted
+        // on OML write, vs. a genuinely temporal-kinded value writing
+        // bare.
         let vectors = iter_vectors(&suite_dir());
-        assert_eq!(vectors.len(), 139);
+        assert_eq!(vectors.len(), 146);
     }
 
     /// Full-suite regression guard: runs every real vector through every
     /// driver (also this file's real coverage-driving test, since
     /// `main`/`main_with_dir` itself is process-entry-point code no test
     /// calls directly). The exact counts are this step's honest,
-    /// freshly-reproduced measurement -- originally issue #82 Step 3's
-    /// report (112, 5, 22), updated to (113, 4, 22) by omnist-rs#86 (XML
-    /// interleaving fix), then (113, 3, 23) by omnist-rs#89 (JSON
-    /// temporal-write vector reclassified FAIL -> cited SKIP), then
-    /// (114, 2, 23) once #86+#89 were combined (one extra pass beyond
-    /// the naive sum), and now further updated by omnist-rs#87/#88
-    /// (legacy sexagesimal int + Norway-problem mapping-key rejection),
-    /// which also incidentally resolves
-    /// `formats-json/basic/nested-array-is-rejected` from skip to pass
-    /// via the same general `DocumentError` path-checking fix. Every
-    /// count here is freshly reproduced by running the rebased harness,
-    /// not computed by hand. Pinned so a future change that silently
-    /// regresses pass/fail/skip counts is caught, not a "this must
-    /// always be 0 fails" gate.
+    /// freshly-reproduced measurement -- history through (117, 0, 22) at
+    /// 139 vectors covered by earlier PRs (#86/#87/#88/#89, issue #82).
+    /// Now (124, 0, 22) at 146 vectors: vendor/omnist-spec bumped
+    /// v0.1.0-alpha -> v0.1.1-alpha, adding 7 new vectors total, all 7
+    /// newly passing (diffed pass-list vector-by-vector against the old
+    /// pin, not assumed) -- 6 in `formats-oml/oml.json` (issue #99's own
+    /// vectors: a plain string that merely looks temporal-shaped stays
+    /// quoted on OML write, a genuinely temporal-kinded value writes
+    /// bare) plus 1 unrelated one,
+    /// `formats-json/basic/nan-substituted-with-null-and-reported`, from
+    /// a *different* omnist-spec fix bundled into the same tag
+    /// (omnist-spec#30/#31, NaN/Infinity vector encoding) -- Rust's
+    /// `write_json` already substitutes `null` for NaN correctly, this
+    /// vector just wasn't representable/testable before that upstream
+    /// fix. Every count here is freshly reproduced by running the
+    /// harness, not computed by hand. Pinned so a future change that
+    /// silently regresses pass/fail/skip counts is caught, not a "this
+    /// must always be 0 fails" gate.
     #[test]
     fn full_suite_counts_match_the_measured_baseline() {
         let (passed, failed, skipped) = run_all(&suite_dir());
         assert_eq!(
             (passed, failed, skipped),
-            (117, 0, 22),
+            (124, 0, 22),
             "vector pass/fail/skip counts changed -- if this is an intentional fix or a new \
              vector, update the pinned baseline; if not, something regressed"
         );


### PR DESCRIPTION
fix(oml): track genuine temporal provenance instead of shape-guessing on write (#99)

OML's writer decided bare-vs-quoted for a Scalar::Str by re-checking
is_iso_date/is_iso_time/is_iso_datetime on its content -- with no way
to tell "genuinely read/upgraded as temporal" apart from "a plain
string that happens to look like one". A plain JSON string like
"2024-01-01" wrote unquoted, silently becoming a genuine OML temporal
literal on the next read (a different Document per ch.4's grammar).
Python and TypeScript both keep it quoted correctly; confirmed live.

Settled between the issue's two named options (track provenance vs.
always quote) empirically: the new vendor/omnist-spec v0.1.1-alpha
vectors require distinguishing a kind:"string" input from a
kind:"date" input holding the identical value string, with opposite
expected output -- structurally impossible for the "always quote"
option to satisfy for real (not skip). Full design decision posted to
the issue before implementing.

document.rs: RawNode gains a TemporalLeaf(Scalar) variant alongside
Leaf, with a manual PartialEq (replacing the derive) so a Leaf/
TemporalLeaf pair holding the same Scalar still compares equal --
the tag is a write-hint, not a value difference. Doc's internal arena
carries the tag as an Entry.is_temporal flag rather than doubling
NodeData into a matching third variant, keeping every existing
NodeData match (equality, mutation guards, Value conversion) exhaustive
and untouched.

Two real sources construct RawNode::TemporalLeaf: oml/parser.rs's
parse_scalar (a genuinely bare, grammar-validated temporal token) and
materialize.rs's Date/Time/Datetime schema-directed upgrades. oml/
writer.rs's write_str_scalar shape-guessing heuristic is deleted
outright; a leaf writes bare only when it's a TemporalLeaf.

tools/conformance/src/bin/vector_runner.rs: added run_write's
previously-missing "oml" dispatch arm (the first OML write vectors
this suite has ever had) and decode_document now constructs
TemporalLeaf for kind:"date"/"time"/"datetime", plain Leaf for
kind:"string". All 6 new formats-oml/oml.json vectors pass for real.

Adversarially verified: broke decode_document's kind check (collapsed
both branches to plain Leaf), confirmed the 3 "genuine-*-writes-bare"
vectors fail for real with the expected mismatch, reverted, confirmed
clean.

vendor/omnist-spec bumped v0.1.0-alpha -> v0.1.1-alpha. Track 2:
117/0/22 (139 vectors) -> 124/0/22 (146 vectors) -- the 6 new OML
vectors plus 1 unrelated newly-testable vector from a different
bundled omnist-spec fix (#30/#31, NaN/Infinity vector encoding),
diffed pass-list vector-by-vector against the old pin, not assumed.

docs/formats/oml.md (+ src/ mirror): new section on the
RawNode::TemporalLeaf mechanism. No python-divergences.md entry --
this closes a real Rust-side bug to match Python's already-correct
behavior, not a new divergence. docs/conformance.md updated with the
real numbers and this as the sixth real bug this harness has found.

Version bump: every workspace crate 0.1.0-alpha -> 0.1.1-alpha.
