### PR TITLE
fix: close the real coverage gaps behind issue #95, root cause found

### DIFF
--- a/omnist/src/document.rs
+++ b/omnist/src/document.rs
@@ -791,6 +791,19 @@ fn push_raw(arena: &mut Vec<Entry>, node: RawNode, depth: usize) -> Result<NodeI
 mod tests {
     use super::*;
 
+    #[test]
+    fn raw_node_leaf_and_edges_are_never_equal() {
+        // The `_ => false` catch-all in `RawNode`'s manual `PartialEq`
+        // (issue #99) -- a leaf (either variant) can never equal an
+        // internal node, regardless of the leaf's own tag.
+        let leaf = RawNode::Leaf(Scalar::Int(1));
+        let temporal = RawNode::TemporalLeaf(Scalar::Str("2024-01-01".to_string()));
+        let edges = RawNode::Edges(vec![]);
+        assert_ne!(leaf, edges);
+        assert_ne!(temporal, edges);
+        assert_ne!(edges, leaf);
+    }
+
     fn obj(pairs: &[(&str, Value)]) -> Value {
         let mut m = IndexMap::new();
         for (k, v) in pairs {

--- a/omnist/src/oml/tests.rs
+++ b/omnist/src/oml/tests.rs
@@ -149,6 +149,26 @@ fn time_literal_with_short_fraction_zero_pads_on_read() {
     );
 }
 
+// A bare TIME literal (not DATETIME) may itself carry a UTC offset
+// (`TIME_RE` in schema.rs has its own `off` group, independent of
+// DATETIME's) -- exercises the scanner's offset-lookahead for a bare
+// TIME token specifically, and `canonicalize_time_captures`'s offset
+// branch.
+#[test]
+fn bare_time_literal_with_utc_offset_reads_as_a_genuine_temporal_leaf() {
+    let parsed = read_oml("a: 12:00:00+05:00\n").unwrap();
+    let RawNode::Edges(edges) = &parsed else {
+        panic!("expected edges, got {parsed:?}");
+    };
+    assert_eq!(
+        edges[0],
+        (
+            "a".to_string(),
+            RawNode::TemporalLeaf(crate::document::Scalar::Str("12:00:00+05:00".to_string()))
+        )
+    );
+}
+
 #[test]
 fn datetime_round_trips_with_and_without_utc_offset() {
     roundtrip_value(&obj(&[
@@ -335,6 +355,13 @@ fn genuine_temporal_leaf_writes_bare_for_date_and_datetime_too() {
     ]);
     let text = write_oml(&raw, 2).unwrap();
     assert_eq!(text, "d: 2024-01-01\ndt: 2024-01-01T12:30:00");
+    // Compact mode has its own `RawNode::TemporalLeaf` arm
+    // (`write_edges_compact`), separate from pretty mode's -- covered here
+    // too rather than only through the pretty-mode assertion above.
+    assert_eq!(
+        write_oml_compact(&raw).unwrap(),
+        "d: 2024-01-01; dt: 2024-01-01T12:30:00"
+    );
 }
 
 // A `TemporalLeaf`/`Leaf` pair holding the same `Scalar` must compare
@@ -345,6 +372,19 @@ fn temporal_leaf_and_leaf_with_the_same_scalar_are_equal() {
     let a = RawNode::Leaf(crate::document::Scalar::Str("2024-01-01".to_string()));
     let b = RawNode::TemporalLeaf(crate::document::Scalar::Str("2024-01-01".to_string()));
     assert_eq!(a, b);
+}
+
+#[test]
+fn write_temporal_leaf_falls_back_to_write_scalar_for_a_non_str_scalar() {
+    // Structurally unreachable via any real construction path (see
+    // `write_temporal_leaf`'s own doc comment -- nothing in this crate
+    // ever wraps a non-`Str` scalar in `TemporalLeaf`), exercised
+    // directly so the fallback arm is real, tested code, not a dead
+    // branch.
+    assert_eq!(
+        writer::write_temporal_leaf(&crate::document::Scalar::Int(5)),
+        "5"
+    );
 }
 
 // A schema-directed materialize upgrade to a Date-kinded field is the
@@ -996,6 +1036,17 @@ fn write_oml_compact_on_a_bare_leaf_node() {
     let raw = RawNode::Leaf(crate::document::Scalar::Int(5));
     assert_eq!(write_oml(&raw, 2).unwrap(), "5");
     assert_eq!(write_oml_compact(&raw).unwrap(), "5");
+}
+
+#[test]
+fn write_oml_on_a_bare_temporal_leaf_node() {
+    // A whole document that's a single genuinely-temporal leaf (no
+    // wrapping edges) -- `write_oml`/`write_oml_compact`'s own
+    // `RawNode::TemporalLeaf` top-level arm, distinct from the same tag
+    // appearing nested under an edge (already covered elsewhere).
+    let raw = RawNode::TemporalLeaf(crate::document::Scalar::Str("2024-01-01".to_string()));
+    assert_eq!(write_oml(&raw, 2).unwrap(), "2024-01-01");
+    assert_eq!(write_oml_compact(&raw).unwrap(), "2024-01-01");
 }
 
 #[test]

--- a/tools/conformance/src/bin/vector_runner.rs
+++ b/tools/conformance/src/bin/vector_runner.rs
@@ -1020,6 +1020,23 @@ mod tests {
     }
 
     #[test]
+    fn run_parse_success_but_document_mismatch_fails() {
+        // A real parse success whose resulting document simply doesn't
+        // match `expect.document` -- no vector in the real suite happens
+        // to hit this specific combination (every real fail is a
+        // diagnostics/error-shape mismatch instead), so it's exercised
+        // directly here.
+        let v = json!({
+            "operation": "parse",
+            "input": {"format": "json", "text": "1"},
+            "expect": {"ok": true, "document": {"scalar": {"kind": "integer", "value": 2}}}
+        });
+        let r = dispatch(&v);
+        assert_eq!(r.status, Status::Fail);
+        assert_eq!(r.message, "parsed document does not match expected");
+    }
+
+    #[test]
     fn run_parse_success_when_expect_ok_false_fails() {
         let v = json!({"operation": "parse", "input": {"format": "oml", "text": "a: 1\n"}, "expect": {"ok": false}});
         assert_eq!(dispatch(&v).status, Status::Fail);
@@ -1234,6 +1251,23 @@ mod tests {
         )
         .unwrap();
         assert_eq!(main_with_dir(&tmp), 0);
+    }
+
+    #[test]
+    fn run_all_counts_and_prints_a_real_fail() {
+        // `run_all`'s own `Status::Fail` handling (the "FAIL" print label
+        // and `failed += 1`) is never exercised by the real suite, which
+        // currently has 0 real fails -- a synthetic directory with one
+        // genuinely failing vector drives it directly.
+        let tmp = std::env::temp_dir().join("vector-runner-one-fail");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::fs::write(
+            tmp.join("basic.json"),
+            r#"{"vectors": [{"name": "x", "operation": "parse", "input": {"format": "json", "text": "1"}, "expect": {"ok": true, "document": {"scalar": {"kind": "integer", "value": 2}}}}]}"#,
+        )
+        .unwrap();
+        assert_eq!(run_all(&tmp), (0, 1, 0));
     }
 
     #[test]


### PR DESCRIPTION
fix: close the real coverage gaps behind issue #95, root cause found

issue #95 diagnosed cargo-llvm-cov's --fail-under-lines as flaky --
exit code not correlating with its own printed Lines% column. That
diagnosis was wrong: I had been misreading the coverage table's
column layout the entire time. `cargo-llvm-cov`'s table is Regions |
Functions | Lines | Branches, each its own (total, missed, %) triple
-- the number I kept quoting as "Lines%" (~99.4x%) was actually the
Regions% column. The real Lines metric (further right in the same
row) was never checked directly.

Re-diagnosed properly this time: lcov export's per-line DA records
(not the summary table) named 16 real, concrete uncovered lines, all
genuine gaps from #99's RawNode::TemporalLeaf work landing without
full coverage, not tool flakiness:

- document.rs: RawNode's manual PartialEq's `_ => false` arm (a leaf
  vs an internal node) had no direct test.
- oml.rs: write_oml/write_oml_compact's top-level bare TemporalLeaf
  arms (a whole document that's a single temporal leaf, not nested
  under an edge) were untested.
- oml/writer.rs: write_edges_compact's TemporalLeaf arm (compact mode
  specifically) and write_temporal_leaf's non-Str fallback arm.
- oml/scanner.rs + schema.rs: a bare TIME literal (not DATETIME) can
  carry its own UTC offset per TIME_RE's own `off` group -- untested,
  so the scanner's offset-lookahead and canonicalize_time_captures'
  offset-append branch never ran.
- tools/conformance/src/bin/vector_runner.rs: run_parse's
  document-mismatch fail path and run_all's own Status::Fail handling
  (print label + counter) are never exercised by the real vector
  suite, which currently has 0 real fails -- both needed a direct
  unit test / synthetic fixture.

Added a direct test for each. Fresh `cargo llvm-cov clean --workspace`
+ `cargo llvm-cov --workspace --fail-under-lines 100` now reports the
real Lines metric at 100.00% (11058/11058) and exits 0 -- confirmed,
not assumed.

Closes #95.
