### PR TITLE
fix: Scalar::Int/Value::Int are arbitrary-precision, not i64 (#104)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "check-doc-examples"
-version = "0.1.1-alpha"
+version = "0.1.2-alpha"
 dependencies = [
  "tempfile",
 ]
@@ -155,8 +155,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "conformance"
-version = "0.1.1-alpha"
+version = "0.1.2-alpha"
 dependencies = [
+ "num-bigint",
  "omnist",
  "serde_json",
 ]
@@ -289,6 +290,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,9 +319,11 @@ dependencies = [
 
 [[package]]
 name = "omnist"
-version = "0.1.1-alpha"
+version = "0.1.2-alpha"
 dependencies = [
  "indexmap",
+ "num-bigint",
+ "num-traits",
  "proptest",
  "quick-xml",
  "regex",
@@ -313,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "omnist-cli"
-version = "0.1.1-alpha"
+version = "0.1.2-alpha"
 dependencies = [
  "clap",
  "indexmap",

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -3,7 +3,9 @@
 This port has its own conformance-test harness (`tools/conformance/`)
 against [omnist-spec](https://github.com/omnist-dev/omnist-spec), the
 language-agnostic upstream specification. It vendors omnist-spec as a
-pinned git submodule (`vendor/omnist-spec`, currently `v0.1.1-alpha`) and
+pinned git submodule (`vendor/omnist-spec`, currently commit `f93c569`,
+past the `v0.2.2-alpha` tag -- pinned to the exact commit adding issue
+#104's conformance vector, ahead of any tag that includes it yet) and
 runs entirely against this crate's own library code -- it does not depend
 on the Python or TypeScript ports' implementations.
 
@@ -16,7 +18,7 @@ reporting rule:
 - **Track 1** (`vendor/omnist-spec/conformance/fixtures/`, directory-per-fixture,
   11 operations): **19 passed, 0 failed, 0 skipped**.
 - **Track 2** (`vendor/omnist-spec/test-suite/`, JSON-vector suite, 14-operation
-  vocabulary): **124 passed, 0 failed, 22 skipped** (of 146 vectors).
+  vocabulary): **129 passed, 0 failed, 23 skipped** (of 152 vectors).
 
 Zero real fails on either track as of this writing. Run it yourself:
 
@@ -72,8 +74,8 @@ not implied parity
 ## Real bugs this harness found and fixed
 
 Building this harness against the real spec (rather than trusting the
-Python/TypeScript ports as ground truth) found six real product bugs,
-all fixed across this port's `0.1.0-alpha`/`0.1.1-alpha`:
+Python/TypeScript ports as ground truth) found seven real product bugs,
+all fixed across this port's `0.1.0-alpha`/`0.1.1-alpha` releases:
 
 - **XML reader was type-coercing leaf text** (int/float/bool) at parse
   time, contradicting the spec -- XML has no typed literals. Fixed:
@@ -106,6 +108,24 @@ all fixed across this port's `0.1.0-alpha`/`0.1.1-alpha`:
   structurally unreachable given this port's `any`-scoping decision (see
   [`limitations.md`](limitations.md#the-any-type-scoping-gap-deferred-not-forgotten));
   reclassified from fail to a cited skip rather than a product fix.
+- **`Scalar::Int(i64)` rejected valid arbitrary-precision integer
+  literals** -- omnist-spec section 2.2 defines `integer` as
+  arbitrary-precision (bounded only by the shared 4,300-digit cap), not
+  fixed-width; a 20+ digit OML literal was rejected outright with no
+  digit-cap override in play, a real grammar-acceptance bug (spec
+  section 9.2), not a permitted narrower-limit variation. Not found by
+  this harness on its own -- surfaced by a maintainer-prompted
+  ledger-legitimacy audit ("is this a genuine language limitation or an
+  unexamined shortcut") on the `omnist-spec` side, which added the vector
+  this fix now passes for real. Fixed by moving `Scalar::Int`/`Value::Int`
+  onto `num_bigint::BigInt`; see
+  [Limitations](limitations.md#scalarint-is-arbitrary-precision-issue-104).
+  Found and fixed along the way, not assumed mechanical: the YAML legacy
+  sexagesimal literal's fold used to rely on `i64` overflow as an
+  incidental size bound -- a naive `BigInt` swap would have silently
+  removed it, letting a many-`:`-group literal build an arbitrarily large
+  integer with nothing stopping it. Fixed by enforcing the existing
+  digit cap explicitly on the fold's result instead.
 
 None of these required filing against omnist-spec, Python, or
 TypeScript -- every real fail traced back to an omnist-rs bug when

--- a/docs/formats/json.md
+++ b/docs/formats/json.md
@@ -37,15 +37,14 @@ time it reaches this codec, so there is nothing left to adjust or report
 here, unlike Python (which stringifies a live `datetime.date`/`time` object
 and records a `temporal.stringified` warning).
 
-## Integer digit cap and the `i64` representational limit
+## Integer digit cap (arbitrary-precision, matching Python -- issue #104)
 
 A JSON integer literal over **4300 digits** is a `ParseError` (mirrors
 CPython's `sys.set_int_max_str_digits` guard, which fires inside
-`json.loads` before Python ever sees the value). Because this port's
-`Scalar::Int` is `i64` (max ~19 significant digits), any literal over 19
-digits fails first with "out of range for a 64-bit integer" -- the
-4300-digit cap essentially never fires in practice for this port, but is
-kept anyway for parity with the same guard `oml.rs`/`yaml.rs`/`toml.rs`
-share. Python's reference, by contrast, holds arbitrary-precision `int`s
-under the 4300-digit cap with no 64-bit ceiling at all -- a disclosed
-Rust-specific representational gap, not a bug.
+`json.loads` before Python ever sees the value). Under that cap, this
+port's `Scalar::Int`/`Value::Int` hold the value exactly, at any size --
+`num_bigint::BigInt`, not a fixed-width integer -- matching Python's own
+arbitrary-precision `int` with no additional ceiling. (Previously
+`i64`-backed, ~19 significant digits; that was a real spec-conformance
+bug, not a disclosed representational gap -- see
+[Limitations](../limitations.md#scalarint-is-arbitrary-precision-issue-104).)

--- a/docs/formats/toml.md
+++ b/docs/formats/toml.md
@@ -31,7 +31,7 @@ live-confirmed against `tomli_w.dumps` (Python's reference TOML writer) to
 match exactly, path-for-path. `strict` mode raises even though the severity
 is only `Warning`.
 
-## Integer digit cap, and a disclosed hex/octal/binary divergence from Python
+## Integer digit cap, and a real, external `i64` ceiling from `toml_edit`
 
 Live-confirmed against `tomllib.loads`: a **decimal** integer literal
 follows the identical 4300-digit `sys.set_int_max_str_digits` cap
@@ -40,15 +40,24 @@ genuine exception in Python** -- `tomllib.loads("x = 0x" + "f" * 10000)`
 parses successfully with no error at all, because CPython's digit-limit
 guard explicitly exempts power-of-two bases.
 
-This port does **not** replicate that decimal/non-decimal split: every
-radix goes through the same 4300-digit cap, because the underlying
-`toml_edit` crate itself enforces a strict `i64` range at parse time
-regardless of radix -- there is no path here for an oversized hex/octal/
-binary literal to reach `Scalar::Int` uncapped the way Python's
-arbitrary-precision `int` does. This is a **disclosed divergence from
-Python**, not a parity gap to close: `Scalar::Int` is `i64`-backed
-regardless of a literal's original radix, so an "uncapped hex" path would
-still have to fail somewhere past 64 bits either way.
+This port does **not** replicate that decimal/non-decimal split, but for
+a different reason than it used to (issue #104: `Scalar::Int`/`Value::Int`
+are arbitrary-precision `BigInt`s now, not `i64`). The underlying
+`toml_edit` crate's own `Integer` type is `i64`-backed regardless of
+radix (the TOML 1.0 format spec itself documents 64-bit signed
+integers), so **reading** a >19-digit literal of any radix from TOML
+*source text* fails in `toml_edit`'s own parser, before this codec's
+`Scalar` conversion ever runs -- a real, external, still-current
+divergence from Python's arbitrary-precision `int`, not something this
+port's own representation choice can lift. Live-confirmed:
+`convert --from toml` on `n = 99999999999999999999999999` fails with
+`"integer literal ... is out of range for a 64-bit integer"`.
+**Writing** an oversized `Scalar::Int` *to* TOML, by contrast, succeeds
+-- this codec's writer renders integers as plain digit text rather than
+going through `toml_edit`'s typed API, so the ceiling is read-side only;
+live-confirmed the same 26-digit value round-trips out via
+`convert --from oml --to toml` with no error, it just can't be read back
+in through TOML afterward.
 
 ## Native temporal types, truncated (not rounded) sub-microsecond precision
 

--- a/docs/formats/yaml.md
+++ b/docs/formats/yaml.md
@@ -87,5 +87,10 @@ omnist-rs issue #88, found and fixed alongside #87 above.
 ## Integer digit cap
 
 Same 4300-digit cap as `json.rs`/`oml.rs`/`toml.rs`, applied to a plain
-decimal integer scalar's digit run before parsing; the same `i64`
-representational ceiling applies (see [formats/json.md](json.md)).
+decimal integer scalar's digit run before parsing; arbitrary-precision
+above that (see [formats/json.md](json.md#integer-digit-cap-arbitrary-precision-matching-python----issue-104)).
+The legacy sexagesimal fold (above) enforces the identical cap on its
+*folded result*, not any one group -- issue #104: an unbounded
+`BigInt` fold with no such check would let a many-group literal build an
+arbitrarily large integer, a resource-exhaustion regression the fold's
+old `i64` overflow used to prevent as an unplanned side effect.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -40,29 +40,30 @@ Closing this gap is 1.0-gating work, not a bug to fix incrementally --
 see the sibling `omnist` project's own `any`-openness decision, which this
 port's scoping deliberately mirrors rather than resolves independently.
 
-## Representational limits from `Scalar::Int` being `i64`
+## `Scalar::Int` is arbitrary-precision (issue #104)
 
-Every format codec shares one representational ceiling this port's Python
-and TypeScript siblings don't have: `omnist::document::Scalar::Int` is a
-plain `i64` (max ~19 significant decimal digits), not an arbitrary-
-precision integer. Each format's own page documents the specific
-consequence:
+`omnist::document::Scalar::Int` and `Value::Int` are backed by
+`num_bigint::BigInt`, not a fixed-width integer -- matching omnist-spec
+[section 2.2](https://github.com/omnist-dev/omnist-spec/blob/main/docs/02-document-model.md#22-values)'s
+requirement that `integer` be arbitrary-precision, and Python's/Go's own
+representations (`int`, `*big.Int`). This was previously `i64` (max ~19
+significant decimal digits) -- a real spec-conformance bug, not a
+disclosed permitted variation, since a 20+ digit literal under the shared
+4,300-digit security cap was rejected outright with no
+`declared_max_int_digits` override in play (omnist-spec ledger entry D-9).
+Fixed; see each format's own page for anything still worth knowing:
 
-- [formats/json.md](formats/json.md), [formats/yaml.md](formats/yaml.md) --
-  a decimal integer literal over 19 digits (but under the shared
-  4300-digit security cap) is a `ParseError` ("out of range for a 64-bit
-  integer"), where Python holds it as an exact arbitrary-precision `int`.
-- [formats/toml.md](formats/toml.md) -- the same cap is applied uniformly
-  to hex/octal/binary literals too, a disclosed divergence from Python
-  (which exempts those radixes from its digit-limit guard entirely).
-- [formats/xml.md](formats/xml.md) -- an over-`i64` numeral falls through
-  to `Scalar::Float` instead of erroring, mirroring Python's own
-  int-then-float coercion fallback, just with a narrower `Scalar::Int`.
-
-None of this is a bug: it is the direct, disclosed consequence of issue
-#4's Document-model architecture decision (`Scalar` has exactly five
-variants, `Int` is `i64`), applied consistently across every codec rather
-than special-cased away.
+- [formats/toml.md](formats/toml.md) -- **one real, external divergence
+  remains**: `toml_edit`, the crate this port's TOML codec is built on,
+  has its own `i64`-backed integer type (the TOML 1.0 format spec itself
+  documents 64-bit signed integers), so a >19-digit integer literal in
+  TOML *source text* is still rejected -- by `toml_edit`'s own parser,
+  before this port's `Scalar` is ever involved. Writing an
+  arbitrary-precision `Scalar::Int` *to* TOML still succeeds (this
+  codec's writer renders integers as plain digit text, not through
+  `toml_edit`'s typed API), so the asymmetry is read-side only: such a
+  value round-trips out but not back in through TOML specifically. Every
+  other format (JSON, YAML, OML) has no such ceiling.
 
 ## No native temporal `Scalar` variant
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,7 +2,7 @@
 
 ```toml
 [dependencies]
-omnist = "0.1.1-alpha"
+omnist = "0.1.2-alpha"
 ```
 <!-- doc-illustrative -->
 

--- a/omnist-cli/Cargo.toml
+++ b/omnist-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnist-cli"
-version = "0.1.1-alpha"
+version = "0.1.2-alpha"
 edition = "2024"
 description = "CLI for omnist (Rust port)."
 license = "Apache-2.0"

--- a/omnist/Cargo.toml
+++ b/omnist/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnist"
-version = "0.1.1-alpha"
+version = "0.1.2-alpha"
 edition = "2024"
 description = "One data model, many formats: read, validate, and write JSON, YAML, TOML, XML, and OML. (Rust port of https://github.com/omnist-dev/omnist)"
 license = "Apache-2.0"
@@ -14,6 +14,8 @@ regex = "1"
 yaml-rust2 = { version = "0.11.0", default-features = false }
 toml_edit = { version = "0.25.13", default-features = false, features = ["parse", "display"] }
 quick-xml = "0.41.0"
+num-bigint = "0.4"
+num-traits = "0.2"
 
 [dev-dependencies]
 proptest = "1"

--- a/omnist/examples/json_roundtrip.rs
+++ b/omnist/examples/json_roundtrip.rs
@@ -6,7 +6,7 @@ use omnist::formats::json::{read_json, write_json};
 fn main() {
     let mut fields = IndexMap::new();
     fields.insert("name".to_string(), Value::Str("Ada".to_string()));
-    fields.insert("age".to_string(), Value::Int(37));
+    fields.insert("age".to_string(), Value::Int(37.into()));
     let doc = Doc::of(&Value::Object(fields)).unwrap();
 
     let text = write_json(&doc, Some(2), true, None).unwrap();

--- a/omnist/examples/oml_roundtrip.rs
+++ b/omnist/examples/oml_roundtrip.rs
@@ -7,7 +7,7 @@ use omnist::oml::{read_oml, write_oml};
 fn main() {
     let mut fields = IndexMap::new();
     fields.insert("name".to_string(), Value::Str("Ada".to_string()));
-    fields.insert("age".to_string(), Value::Int(37));
+    fields.insert("age".to_string(), Value::Int(37.into()));
     let doc = Doc::of(&Value::Object(fields)).unwrap();
 
     let text = write_oml(&doc.to_raw(), 2).unwrap();

--- a/omnist/examples/schema_infer.rs
+++ b/omnist/examples/schema_infer.rs
@@ -7,7 +7,7 @@ use omnist::osd::to_osd;
 fn person(name: &str, age: i64, tags: Vec<&str>) -> Value {
     let mut fields = IndexMap::new();
     fields.insert("name".to_string(), Value::Str(name.to_string()));
-    fields.insert("age".to_string(), Value::Int(age));
+    fields.insert("age".to_string(), Value::Int(age.into()));
     fields.insert(
         "tags".to_string(),
         Value::Array(

--- a/omnist/examples/schema_validate.rs
+++ b/omnist/examples/schema_validate.rs
@@ -18,7 +18,7 @@ fn main() {
 
     let mut fields = IndexMap::new();
     fields.insert("name".to_string(), Value::Str("Ada".to_string()));
-    fields.insert("age".to_string(), Value::Int(37));
+    fields.insert("age".to_string(), Value::Int(37.into()));
     let doc = Doc::of(&Value::Object(fields)).unwrap();
 
     let result = schema.validate(&doc.root());

--- a/omnist/examples/toml_roundtrip.rs
+++ b/omnist/examples/toml_roundtrip.rs
@@ -6,7 +6,7 @@ use omnist::formats::toml::{read_toml, write_toml};
 fn main() {
     let mut fields = IndexMap::new();
     fields.insert("name".to_string(), Value::Str("Ada".to_string()));
-    fields.insert("age".to_string(), Value::Int(37));
+    fields.insert("age".to_string(), Value::Int(37.into()));
     let doc = Doc::of(&Value::Object(fields)).unwrap();
 
     let text = write_toml(&doc, true, None).unwrap();

--- a/omnist/examples/yaml_roundtrip.rs
+++ b/omnist/examples/yaml_roundtrip.rs
@@ -6,7 +6,7 @@ use omnist::formats::yaml::{read_yaml, write_yaml};
 fn main() {
     let mut fields = IndexMap::new();
     fields.insert("name".to_string(), Value::Str("Ada".to_string()));
-    fields.insert("age".to_string(), Value::Int(37));
+    fields.insert("age".to_string(), Value::Int(37.into()));
     let doc = Doc::of(&Value::Object(fields)).unwrap();
 
     let text = write_yaml(&doc, true, None).unwrap();

--- a/omnist/src/document.rs
+++ b/omnist/src/document.rs
@@ -56,11 +56,19 @@ pub const MAX_NODES: usize = 1_000_000;
 pub struct NodeId(usize);
 
 /// A leaf value.
+///
+/// `Int` is arbitrary-precision (`BigInt`), not a fixed-width integer --
+/// omnist-spec §2.2 defines `integer` as arbitrary-precision, bounded only
+/// by the shared digit-count cap (`MAX_INT_DIGITS`), the same way Python's
+/// native `int` and Go's `*big.Int` already are (issue #104; previously
+/// `i64`, which silently rejected any literal past ~19 digits -- a
+/// spec-conformance bug, not a permitted narrower-limit variation, since no
+/// digit-count override was in play).
 #[derive(Debug, Clone, PartialEq)]
 pub enum Scalar {
     Null,
     Bool(bool),
-    Int(i64),
+    Int(num_bigint::BigInt),
     Float(f64),
     Str(String),
 }
@@ -86,7 +94,7 @@ impl fmt::Display for Scalar {
 pub enum Value {
     Null,
     Bool(bool),
-    Int(i64),
+    Int(num_bigint::BigInt),
     Float(f64),
     Str(String),
     Array(Vec<Value>),
@@ -254,7 +262,7 @@ fn build_node(
         // to justify, since those two variants are already handled above.
         Value::Null => push(arena, NodeData::Leaf(Scalar::Null), depth, path),
         Value::Bool(b) => push(arena, NodeData::Leaf(Scalar::Bool(*b)), depth, path),
-        Value::Int(i) => push(arena, NodeData::Leaf(Scalar::Int(*i)), depth, path),
+        Value::Int(i) => push(arena, NodeData::Leaf(Scalar::Int(i.clone())), depth, path),
         Value::Float(x) => push(arena, NodeData::Leaf(Scalar::Float(*x)), depth, path),
         Value::Str(s) => push(arena, NodeData::Leaf(Scalar::Str(s.clone())), depth, path),
     }
@@ -796,7 +804,7 @@ mod tests {
         // The `_ => false` catch-all in `RawNode`'s manual `PartialEq`
         // (issue #99) -- a leaf (either variant) can never equal an
         // internal node, regardless of the leaf's own tag.
-        let leaf = RawNode::Leaf(Scalar::Int(1));
+        let leaf = RawNode::Leaf(Scalar::Int((1).into()));
         let temporal = RawNode::TemporalLeaf(Scalar::Str("2024-01-01".to_string()));
         let edges = RawNode::Edges(vec![]);
         assert_ne!(leaf, edges);
@@ -816,7 +824,7 @@ mod tests {
     /// `build_node`'s depth arithmetic, the leaf ends up at depth `levels`
     /// (each object level adds exactly 1 -- no array involved).
     fn nest(levels: usize) -> Value {
-        let mut v = Value::Int(0);
+        let mut v = Value::Int((0).into());
         for _ in 0..levels {
             v = obj(&[("a", v)]);
         }
@@ -827,15 +835,15 @@ mod tests {
 
     #[test]
     fn constructs_a_scalar_leaf() {
-        let doc = Doc::of(&Value::Int(42)).unwrap();
+        let doc = Doc::of(&Value::Int((42).into())).unwrap();
         let root = doc.root();
         assert!(root.is_leaf());
-        assert_eq!(root.value().unwrap(), &Scalar::Int(42));
+        assert_eq!(root.value().unwrap(), &Scalar::Int((42).into()));
     }
 
     #[test]
     fn constructs_an_object_as_ordered_edges() {
-        let v = obj(&[("b", Value::Int(1)), ("a", Value::Int(2))]);
+        let v = obj(&[("b", Value::Int((1).into())), ("a", Value::Int((2).into()))]);
         let doc = Doc::of(&v).unwrap();
         let root = doc.root();
         assert!(!root.is_leaf());
@@ -849,7 +857,11 @@ mod tests {
     fn a_list_value_expands_into_repeated_edges() {
         let v = obj(&[(
             "member",
-            Value::Array(vec![Value::Int(1), Value::Int(2), Value::Int(3)]),
+            Value::Array(vec![
+                Value::Int((1).into()),
+                Value::Int((2).into()),
+                Value::Int((3).into()),
+            ]),
         )]);
         let doc = Doc::of(&v).unwrap();
         let root = doc.root();
@@ -858,20 +870,27 @@ mod tests {
         let vals: Vec<&Scalar> = members.iter().map(|c| c.value().unwrap()).collect();
         assert_eq!(
             vals,
-            vec![&Scalar::Int(1), &Scalar::Int(2), &Scalar::Int(3)]
+            vec![
+                &Scalar::Int((1).into()),
+                &Scalar::Int((2).into()),
+                &Scalar::Int((3).into())
+            ]
         );
     }
 
     #[test]
     fn a_bare_top_level_array_is_rejected() {
-        let err = Doc::of(&Value::Array(vec![Value::Int(1)])).unwrap_err();
+        let err = Doc::of(&Value::Array(vec![Value::Int((1).into())])).unwrap_err();
         assert!(err.message.contains("bare array"));
         assert_eq!(err.path, "$");
     }
 
     #[test]
     fn an_array_of_arrays_is_rejected() {
-        let v = obj(&[("a", Value::Array(vec![Value::Array(vec![Value::Int(1)])]))]);
+        let v = obj(&[(
+            "a",
+            Value::Array(vec![Value::Array(vec![Value::Int((1).into())])]),
+        )]);
         let err = Doc::of(&v).unwrap_err();
         assert!(err.message.contains("array of arrays"));
         assert_eq!(err.path, "$.a[0]");
@@ -904,7 +923,7 @@ mod tests {
     // its own node).
 
     fn wide(n: usize) -> Value {
-        obj(&[("a", Value::Array(vec![Value::Int(0); n]))])
+        obj(&[("a", Value::Array(vec![Value::Int((0).into()); n]))])
     }
 
     #[test]
@@ -928,8 +947,8 @@ mod tests {
         // itself costs an extra level, mirroring Python's `_children`
         // (see the module doc comment / build_node's `depth + 1` for the
         // list branch on top of the caller's own `depth + 1`).
-        let direct = obj(&[("a", Value::Int(1))]);
-        let via_array = obj(&[("a", Value::Array(vec![Value::Int(1)]))]);
+        let direct = obj(&[("a", Value::Int((1).into()))]);
+        let via_array = obj(&[("a", Value::Array(vec![Value::Int((1).into())]))]);
         let doc_direct = Doc::of(&direct).unwrap();
         let doc_array = Doc::of(&via_array).unwrap();
         let leaf_direct = doc_direct.root().child("a").unwrap();
@@ -947,7 +966,7 @@ mod tests {
 
         // Doc::add, attaching at the root (depth 0): the pushed subtree's
         // own internal depth is what must exceed MAX_DEPTH.
-        let mut doc = Doc::of(&obj(&[("seed", Value::Int(0))])).unwrap();
+        let mut doc = Doc::of(&obj(&[("seed", Value::Int((0).into()))])).unwrap();
         let root_id = doc.root().id();
         let root_path = doc.root().path.clone();
         assert!(
@@ -956,7 +975,7 @@ mod tests {
         );
 
         // Doc::set: same guard, different mutating call site.
-        let mut doc2 = Doc::of(&obj(&[("seed", Value::Int(0))])).unwrap();
+        let mut doc2 = Doc::of(&obj(&[("seed", Value::Int((0).into()))])).unwrap();
         let root_id2 = doc2.root().id();
         let root_path2 = doc2.root().path.clone();
         assert!(
@@ -1006,20 +1025,26 @@ mod tests {
         // key can't repeat) -- "z" appears twice because its value is a
         // 2-item array, not because the object has two "z" entries.
         let v = obj(&[
-            ("z", Value::Array(vec![Value::Int(1), Value::Int(3)])),
-            ("a", Value::Int(2)),
-            ("m", Value::Int(4)),
+            (
+                "z",
+                Value::Array(vec![Value::Int((1).into()), Value::Int((3).into())]),
+            ),
+            ("a", Value::Int((2).into())),
+            ("m", Value::Int((4).into())),
         ]);
         let doc = Doc::of(&v).unwrap();
         let root = doc.root();
         assert_eq!(root.labels(), vec!["z", "a", "m"]);
         let z_vals: Vec<&Scalar> = root.get("z").iter().map(|c| c.value().unwrap()).collect();
-        assert_eq!(z_vals, vec![&Scalar::Int(1), &Scalar::Int(3)]);
+        assert_eq!(
+            z_vals,
+            vec![&Scalar::Int((1).into()), &Scalar::Int((3).into())]
+        );
     }
 
     #[test]
     fn labels_and_count_on_a_leaf_are_empty() {
-        let doc = Doc::of(&Value::Int(1)).unwrap();
+        let doc = Doc::of(&Value::Int((1).into())).unwrap();
         let root = doc.root();
         assert!(root.labels().is_empty());
         assert_eq!(root.count("anything"), 0);
@@ -1028,14 +1053,20 @@ mod tests {
     #[test]
     fn to_grouped_preserves_first_seen_key_order() {
         let v = obj(&[
-            ("z", Value::Array(vec![Value::Int(1), Value::Int(3)])),
-            ("a", Value::Int(2)),
+            (
+                "z",
+                Value::Array(vec![Value::Int((1).into()), Value::Int((3).into())]),
+            ),
+            ("a", Value::Int((2).into())),
         ]);
         let doc = Doc::of(&v).unwrap();
         let grouped = doc.to_grouped();
         let expected = obj(&[
-            ("z", Value::Array(vec![Value::Int(1), Value::Int(3)])),
-            ("a", Value::Int(2)),
+            (
+                "z",
+                Value::Array(vec![Value::Int((1).into()), Value::Int((3).into())]),
+            ),
+            ("a", Value::Int((2).into())),
         ]);
         assert_eq!(grouped, expected);
         // `assert_eq!` above is order-insensitive (`IndexMap`'s `PartialEq`
@@ -1051,7 +1082,7 @@ mod tests {
 
     #[test]
     fn value_as_object_is_none_for_a_non_object() {
-        assert!(Value::Int(1).as_object().is_none());
+        assert!(Value::Int((1).into()).as_object().is_none());
     }
 
     // -- mutation semantics: add / set / remove / count / get -----------
@@ -1061,8 +1092,10 @@ mod tests {
         let mut doc = Doc::of(&obj(&[])).unwrap();
         let root_id = doc.root().id();
         let root_path = doc.root().path.clone();
-        doc.add(root_id, &root_path, "x", &Value::Int(1)).unwrap();
-        doc.add(root_id, &root_path, "x", &Value::Int(2)).unwrap();
+        doc.add(root_id, &root_path, "x", &Value::Int((1).into()))
+            .unwrap();
+        doc.add(root_id, &root_path, "x", &Value::Int((2).into()))
+            .unwrap();
         let root = doc.root();
         assert_eq!(root.count("x"), 2);
         assert!(root.get_one("x").is_err());
@@ -1071,26 +1104,31 @@ mod tests {
     #[test]
     fn set_replaces_all_occurrences_at_first_position() {
         let mut doc = Doc::of(&obj(&[
-            ("x", Value::Int(1)),
-            ("y", Value::Int(9)),
-            ("x", Value::Int(2)),
+            ("x", Value::Int((1).into())),
+            ("y", Value::Int((9).into())),
+            ("x", Value::Int((2).into())),
         ]))
         .unwrap();
         let root_id = doc.root().id();
         let root_path = doc.root().path.clone();
-        doc.set(root_id, &root_path, "x", &Value::Int(100)).unwrap();
+        doc.set(root_id, &root_path, "x", &Value::Int((100).into()))
+            .unwrap();
         let root = doc.root();
         let labels: Vec<String> = root.edges().unwrap().into_iter().map(|(l, _)| l).collect();
         assert_eq!(labels, vec!["x", "y"]);
         assert_eq!(
             root.get_one("x").unwrap().value().unwrap(),
-            &Scalar::Int(100)
+            &Scalar::Int((100).into())
         );
     }
 
     #[test]
     fn remove_drops_every_edge_with_that_label() {
-        let mut doc = Doc::of(&obj(&[("x", Value::Int(1)), ("x", Value::Int(2))])).unwrap();
+        let mut doc = Doc::of(&obj(&[
+            ("x", Value::Int((1).into())),
+            ("x", Value::Int((2).into())),
+        ]))
+        .unwrap();
         let root_id = doc.root().id();
         let root_path = doc.root().path.clone();
         doc.remove(root_id, &root_path, "x").unwrap();
@@ -1103,7 +1141,7 @@ mod tests {
         // gate through `require_internal` first, so this helper's `Leaf`
         // arm is unreachable via the public API -- call it directly to
         // prove the arm itself is correct (see its doc comment).
-        let mut doc = Doc::of(&Value::Int(1)).unwrap();
+        let mut doc = Doc::of(&Value::Int((1).into())).unwrap();
         let root_id = doc.root().id();
         let err = doc.internal_edges_mut(root_id, "$", "poke").unwrap_err();
         assert_eq!(err.path, "$");
@@ -1112,23 +1150,29 @@ mod tests {
 
     #[test]
     fn mutation_on_a_leaf_is_rejected() {
-        let mut doc = Doc::of(&Value::Int(1)).unwrap();
+        let mut doc = Doc::of(&Value::Int((1).into())).unwrap();
         let root_id = doc.root().id();
         let root_path = doc.root().path.clone();
-        assert!(doc.add(root_id, &root_path, "x", &Value::Int(1)).is_err());
-        assert!(doc.set(root_id, &root_path, "x", &Value::Int(1)).is_err());
+        assert!(
+            doc.add(root_id, &root_path, "x", &Value::Int((1).into()))
+                .is_err()
+        );
+        assert!(
+            doc.set(root_id, &root_path, "x", &Value::Int((1).into()))
+                .is_err()
+        );
         assert!(doc.remove(root_id, &root_path, "x").is_err());
     }
 
     #[test]
     fn value_on_an_internal_node_is_rejected() {
-        let doc = Doc::of(&obj(&[("x", Value::Int(1))])).unwrap();
+        let doc = Doc::of(&obj(&[("x", Value::Int((1).into()))])).unwrap();
         assert!(doc.root().value().is_err());
     }
 
     #[test]
     fn edges_on_a_leaf_is_rejected() {
-        let doc = Doc::of(&Value::Int(1)).unwrap();
+        let doc = Doc::of(&Value::Int((1).into())).unwrap();
         assert!(doc.root().edges().is_err());
     }
 
@@ -1136,7 +1180,7 @@ mod tests {
     fn raw_edges_on_a_leaf_is_rejected() {
         // Mirrors `edges_on_a_leaf_is_rejected` for the lazy-path variant
         // `edges()` piggybacks its own path-numbering on -- see issue #44.
-        let doc = Doc::of(&Value::Int(1)).unwrap();
+        let doc = Doc::of(&Value::Int((1).into())).unwrap();
         assert!(doc.root().raw_edges().is_err());
     }
 
@@ -1144,7 +1188,10 @@ mod tests {
 
     #[test]
     fn to_data_round_trips_structure() {
-        let v = obj(&[("a", Value::Int(1)), ("b", Value::Str("hi".to_string()))]);
+        let v = obj(&[
+            ("a", Value::Int((1).into())),
+            ("b", Value::Str("hi".to_string())),
+        ]);
         let doc = Doc::of(&v).unwrap();
         assert_eq!(doc.to_data(), v);
     }
@@ -1157,7 +1204,7 @@ mod tests {
         let v = obj(&[
             ("n", Value::Null),
             ("b", Value::Bool(true)),
-            ("i", Value::Int(7)),
+            ("i", Value::Int((7).into())),
             ("f", Value::Float(1.5)),
             ("s", Value::Str("hi".to_string())),
         ]);
@@ -1172,7 +1219,7 @@ mod tests {
         // the `path["key"]` form, not `path.key`.
         let v = obj(&[(
             "1bad",
-            Value::Array(vec![Value::Array(vec![Value::Int(1)])]),
+            Value::Array(vec![Value::Array(vec![Value::Int((1).into())])]),
         )]);
         let err = Doc::of(&v).unwrap_err();
         assert_eq!(err.path, "$[\"1bad\"][0]");
@@ -1180,9 +1227,9 @@ mod tests {
 
     #[test]
     fn eq_doc_compares_structurally() {
-        let a = Doc::of(&obj(&[("a", Value::Int(1))])).unwrap();
-        let b = Doc::of(&obj(&[("a", Value::Int(1))])).unwrap();
-        let c = Doc::of(&obj(&[("a", Value::Int(2))])).unwrap();
+        let a = Doc::of(&obj(&[("a", Value::Int((1).into()))])).unwrap();
+        let b = Doc::of(&obj(&[("a", Value::Int((1).into()))])).unwrap();
+        let c = Doc::of(&obj(&[("a", Value::Int((2).into()))])).unwrap();
         assert!(a.eq_doc(&b));
         assert!(!a.eq_doc(&c));
     }
@@ -1191,8 +1238,8 @@ mod tests {
     fn eq_doc_is_false_when_shapes_differ() {
         // A leaf is never equal to an internal node, regardless of
         // content -- exercises `node_eq`'s (Leaf, Internal) mismatch arm.
-        let leaf = Doc::of(&Value::Int(1)).unwrap();
-        let internal = Doc::of(&obj(&[("a", Value::Int(1))])).unwrap();
+        let leaf = Doc::of(&Value::Int((1).into())).unwrap();
+        let internal = Doc::of(&obj(&[("a", Value::Int((1).into()))])).unwrap();
         assert!(!leaf.eq_doc(&internal));
         assert!(!internal.eq_doc(&leaf));
     }
@@ -1201,7 +1248,7 @@ mod tests {
     fn scalar_display_covers_every_variant() {
         assert_eq!(Scalar::Null.to_string(), "null");
         assert_eq!(Scalar::Bool(true).to_string(), "true");
-        assert_eq!(Scalar::Int(1).to_string(), "1");
+        assert_eq!(Scalar::Int((1).into()).to_string(), "1");
         assert_eq!(Scalar::Float(1.5).to_string(), "1.5");
         assert_eq!(Scalar::Str("x".to_string()).to_string(), "\"x\"");
     }
@@ -1214,9 +1261,9 @@ mod tests {
         // exactly the shape `Value`/`IndexMap` cannot represent, which is
         // why the OML codec goes through RawNode instead.
         let raw = RawNode::Edges(vec![
-            ("b".to_string(), RawNode::Leaf(Scalar::Int(1))),
-            ("c".to_string(), RawNode::Leaf(Scalar::Int(2))),
-            ("b".to_string(), RawNode::Leaf(Scalar::Int(3))),
+            ("b".to_string(), RawNode::Leaf(Scalar::Int((1).into()))),
+            ("c".to_string(), RawNode::Leaf(Scalar::Int((2).into()))),
+            ("b".to_string(), RawNode::Leaf(Scalar::Int((3).into()))),
         ]);
         let doc = Doc::from_raw(raw.clone()).unwrap();
         assert_eq!(doc.to_raw(), raw);
@@ -1241,7 +1288,7 @@ mod tests {
     #[test]
     fn from_raw_enforces_the_depth_guard() {
         fn nest_raw(levels: usize) -> RawNode {
-            let mut n = RawNode::Leaf(Scalar::Int(0));
+            let mut n = RawNode::Leaf(Scalar::Int((0).into()));
             for _ in 0..levels {
                 n = RawNode::Edges(vec![("a".to_string(), n)]);
             }

--- a/omnist/src/formats/json.rs
+++ b/omnist/src/formats/json.rs
@@ -47,7 +47,7 @@ use crate::WriteError;
 use crate::document::{Doc, Value};
 use crate::error::{OmnistError, ParseError};
 use crate::formats::float_fmt;
-use crate::formats::int_cap::{MAX_INT_DIGITS, out_of_range_message, over_cap_message};
+use crate::formats::int_cap::{MAX_INT_DIGITS, over_cap_message};
 use crate::formats::string_escape::{JSON_ESCAPES, write_quoted};
 use crate::formats::textpos::line_col_bytes;
 use crate::report::{Severity, WriteReport};
@@ -625,10 +625,13 @@ impl<'a> Parser<'a> {
             if digits.len() > MAX_INT_DIGITS {
                 return Err(self.error_at(start, over_cap_message("", digits.len())));
             }
-            match text.parse::<i64>() {
-                Ok(v) => Ok(Value::Int(v)),
-                Err(_) => Err(self.error_at(start, out_of_range_message("", text))),
-            }
+            // Arbitrary-precision (issue #104): the scanner only emits
+            // number-shaped ASCII-digit text (with an optional leading
+            // `-`), and BigInt::parse_bytes always succeeds on that shape.
+            let v = num_bigint::BigInt::parse_bytes(text.as_bytes(), 10).expect(
+                "scanner only emits digit-shaped text, which BigInt::parse_bytes always parses",
+            );
+            Ok(Value::Int(v))
         }
     }
 }
@@ -649,7 +652,10 @@ mod tests {
     fn reads_object_with_scalars() {
         let doc = read_json(r#"{"a": 1, "b": "s", "c": true, "d": null, "e": 1.5}"#).unwrap();
         let root = doc.root();
-        assert_eq!(*root.get_one("a").unwrap().value().unwrap(), Scalar::Int(1));
+        assert_eq!(
+            *root.get_one("a").unwrap().value().unwrap(),
+            Scalar::Int((1).into())
+        );
         assert_eq!(
             *root.get_one("b").unwrap().value().unwrap(),
             Scalar::Str("s".to_string())
@@ -680,8 +686,8 @@ mod tests {
         let root = doc.root();
         let ms = root.get("m");
         assert_eq!(ms.len(), 3);
-        assert_eq!(*ms[0].value().unwrap(), Scalar::Int(1));
-        assert_eq!(*ms[2].value().unwrap(), Scalar::Int(3));
+        assert_eq!(*ms[0].value().unwrap(), Scalar::Int((1).into()));
+        assert_eq!(*ms[2].value().unwrap(), Scalar::Int((3).into()));
     }
 
     #[test]
@@ -696,7 +702,10 @@ mod tests {
         let root = doc.root();
         let a = root.get_one("a").unwrap();
         let b = a.get_one("b").unwrap();
-        assert_eq!(*b.get_one("c").unwrap().value().unwrap(), Scalar::Int(1));
+        assert_eq!(
+            *b.get_one("c").unwrap().value().unwrap(),
+            Scalar::Int((1).into())
+        );
     }
 
     #[test]
@@ -742,7 +751,10 @@ mod tests {
         let doc = read_json(r#"{"a": 1, "b": 2, "a": 3}"#).unwrap();
         let root = doc.root();
         assert_eq!(root.labels(), vec!["a".to_string(), "b".to_string()]);
-        assert_eq!(*root.get_one("a").unwrap().value().unwrap(), Scalar::Int(3));
+        assert_eq!(
+            *root.get_one("a").unwrap().value().unwrap(),
+            Scalar::Int((3).into())
+        );
     }
 
     #[test]
@@ -806,14 +818,18 @@ mod tests {
     }
 
     #[test]
-    fn integer_literal_under_digit_cap_but_over_i64_range_is_out_of_range_error() {
+    fn integer_literal_under_digit_cap_but_over_i64_range_parses() {
         // 20 nines: over i64::MAX's 19 digits, comfortably under the
-        // 4300-digit cap -- exercises the *out-of-range* branch, not the
-        // digit-cap branch (see this module's doc comment on why the cap
-        // is unreachable via i64 alone for such a literal).
+        // 4300-digit cap -- issue #104: `Scalar::Int` is arbitrary-precision
+        // (`BigInt`), so this is no longer an out-of-range error, it's a
+        // real, correctly-parsed value.
         let text = format!(r#"{{"a": {}}}"#, "9".repeat(20));
-        let err = read_json(&text).unwrap_err();
-        assert!(matches!(err, OmnistError::Parse(_)), "got {err:?}");
+        let doc = read_json(&text).unwrap();
+        let value = doc.root().child("a").unwrap().value().unwrap();
+        assert_eq!(
+            value,
+            &Scalar::Int(num_bigint::BigInt::parse_bytes(b"99999999999999999999", 10).unwrap())
+        );
     }
 
     #[test]
@@ -827,16 +843,17 @@ mod tests {
     }
 
     #[test]
-    fn integer_literal_exactly_at_digit_cap_is_out_of_range_not_digit_cap_error() {
-        // At exactly 4300 digits it's still an i64 range error (this port's
-        // i64-based Scalar can't hold it either way), not the digit-cap
-        // message -- confirms the cap boundary is `> MAX_INT_DIGITS`.
+    fn integer_literal_exactly_at_digit_cap_parses_not_digit_cap_error() {
+        // At exactly 4300 digits: under arbitrary-precision (issue #104)
+        // this is a real, successfully-parsed value -- confirms the cap
+        // boundary is `> MAX_INT_DIGITS`, not `>=`.
         let text = format!(r#"{{"a": {}}}"#, "9".repeat(MAX_INT_DIGITS));
-        let err = read_json(&text).unwrap_err();
+        let doc = read_json(&text).unwrap();
+        let value = doc.root().child("a").unwrap().value().unwrap();
         assert!(
-            matches!(&err, OmnistError::Parse(e) if e.message.contains("out of range")),
-            "got {err:?}"
-        )
+            matches!(value, Scalar::Int(i) if i.to_string().len() == MAX_INT_DIGITS),
+            "got {value:?}"
+        );
     }
 
     #[test]
@@ -1064,7 +1081,7 @@ mod tests {
         let v = obj(vec![
             ("null", Value::Null),
             ("bool", Value::Bool(true)),
-            ("int", Value::Int(42)),
+            ("int", Value::Int((42).into())),
             ("float", Value::Float(1.5)),
             ("str", Value::Str("hi".to_string())),
         ]);
@@ -1111,7 +1128,7 @@ mod tests {
     fn writes_repeated_labels_as_a_json_array() {
         let doc = doc_of(obj(vec![(
             "m",
-            Value::Array(vec![Value::Int(1), Value::Int(2)]),
+            Value::Array(vec![Value::Int((1).into()), Value::Int((2).into())]),
         )]));
         let text = write_json(&doc, None, false, None).unwrap();
         assert_eq!(text, r#"{"m": [1, 2]}"#);
@@ -1119,14 +1136,17 @@ mod tests {
 
     #[test]
     fn writes_compact_with_comma_space_separators() {
-        let doc = doc_of(obj(vec![("a", Value::Int(1)), ("b", Value::Int(2))]));
+        let doc = doc_of(obj(vec![
+            ("a", Value::Int((1).into())),
+            ("b", Value::Int((2).into())),
+        ]));
         let text = write_json(&doc, None, false, None).unwrap();
         assert_eq!(text, r#"{"a": 1, "b": 2}"#);
     }
 
     #[test]
     fn writes_indented_multiline() {
-        let doc = doc_of(obj(vec![("a", Value::Int(1))]));
+        let doc = doc_of(obj(vec![("a", Value::Int((1).into()))]));
         let text = write_json(&doc, Some(2), false, None).unwrap();
         assert_eq!(text, "{\n  \"a\": 1\n}");
     }
@@ -1144,7 +1164,10 @@ mod tests {
         // (see `document.rs`'s `child_specs`) -- the label simply doesn't
         // appear in the built `Doc`, so it can't round-trip as `[]`. This
         // is a Document-model property, not something this codec controls.
-        let doc = doc_of(obj(vec![("a", Value::Array(vec![])), ("b", Value::Int(1))]));
+        let doc = doc_of(obj(vec![
+            ("a", Value::Array(vec![])),
+            ("b", Value::Int((1).into())),
+        ]));
         let text = write_json(&doc, None, false, None).unwrap();
         assert_eq!(text, r#"{"b": 1}"#);
     }
@@ -1174,7 +1197,7 @@ mod tests {
 
     #[test]
     fn strict_write_with_no_adjustments_succeeds() {
-        let doc = doc_of(obj(vec![("a", Value::Int(1))]));
+        let doc = doc_of(obj(vec![("a", Value::Int((1).into()))]));
         let text = write_json(&doc, None, true, None).unwrap();
         assert_eq!(text, r#"{"a": 1}"#);
     }
@@ -1252,7 +1275,7 @@ mod tests {
         // Doc::of already rejects nesting past MAX_DEPTH at construction
         // time (see this module's doc comment) -- confirms write_json never
         // even sees an over-deep Doc to begin with.
-        let mut v = Value::Int(0);
+        let mut v = Value::Int((0).into());
         for _ in 0..=crate::document::MAX_DEPTH {
             v = obj(vec![("a", v)]);
         }
@@ -1266,11 +1289,15 @@ mod tests {
         // (see the PR description) -- this test pins the Rust side of that
         // comparison.
         let doc = doc_of(obj(vec![
-            ("a", Value::Int(1)),
+            ("a", Value::Int((1).into())),
             ("b", Value::Str("x".to_string())),
             (
                 "c",
-                Value::Array(vec![Value::Int(1), Value::Int(2), Value::Int(3)]),
+                Value::Array(vec![
+                    Value::Int((1).into()),
+                    Value::Int((2).into()),
+                    Value::Int((3).into()),
+                ]),
             ),
         ]));
         let text = write_json(&doc, None, false, None).unwrap();

--- a/omnist/src/formats/toml.rs
+++ b/omnist/src/formats/toml.rs
@@ -319,7 +319,13 @@ fn item_to_value(item: &Item) -> Result<Value, ParseError> {
 fn toml_value_to_value(v: &toml_edit::Value) -> Result<Value, ParseError> {
     match v {
         toml_edit::Value::String(s) => Ok(Value::Str(s.value().clone())),
-        toml_edit::Value::Integer(i) => Ok(Value::Int(*i.value())),
+        // `toml_edit`'s own `Integer` is `i64`-backed (the TOML 1.0 format
+        // spec itself specifies 64-bit signed integers) -- a >19-digit
+        // literal in TOML *source text* is rejected by `toml_edit`'s own
+        // parser before this function ever runs, a genuine external
+        // format-level constraint distinct from omnist's own Scalar
+        // representation (issue #104; see docs/formats/toml.md).
+        toml_edit::Value::Integer(i) => Ok(Value::Int((*i.value()).into())),
         toml_edit::Value::Float(f) => Ok(Value::Float(*f.value())),
         toml_edit::Value::Boolean(b) => Ok(Value::Bool(*b.value())),
         toml_edit::Value::Datetime(dt) => Ok(Value::Str(format_datetime(dt.value()))),
@@ -599,7 +605,10 @@ mod tests {
     fn reads_every_native_scalar_kind() {
         let doc = read_toml("a = 1\nb = \"s\"\nc = true\nd = 1.5\ne = false\n").unwrap();
         let root = doc.root();
-        assert_eq!(*root.get_one("a").unwrap().value().unwrap(), Scalar::Int(1));
+        assert_eq!(
+            *root.get_one("a").unwrap().value().unwrap(),
+            Scalar::Int((1).into())
+        );
         assert_eq!(
             *root.get_one("b").unwrap().value().unwrap(),
             Scalar::Str("s".to_string())
@@ -627,7 +636,7 @@ mod tests {
         let nested = root.get_one("nested").unwrap();
         assert_eq!(
             *nested.get_one("x").unwrap().value().unwrap(),
-            Scalar::Int(1)
+            Scalar::Int((1).into())
         );
     }
 
@@ -639,11 +648,11 @@ mod tests {
         assert_eq!(items.len(), 2);
         assert_eq!(
             *items[0].get_one("x").unwrap().value().unwrap(),
-            Scalar::Int(1)
+            Scalar::Int((1).into())
         );
         assert_eq!(
             *items[1].get_one("x").unwrap().value().unwrap(),
-            Scalar::Int(2)
+            Scalar::Int((2).into())
         );
     }
 
@@ -759,7 +768,7 @@ mod tests {
     #[test]
     fn round_trips_every_native_scalar_kind() {
         let v = obj(vec![
-            ("a", Value::Int(42)),
+            ("a", Value::Int((42).into())),
             ("b", Value::Str("hello".to_string())),
             ("c", Value::Bool(true)),
             ("d", Value::Float(1.5)),
@@ -771,7 +780,7 @@ mod tests {
         let root = doc2.root();
         assert_eq!(
             *root.get_one("a").unwrap().value().unwrap(),
-            Scalar::Int(42)
+            Scalar::Int((42).into())
         );
         assert_eq!(
             *root.get_one("b").unwrap().value().unwrap(),
@@ -842,13 +851,17 @@ mod tests {
             (
                 "nested",
                 obj(vec![
-                    ("x", Value::Int(1)),
+                    ("x", Value::Int((1).into())),
                     ("y", Value::Str("z".to_string())),
                 ]),
             ),
             (
                 "arr",
-                Value::Array(vec![Value::Int(1), Value::Int(2), Value::Int(3)]),
+                Value::Array(vec![
+                    Value::Int((1).into()),
+                    Value::Int((2).into()),
+                    Value::Int((3).into()),
+                ]),
             ),
         ]);
         let doc = doc_of(v);
@@ -858,7 +871,7 @@ mod tests {
         let nested = root.get_one("nested").unwrap();
         assert_eq!(
             *nested.get_one("x").unwrap().value().unwrap(),
-            Scalar::Int(1)
+            Scalar::Int((1).into())
         );
         assert_eq!(
             *nested.get_one("y").unwrap().value().unwrap(),
@@ -872,8 +885,8 @@ mod tests {
         let v = obj(vec![(
             "items",
             Value::Array(vec![
-                obj(vec![("x", Value::Int(1))]),
-                obj(vec![("x", Value::Int(2))]),
+                obj(vec![("x", Value::Int((1).into()))]),
+                obj(vec![("x", Value::Int((2).into()))]),
             ]),
         )]);
         let doc = doc_of(v);
@@ -883,11 +896,11 @@ mod tests {
         assert_eq!(items.len(), 2);
         assert_eq!(
             *items[0].get_one("x").unwrap().value().unwrap(),
-            Scalar::Int(1)
+            Scalar::Int((1).into())
         );
         assert_eq!(
             *items[1].get_one("x").unwrap().value().unwrap(),
-            Scalar::Int(2)
+            Scalar::Int((2).into())
         );
     }
 
@@ -925,7 +938,7 @@ mod tests {
 
     #[test]
     fn lenient_write_drops_null_field_and_records_adjustment() {
-        let v = obj(vec![("a", Value::Int(1)), ("b", Value::Null)]);
+        let v = obj(vec![("a", Value::Int((1).into())), ("b", Value::Null)]);
         let doc = doc_of(v);
         let mut rep = WriteReport::new();
         let text = write_toml(&doc, false, Some(&mut rep)).unwrap();
@@ -940,7 +953,11 @@ mod tests {
     fn lenient_write_drops_null_array_item_shifting_index() {
         let v = obj(vec![(
             "c",
-            Value::Array(vec![Value::Int(1), Value::Null, Value::Int(2)]),
+            Value::Array(vec![
+                Value::Int((1).into()),
+                Value::Null,
+                Value::Int((2).into()),
+            ]),
         )]);
         let doc = doc_of(v);
         let mut rep = WriteReport::new();
@@ -955,7 +972,7 @@ mod tests {
     fn null_in_nested_table_records_nested_path() {
         let v = obj(vec![(
             "nested",
-            obj(vec![("x", Value::Null), ("y", Value::Int(5))]),
+            obj(vec![("x", Value::Null), ("y", Value::Int((5).into()))]),
         )]);
         let doc = doc_of(v);
         let rep = check_toml(&doc);
@@ -965,7 +982,7 @@ mod tests {
 
     #[test]
     fn strict_write_raises_on_null_even_though_severity_is_warning() {
-        let v = obj(vec![("a", Value::Int(1)), ("b", Value::Null)]);
+        let v = obj(vec![("a", Value::Int((1).into())), ("b", Value::Null)]);
         let doc = doc_of(v);
         let err = write_toml(&doc, true, None).unwrap_err();
         assert!(err.to_string().contains("$.b"));
@@ -985,7 +1002,7 @@ mod tests {
 
     #[test]
     fn non_table_root_is_a_write_error() {
-        let doc = doc_of(Value::Int(5));
+        let doc = doc_of(Value::Int((5).into()));
         let err = write_toml(&doc, false, None).unwrap_err();
         assert!(err.to_string().contains("top-level table"));
         assert!(err.report().is_none());
@@ -993,7 +1010,7 @@ mod tests {
 
     #[test]
     fn non_table_root_is_a_write_error_even_with_a_report_supplied() {
-        let doc = doc_of(Value::Int(5));
+        let doc = doc_of(Value::Int((5).into()));
         let mut rep = WriteReport::new();
         let err = write_toml(&doc, false, Some(&mut rep)).unwrap_err();
         assert!(err.to_string().contains("top-level table"));
@@ -1073,11 +1090,11 @@ mod tests {
         let root = doc.root();
         assert_eq!(
             *root.get_one("a").unwrap().value().unwrap(),
-            Scalar::Int(i64::MAX)
+            Scalar::Int((i64::MAX).into())
         );
         assert_eq!(
             *root.get_one("b").unwrap().value().unwrap(),
-            Scalar::Int(i64::MIN)
+            Scalar::Int((i64::MIN).into())
         );
     }
 
@@ -1112,7 +1129,7 @@ mod tests {
         // time (see this module's doc comment) -- confirms write_toml/
         // check_toml never even see an over-deep Doc to begin with, exactly
         // json.rs's/yaml.rs's own precedent test for this same guard.
-        let mut v = Value::Int(0);
+        let mut v = Value::Int((0).into());
         for _ in 0..=crate::document::MAX_DEPTH {
             v = obj(vec![("a", v)]);
         }
@@ -1123,14 +1140,14 @@ mod tests {
 
     #[test]
     fn writes_quoted_key_for_non_bare_label() {
-        let v = obj(vec![("has space", Value::Int(1))]);
+        let v = obj(vec![("has space", Value::Int((1).into()))]);
         let doc = doc_of(v);
         let text = write_toml(&doc, false, None).unwrap();
         assert_eq!(text, "\"has space\" = 1\n");
         let doc2 = read_toml(&text).unwrap();
         assert_eq!(
             *doc2.root().get_one("has space").unwrap().value().unwrap(),
-            Scalar::Int(1)
+            Scalar::Int((1).into())
         );
     }
 

--- a/omnist/src/formats/xml.rs
+++ b/omnist/src/formats/xml.rs
@@ -62,7 +62,7 @@
 //! schema in stage 2."), [`read_xml`] builds every leaf as `Scalar::Str`
 //! unconditionally, with no int/float/bool inference at parse time --
 //! confirmed against a live `~/dev/venvs/omnist` `read_xml`: `<m>1</m>`
-//! reads as `Scalar::Str("1")`, never `Scalar::Int(1)`.
+//! reads as `Scalar::Str("1")`, never `Scalar::Int((1).into())`.
 //!
 //! An earlier version of this module ported a `coerce()` helper that
 //! type-inferred leaf text (bool/int/float) at parse time, contradicting

--- a/omnist/src/formats/xml/tests.rs
+++ b/omnist/src/formats/xml/tests.rs
@@ -13,7 +13,7 @@ fn leaf_str(s: &str) -> RawNode {
 /// produces `Scalar::Int` -- every leaf it builds is a `Scalar::Str`). Kept
 /// for constructing `Doc`s to feed into `write_xml`/`check_xml`.
 fn leaf_int(i: i64) -> RawNode {
-    RawNode::Leaf(Scalar::Int(i))
+    RawNode::Leaf(Scalar::Int(i.into()))
 }
 
 // ------------------------------------------------------------ reader: basics
@@ -316,7 +316,7 @@ fn depth_at_the_boundary_is_accepted() {
 
 #[test]
 fn write_requires_exactly_one_top_level_edge() {
-    let doc = Doc::of(&crate::document::Value::Int(5)).unwrap();
+    let doc = Doc::of(&crate::document::Value::Int((5).into())).unwrap();
     let err = write_xml(&doc, false, None).unwrap_err();
     assert!(err.to_string().contains("exactly one document element"));
     assert!(err.report().is_none());
@@ -332,7 +332,7 @@ fn write_rejects_a_multi_edge_root() {
 
 #[test]
 fn write_requires_exactly_one_top_level_edge_even_with_a_report_supplied() {
-    let doc = Doc::of(&crate::document::Value::Int(5)).unwrap();
+    let doc = Doc::of(&crate::document::Value::Int((5).into())).unwrap();
     let mut rep = crate::report::WriteReport::new();
     let err = write_xml(&doc, false, Some(&mut rep)).unwrap_err();
     assert!(err.to_string().contains("exactly one document element"));

--- a/omnist/src/formats/yaml.rs
+++ b/omnist/src/formats/yaml.rs
@@ -98,10 +98,11 @@ use crate::WriteError;
 use crate::document::{Doc, Value};
 use crate::error::{DocumentError, OmnistError, ParseError};
 use crate::formats::float_fmt;
-use crate::formats::int_cap::{MAX_INT_DIGITS, out_of_range_message, over_cap_message};
+use crate::formats::int_cap::{MAX_INT_DIGITS, over_cap_message};
 use crate::formats::string_escape::{YAML_ESCAPES, write_quoted};
 use crate::report::{Severity, WriteReport};
 use indexmap::IndexMap;
+use num_bigint::BigInt;
 
 // Same guard, same constant as `json.rs`'s/`oml.rs`'s -- see this
 // module's doc comment. Constant and message constructors now live in
@@ -696,34 +697,47 @@ fn is_sexagesimal_int_shape(text: &str) -> bool {
 /// Parses a sexagesimal-shaped string (already confirmed via
 /// [`is_sexagesimal_int_shape`]) into its base-60 integer value: fold each
 /// `:`-separated group left to right as `acc = acc*60 + group`, matching
-/// PyYAML's `construct_yaml_int`'s own sexagesimal branch. Uses checked
-/// arithmetic and reports the same out-of-range `ParseError` shape as
-/// `parse_int_literal` if the fold overflows `i64`.
+/// PyYAML's `construct_yaml_int`'s own sexagesimal branch.
+///
+/// Arbitrary-precision (issue #104): the fold itself can no longer
+/// overflow -- `BigInt` has no width limit -- so `MAX_INT_DIGITS` (the
+/// same cap `parse_int_literal` enforces) is checked explicitly on the
+/// fold's *result* instead. This replaces a real guard, not just
+/// tidies one: the old `i64` accumulator's `checked_mul`/`checked_add`
+/// overflow was incidentally bounding a many-group literal like
+/// `1:0:0:...:0` (thousands of groups); a naive swap to unchecked
+/// `BigInt` arithmetic here would silently remove that bound entirely,
+/// letting such a literal build an arbitrarily large integer.
 fn parse_sexagesimal_int(text: &str) -> Result<Value, ParseError> {
     let neg = text.starts_with('-');
     let t = text.strip_prefix(['+', '-']).unwrap_or(text);
-    let mut acc: i64 = 0;
+    let mut acc = BigInt::from(0);
+    let sixty = BigInt::from(60);
     for group in t.split(':') {
         let cleaned: String = group.chars().filter(|&c| c != '_').collect();
-        let digit: i64 = cleaned
-            .parse()
-            .map_err(|_| ParseError::new(1, 1, out_of_range_message("invalid YAML: ", text)))?;
-        acc = acc
-            .checked_mul(60)
-            .and_then(|v| v.checked_add(digit))
-            .ok_or_else(|| ParseError::new(1, 1, out_of_range_message("invalid YAML: ", text)))?;
+        // Every group is guaranteed decimal digits by `SEXAGESIMAL_INT_RE`
+        // (the caller's shape check) -- this can't fail.
+        let digit = BigInt::parse_bytes(cleaned.as_bytes(), 10)
+            .expect("SEXAGESIMAL_INT_RE guarantees decimal digit groups");
+        acc = acc * &sixty + digit;
     }
-    // `acc` is only ever built via the two checked ops above, both of which
-    // reject on overflow -- so `acc` is provably in `0..=i64::MAX` here,
-    // and `-acc` can never itself overflow `i64` (unlike the general
-    // "negate an arbitrary i64" case `parse_int_literal` handles, where the
-    // magnitude is parsed unsigned first specifically to allow `i64::MIN`).
-    // No `checked_neg` needed -- that would be a fallible-looking branch
-    // that's actually structurally dead, not a real error path to report.
     let value = if neg { -acc } else { acc };
+    let digit_count = value.to_string().trim_start_matches('-').len();
+    if digit_count > MAX_INT_DIGITS {
+        return Err(ParseError::new(
+            1,
+            1,
+            over_cap_message("invalid YAML: ", digit_count),
+        ));
+    }
     Ok(Value::Int(value))
 }
 
+/// Arbitrary-precision (issue #104): a magnitude that fits the shape
+/// `is_int_literal_shape` already confirmed always parses -- no more
+/// `i64`-overflow special-casing (the old version's own comment about
+/// `i64::MIN`'s asymmetric magnitude is now moot, since `BigInt` negation
+/// never overflows).
 fn parse_int_literal(text: &str) -> Result<Value, ParseError> {
     let neg = text.starts_with('-');
     let t = text.strip_prefix(['+', '-']).unwrap_or(text);
@@ -744,43 +758,10 @@ fn parse_int_literal(text: &str) -> Result<Value, ParseError> {
             over_cap_message("invalid YAML: ", digits.len()),
         ));
     }
-    // Parse the unsigned magnitude first, then apply the sign -- issue #26's
-    // fuzz harness caught the previous version parsing `-9223372036854775808`
-    // (`i64::MIN`) by stripping the sign and calling
-    // `i64::from_str_radix("9223372036854775808", 10)`, which itself
-    // overflows (the positive magnitude `9223372036854775808` is one past
-    // `i64::MAX`) even though the signed value is perfectly representable.
-    // `u64` holds the full magnitude range for both `i64::MIN` and
-    // `i64::MAX`, so parse there and negate via `checked_neg` on the signed
-    // conversion instead of negating a possibly-unrepresentable positive
-    // `i64`.
-    let magnitude = match u64::from_str_radix(digits, radix) {
-        Ok(m) => m,
-        Err(_) => {
-            return Err(ParseError::new(
-                1,
-                1,
-                out_of_range_message("invalid YAML: ", text),
-            ));
-        }
-    };
-    let value = if neg {
-        if magnitude == i64::MIN.unsigned_abs() {
-            Some(i64::MIN)
-        } else {
-            i64::try_from(magnitude).ok().and_then(i64::checked_neg)
-        }
-    } else {
-        i64::try_from(magnitude).ok()
-    };
-    match value {
-        Some(v) => Ok(Value::Int(v)),
-        None => Err(ParseError::new(
-            1,
-            1,
-            out_of_range_message("invalid YAML: ", text),
-        )),
-    }
+    let magnitude = BigInt::parse_bytes(digits.as_bytes(), radix)
+        .expect("is_int_literal_shape guarantees valid digits for the detected radix");
+    let value = if neg { -magnitude } else { magnitude };
+    Ok(Value::Int(value))
 }
 
 /// Live-confirmed against `yaml.safe_load`: PyYAML's `tag:yaml.org,2002:float`
@@ -1161,7 +1142,10 @@ mod tests {
     fn reads_every_scalar_kind() {
         let doc = read_yaml("a: 1\nb: \"s\"\nc: true\nd: null\ne: 1.5\n").unwrap();
         let root = doc.root();
-        assert_eq!(*root.get_one("a").unwrap().value().unwrap(), Scalar::Int(1));
+        assert_eq!(
+            *root.get_one("a").unwrap().value().unwrap(),
+            Scalar::Int((1).into())
+        );
         assert_eq!(
             *root.get_one("b").unwrap().value().unwrap(),
             Scalar::Str("s".to_string())
@@ -1241,20 +1225,23 @@ mod tests {
         let root = doc.root();
         assert_eq!(
             *root.get_one("a").unwrap().value().unwrap(),
-            Scalar::Int(-5)
+            Scalar::Int((-5).into())
         );
         assert_eq!(
             *root.get_one("b").unwrap().value().unwrap(),
-            Scalar::Int(26)
+            Scalar::Int((26).into())
         );
         assert_eq!(
             *root.get_one("c").unwrap().value().unwrap(),
-            Scalar::Int(15)
+            Scalar::Int((15).into())
         );
-        assert_eq!(*root.get_one("d").unwrap().value().unwrap(), Scalar::Int(5));
+        assert_eq!(
+            *root.get_one("d").unwrap().value().unwrap(),
+            Scalar::Int((5).into())
+        );
         assert_eq!(
             *root.get_one("e").unwrap().value().unwrap(),
-            Scalar::Int(1000)
+            Scalar::Int((1000).into())
         );
     }
 
@@ -1278,58 +1265,78 @@ mod tests {
         let root = doc.root();
         assert_eq!(
             *root.get_one("a").unwrap().value().unwrap(),
-            Scalar::Int(43200)
+            Scalar::Int((43200).into())
         );
         assert_eq!(
             *root.get_one("b").unwrap().value().unwrap(),
-            Scalar::Int(80)
+            Scalar::Int((80).into())
         );
         assert_eq!(
             *root.get_one("c").unwrap().value().unwrap(),
-            Scalar::Int(3723)
+            Scalar::Int((3723).into())
         );
         assert_eq!(
             *root.get_one("d").unwrap().value().unwrap(),
-            Scalar::Int(-80)
+            Scalar::Int((-80).into())
         );
         assert_eq!(
             *root.get_one("e").unwrap().value().unwrap(),
-            Scalar::Int(80)
+            Scalar::Int((80).into())
         );
         assert_eq!(
             *root.get_one("f").unwrap().value().unwrap(),
-            Scalar::Int(7425)
+            Scalar::Int((7425).into())
         );
         assert_eq!(
             *root.get_one("g").unwrap().value().unwrap(),
-            Scalar::Int(750)
+            Scalar::Int((750).into())
         );
     }
 
     #[test]
-    fn sexagesimal_first_group_over_i64_range_is_out_of_range_error() {
-        // Unlike PyYAML (arbitrary-precision Python ints), this port caps
-        // integers at i64, same ceiling `parse_int_literal` already
-        // enforces for plain decimal literals -- a first digit group this
-        // large fails to even parse as i64, hitting the group-parse
-        // `map_err` branch in `parse_sexagesimal_int`.
+    fn sexagesimal_first_group_over_i64_range_parses() {
+        // Issue #104: `Scalar::Int` is arbitrary-precision (`BigInt`), so
+        // a first digit group beyond `i64`'s ~19-digit range is no longer
+        // a parse error -- `parse_sexagesimal_int`'s fold just produces a
+        // real, correctly-computed `BigInt` value.
         let text = format!("a: {}:0\n", "9".repeat(20));
-        let err = read_yaml(&text).unwrap_err();
-        assert!(
-            matches!(&err, OmnistError::Parse(e) if e.message.contains("out of range")),
-            "got {err:?}"
+        let doc = read_yaml(&text).unwrap();
+        let value = doc.root().child("a").unwrap().value().unwrap();
+        assert_eq!(
+            value,
+            &Scalar::Int(num_bigint::BigInt::parse_bytes(b"5999999999999999999940", 10).unwrap())
         );
     }
 
     #[test]
-    fn sexagesimal_fold_overflow_across_many_in_range_groups_is_out_of_range_error() {
-        // Every individual group here is a legal 0-59 sexagesimal digit, so
-        // this exercises the *fold* overflow (`checked_mul(60)`/
-        // `checked_add`), not the single-group-parse overflow above.
+    fn sexagesimal_fold_overflow_across_many_in_range_groups_parses() {
+        // Every individual group here is a legal 0-59 sexagesimal digit;
+        // this exercises the *fold* itself accumulating well past `i64`
+        // range across many groups -- issue #104 means the fold no longer
+        // overflows, it just keeps growing the `BigInt`.
         let text = format!("a: 1{}\n", ":59".repeat(15));
+        let doc = read_yaml(&text).unwrap();
+        let value = doc.root().child("a").unwrap().value().unwrap();
+        assert_eq!(
+            value,
+            &Scalar::Int(
+                num_bigint::BigInt::parse_bytes(b"940369969151999999999999999", 10).unwrap()
+            )
+        );
+    }
+
+    #[test]
+    fn sexagesimal_fold_still_rejects_past_the_digit_cap() {
+        // The digit-cap check this migration *added* to the fold (issue
+        // #104 -- replacing the `i64` overflow that used to bound this
+        // incidentally) -- enough groups to push the folded result's
+        // decimal digit count past MAX_INT_DIGITS must still be rejected,
+        // not silently accepted now that raw fold overflow no longer does
+        // that job.
+        let text = format!("a: 1{}\n", ":59".repeat(2500));
         let err = read_yaml(&text).unwrap_err();
         assert!(
-            matches!(&err, OmnistError::Parse(e) if e.message.contains("out of range")),
+            matches!(&err, OmnistError::Parse(e) if e.message.contains("4300-digit")),
             "got {err:?}"
         );
     }
@@ -1476,10 +1483,13 @@ mod tests {
         let root = doc.root();
         let a = root.get_one("a").unwrap();
         let b = a.get_one("b").unwrap();
-        assert_eq!(*b.get_one("c").unwrap().value().unwrap(), Scalar::Int(1));
+        assert_eq!(
+            *b.get_one("c").unwrap().value().unwrap(),
+            Scalar::Int((1).into())
+        );
         let ms = root.get("m");
         assert_eq!(ms.len(), 3);
-        assert_eq!(*ms[2].value().unwrap(), Scalar::Int(3));
+        assert_eq!(*ms[2].value().unwrap(), Scalar::Int((3).into()));
     }
 
     #[test]
@@ -1487,7 +1497,10 @@ mod tests {
         let doc = read_yaml("a: {b: 1, c: 2}\nm: [1, 2, 3]\n").unwrap();
         let root = doc.root();
         let a = root.get_one("a").unwrap();
-        assert_eq!(*a.get_one("b").unwrap().value().unwrap(), Scalar::Int(1));
+        assert_eq!(
+            *a.get_one("b").unwrap().value().unwrap(),
+            Scalar::Int((1).into())
+        );
         assert_eq!(root.get("m").len(), 3);
     }
 
@@ -1524,7 +1537,10 @@ mod tests {
         let doc = read_yaml("a: 1\nb: 2\na: 3\n").unwrap();
         let root = doc.root();
         assert_eq!(root.labels(), vec!["a".to_string(), "b".to_string()]);
-        assert_eq!(*root.get_one("a").unwrap().value().unwrap(), Scalar::Int(3));
+        assert_eq!(
+            *root.get_one("a").unwrap().value().unwrap(),
+            Scalar::Int((3).into())
+        );
     }
 
     #[test]
@@ -1575,43 +1591,36 @@ mod tests {
         let doc = read_yaml("a: -9223372036854775808\n").unwrap();
         assert_eq!(
             *doc.root().get_one("a").unwrap().value().unwrap(),
-            Scalar::Int(i64::MIN)
+            Scalar::Int((i64::MIN).into())
         );
     }
 
     #[test]
-    fn positive_integer_one_past_i64_max_is_out_of_range_error() {
-        // Fits in u64 (so passes the magnitude parse) but not in i64 --
-        // exercises the final `None` arm of `parse_int_literal`'s match,
-        // distinct from `integer_literal_over_i64_range_is_out_of_range_error`
-        // below (whose 20-nines literal overflows even `u64`).
-        let err = read_yaml("a: 9223372036854775808\n").unwrap_err();
-        assert!(
-            matches!(&err, OmnistError::Parse(e) if e.message.contains("out of range")),
-            "got {err:?}"
-        );
+    fn positive_integer_one_past_i64_max_parses() {
+        // Issue #104: no more `i64` ceiling -- one past `i64::MAX` is now
+        // just a real, correctly-parsed value.
+        let doc = read_yaml("a: 9223372036854775808\n").unwrap();
+        let value = doc.root().child("a").unwrap().value().unwrap();
+        assert_eq!(value, &Scalar::Int(num_bigint::BigInt::from(i64::MAX) + 1));
     }
 
     #[test]
-    fn negative_integer_one_past_i64_min_is_out_of_range_error() {
-        // Magnitude 9223372036854775809 fits in u64 and isn't
-        // `i64::MIN.unsigned_abs()`, so it falls through to the
-        // `checked_neg` arm, which correctly reports out-of-range instead
-        // of silently wrapping.
-        let err = read_yaml("a: -9223372036854775809\n").unwrap_err();
-        assert!(
-            matches!(&err, OmnistError::Parse(e) if e.message.contains("out of range")),
-            "got {err:?}"
-        );
+    fn negative_integer_one_past_i64_min_parses() {
+        // Issue #104: same, on the negative side -- was the `checked_neg`
+        // overflow arm, now just a real value one past `i64::MIN`.
+        let doc = read_yaml("a: -9223372036854775809\n").unwrap();
+        let value = doc.root().child("a").unwrap().value().unwrap();
+        assert_eq!(value, &Scalar::Int(num_bigint::BigInt::from(i64::MIN) - 1));
     }
 
     #[test]
-    fn integer_literal_over_i64_range_is_out_of_range_error() {
+    fn integer_literal_over_i64_range_parses() {
         let text = format!("a: {}\n", "9".repeat(20));
-        let err = read_yaml(&text).unwrap_err();
-        assert!(
-            matches!(&err, OmnistError::Parse(e) if e.message.contains("out of range")),
-            "got {err:?}"
+        let doc = read_yaml(&text).unwrap();
+        let value = doc.root().child("a").unwrap().value().unwrap();
+        assert_eq!(
+            value,
+            &Scalar::Int(num_bigint::BigInt::parse_bytes(b"99999999999999999999", 10).unwrap())
         );
     }
 
@@ -1623,7 +1632,7 @@ mod tests {
         let root = doc.root();
         assert_eq!(root.get("a").len(), 3);
         assert_eq!(root.get("b").len(), 3);
-        assert_eq!(*root.get("b")[1].value().unwrap(), Scalar::Int(2));
+        assert_eq!(*root.get("b")[1].value().unwrap(), Scalar::Int((2).into()));
     }
 
     #[test]
@@ -1692,8 +1701,14 @@ mod tests {
         let root = doc.root();
         for label in ["a", "b", "c"] {
             let node = root.get_one(label).unwrap();
-            assert_eq!(*node.get_one("x").unwrap().value().unwrap(), Scalar::Int(1));
-            assert_eq!(*node.get_one("y").unwrap().value().unwrap(), Scalar::Int(2));
+            assert_eq!(
+                *node.get_one("x").unwrap().value().unwrap(),
+                Scalar::Int((1).into())
+            );
+            assert_eq!(
+                *node.get_one("y").unwrap().value().unwrap(),
+                Scalar::Int((2).into())
+            );
         }
         for label in ["d", "e"] {
             assert_eq!(root.get(label).len(), 3);
@@ -1709,16 +1724,16 @@ mod tests {
         let child = doc.root().get_one("child").unwrap();
         assert_eq!(
             *child.get_one("x").unwrap().value().unwrap(),
-            Scalar::Int(1)
+            Scalar::Int((1).into())
         );
         assert_eq!(
             *child.get_one("y").unwrap().value().unwrap(),
-            Scalar::Int(20),
+            Scalar::Int((20).into()),
             "an explicit local key beats the merged-in value"
         );
         assert_eq!(
             *child.get_one("z").unwrap().value().unwrap(),
-            Scalar::Int(3)
+            Scalar::Int((3).into())
         );
     }
 
@@ -1731,11 +1746,11 @@ mod tests {
         let child = doc.root().get_one("child").unwrap();
         assert_eq!(
             *child.get_one("x").unwrap().value().unwrap(),
-            Scalar::Int(1)
+            Scalar::Int((1).into())
         );
         assert_eq!(
             *child.get_one("y").unwrap().value().unwrap(),
-            Scalar::Int(3)
+            Scalar::Int((3).into())
         );
     }
 
@@ -1743,7 +1758,10 @@ mod tests {
     fn quoted_double_angle_bracket_key_is_a_literal_string_not_a_merge() {
         let doc = read_yaml("a:\n  \"<<\": 1\n").unwrap();
         let a = doc.root().get_one("a").unwrap();
-        assert_eq!(*a.get_one("<<").unwrap().value().unwrap(), Scalar::Int(1));
+        assert_eq!(
+            *a.get_one("<<").unwrap().value().unwrap(),
+            Scalar::Int((1).into())
+        );
     }
 
     // omnist-ts#46: a fuzz suite intermittently found a ParseError with a
@@ -1794,7 +1812,10 @@ mod tests {
             *root.get_one("a").unwrap().value().unwrap(),
             Scalar::Str("yes".to_string())
         );
-        assert_eq!(*root.get_one("b").unwrap().value().unwrap(), Scalar::Int(5));
+        assert_eq!(
+            *root.get_one("b").unwrap().value().unwrap(),
+            Scalar::Int((5).into())
+        );
         assert_eq!(
             *root.get_one("c").unwrap().value().unwrap(),
             Scalar::Bool(true)
@@ -1905,7 +1926,10 @@ mod tests {
         assert_eq!(describe_non_string_key(&Value::Bool(true)), "True");
         assert_eq!(describe_non_string_key(&Value::Bool(false)), "False");
         assert_eq!(describe_non_string_key(&Value::Null), "None");
-        assert_eq!(describe_non_string_key(&Value::Int(43200)), "43200");
+        assert_eq!(
+            describe_non_string_key(&Value::Int((43200).into())),
+            "43200"
+        );
         assert_eq!(describe_non_string_key(&Value::Float(1.5)), "1.5");
         // Whole-number floats must keep the `.0` (Python's `repr(1.0)` is
         // `'1.0'`, not `'1'` -- `f64::to_string()` alone drops it).
@@ -1956,7 +1980,7 @@ mod tests {
         let v = obj(vec![
             ("null", Value::Null),
             ("bool", Value::Bool(true)),
-            ("int", Value::Int(42)),
+            ("int", Value::Int((42).into())),
             ("float", Value::Float(1.5)),
             ("str", Value::Str("hi".to_string())),
         ]);
@@ -2028,7 +2052,11 @@ mod tests {
     fn round_trips_repeated_labels_as_a_yaml_sequence() {
         let doc = doc_of(obj(vec![(
             "m",
-            Value::Array(vec![Value::Int(1), Value::Int(2), Value::Int(3)]),
+            Value::Array(vec![
+                Value::Int((1).into()),
+                Value::Int((2).into()),
+                Value::Int((3).into()),
+            ]),
         )]));
         let text = write_yaml(&doc, false, None).unwrap();
         let back = read_yaml(&text).unwrap();
@@ -2038,12 +2066,24 @@ mod tests {
     #[test]
     fn round_trips_nested_mappings_and_sequences_of_mappings() {
         let v = obj(vec![
-            ("a", obj(vec![("b", Value::Int(1)), ("c", Value::Int(2))])),
+            (
+                "a",
+                obj(vec![
+                    ("b", Value::Int((1).into())),
+                    ("c", Value::Int((2).into())),
+                ]),
+            ),
             (
                 "items",
                 Value::Array(vec![
-                    obj(vec![("x", Value::Int(1)), ("y", Value::Int(2))]),
-                    obj(vec![("x", Value::Int(3)), ("y", Value::Int(4))]),
+                    obj(vec![
+                        ("x", Value::Int((1).into())),
+                        ("y", Value::Int((2).into())),
+                    ]),
+                    obj(vec![
+                        ("x", Value::Int((3).into())),
+                        ("y", Value::Int((4).into())),
+                    ]),
                 ]),
             ),
         ]);
@@ -2086,7 +2126,7 @@ mod tests {
 
     #[test]
     fn strict_write_with_no_adjustments_succeeds() {
-        let doc = doc_of(obj(vec![("a", Value::Int(1))]));
+        let doc = doc_of(obj(vec![("a", Value::Int((1).into()))]));
         let text = write_yaml(&doc, true, None).unwrap();
         assert!(text.contains("a: 1"));
     }
@@ -2102,7 +2142,7 @@ mod tests {
 
     #[test]
     fn deeply_nested_document_write_reuses_doc_construction_depth_guard() {
-        let mut v = Value::Int(0);
+        let mut v = Value::Int((0).into());
         for _ in 0..=crate::document::MAX_DEPTH {
             v = obj(vec![("a", v)]);
         }
@@ -2130,7 +2170,7 @@ mod tests {
         for i in [0, n / 2, n - 1] {
             assert_eq!(
                 *root.get_one(&format!("field{i}")).unwrap().value().unwrap(),
-                Scalar::Int(i as i64)
+                Scalar::Int((i as i64).into())
             );
         }
         let out = write_yaml(&doc, false, None).unwrap();
@@ -2268,7 +2308,7 @@ mod tests {
     #[test]
     fn nel_in_a_label_triggers_a_warning_and_still_round_trips() {
         let label = format!("a{}b", '\u{0085}');
-        let doc = doc_of(obj(vec![(label.as_str(), Value::Int(1))]));
+        let doc = doc_of(obj(vec![(label.as_str(), Value::Int((1).into()))]));
         let mut rep = WriteReport::new();
         let text = write_yaml(&doc, false, Some(&mut rep)).unwrap();
         assert_eq!(rep.len(), 1);
@@ -2276,7 +2316,7 @@ mod tests {
         let back = read_yaml(&text).unwrap();
         assert_eq!(
             *back.root().get_one(&label).unwrap().value().unwrap(),
-            Scalar::Int(1)
+            Scalar::Int((1).into())
         );
     }
 
@@ -2540,7 +2580,7 @@ mod tests {
         // `write_node_on_a_bare_empty_array_writes_the_flow_empty_token`.
         let mut out = String::new();
         write_seq_child(
-            &Value::Array(vec![Value::Int(1), Value::Int(2)]),
+            &Value::Array(vec![Value::Int((1).into()), Value::Int((2).into())]),
             0,
             &mut out,
         );

--- a/omnist/src/infer/tests.rs
+++ b/omnist/src/infer/tests.rs
@@ -81,7 +81,7 @@ fn array_field_min_reflects_the_smallest_sample_count() {
 #[test]
 fn integer_and_number_samples_collapse_to_number() {
     let samples = vec![
-        doc(obj(&[("x", Value::Int(1))])),
+        doc(obj(&[("x", Value::Int((1).into()))])),
         doc(obj(&[("x", Value::Float(1.5))])),
     ];
     let schema = infer(&samples, "Root").unwrap();
@@ -96,8 +96,8 @@ fn integer_and_number_samples_collapse_to_number() {
 #[test]
 fn all_integer_samples_stay_integer() {
     let samples = vec![
-        doc(obj(&[("x", Value::Int(1))])),
-        doc(obj(&[("x", Value::Int(2))])),
+        doc(obj(&[("x", Value::Int((1).into()))])),
+        doc(obj(&[("x", Value::Int((2).into()))])),
     ];
     let schema = infer(&samples, "Root").unwrap();
     let f = field(schema.env(), "Root", "x");
@@ -111,7 +111,7 @@ fn all_integer_samples_stay_integer() {
 #[test]
 fn null_sample_makes_the_scalar_nullable() {
     let samples = vec![
-        doc(obj(&[("x", Value::Int(1))])),
+        doc(obj(&[("x", Value::Int((1).into()))])),
         doc(obj(&[("x", Value::Null)])),
     ];
     let schema = infer(&samples, "Root").unwrap();
@@ -168,8 +168,8 @@ fn duplicate_generated_names_are_disambiguated() {
     // Two different labels that both identifier-normalize to "Item" force
     // a numeric suffix on the second.
     let samples = vec![doc(obj(&[
-        ("item", obj(&[("a", Value::Int(1))])),
-        ("Item", obj(&[("b", Value::Int(1))])),
+        ("item", obj(&[("a", Value::Int((1).into()))])),
+        ("Item", obj(&[("b", Value::Int((1).into()))])),
     ]))];
     let schema = infer(&samples, "Root").unwrap();
     let names: Vec<&String> = schema.env().keys().collect();
@@ -199,8 +199,8 @@ fn disagreeing_scalar_shapes_raise_a_schema_error() {
 #[test]
 fn mixing_objects_and_scalars_under_one_label_is_a_schema_error() {
     let samples = vec![
-        doc(obj(&[("x", obj(&[("a", Value::Int(1))]))])),
-        doc(obj(&[("x", Value::Int(1))])),
+        doc(obj(&[("x", obj(&[("a", Value::Int((1).into()))]))])),
+        doc(obj(&[("x", Value::Int((1).into()))])),
     ];
     let err = infer(&samples, "Root").unwrap_err();
     assert!(err.to_string().contains("mixes objects and values"));
@@ -224,8 +224,8 @@ fn disagreeing_scalar_shapes_error_does_not_mention_any_when_allow_any_is_false(
 #[test]
 fn allow_any_opens_a_mixed_object_and_scalar_label_as_any() {
     let samples = vec![
-        doc(obj(&[("x", obj(&[("a", Value::Int(1))]))])),
-        doc(obj(&[("x", Value::Int(1))])),
+        doc(obj(&[("x", obj(&[("a", Value::Int((1).into()))]))])),
+        doc(obj(&[("x", Value::Int((1).into()))])),
     ];
     let (schema, fallbacks) = infer_with_report(&samples, "Root", true).unwrap();
     let f = field(schema.env(), "Root", "x");
@@ -278,7 +278,7 @@ fn zero_samples_is_a_schema_error() {
 
 #[test]
 fn a_bare_scalar_sample_at_the_root_is_a_schema_error() {
-    let samples = vec![doc(Value::Int(1))];
+    let samples = vec![doc(Value::Int((1).into()))];
     let err = infer(&samples, "Root").unwrap_err();
     assert!(err.to_string().contains("object (record) samples"));
 }
@@ -329,7 +329,7 @@ fn materialize_accepts_a_schemas_own_inferred_source_data() {
     let samples = vec![
         doc(obj(&[
             ("name", Value::Str("Ada".into())),
-            ("age", Value::Int(36)),
+            ("age", Value::Int((36).into())),
             ("address", obj(&[("city", Value::Str("London".into()))])),
             (
                 "tag",

--- a/omnist/src/materialize.rs
+++ b/omnist/src/materialize.rs
@@ -62,6 +62,7 @@
 use crate::document::{RawNode, Scalar as DocScalar};
 use crate::error::MaterializeError;
 use crate::schema::{ErrorCode, FieldType, Resolved, ScalarKind, Schema, ValidationResult};
+use num_traits::{FromPrimitive, ToPrimitive};
 
 /// A copy of `node` with leaf values upgraded to match `schema`, guaranteed
 /// to conform to it -- or every reason it can't, collected into one
@@ -222,15 +223,28 @@ fn try_upgrade(value: &DocScalar, kind: ScalarKind) -> Option<DocScalar> {
         (ScalarKind::Boolean, DocScalar::Bool(_)) => Some(value.clone()),
         (ScalarKind::Integer, DocScalar::Int(_)) => Some(value.clone()),
         (ScalarKind::Integer, DocScalar::Float(f)) => {
-            if f.is_finite() && f.fract() == 0.0 && *f >= i64::MIN as f64 && *f <= i64::MAX as f64 {
-                Some(DocScalar::Int(*f as i64))
+            // Arbitrary-precision (issue #104): no upper/lower bound to
+            // check anymore -- `BigInt` has no range limit, so any finite
+            // whole-number float upgrades. `BigInt::from_f64` decomposes
+            // the float's exact mantissa*2^exponent value (well-defined
+            // for any finite f64, not an approximation), consistent with
+            // `f.fract() == 0.0` already having confirmed there's no
+            // fractional part to lose.
+            if f.is_finite() && f.fract() == 0.0 {
+                num_bigint::BigInt::from_f64(*f).map(DocScalar::Int)
             } else {
                 None
             }
         }
         // "number" always ends up a Float, even if it arrived as an Int --
         // matches the Python reference's unconditional `float(value)`.
-        (ScalarKind::Number, DocScalar::Int(i)) => Some(DocScalar::Float(*i as f64)),
+        // `BigInt::to_f64` saturates to +/-infinity for a magnitude
+        // beyond f64's finite range rather than failing -- matches this
+        // codebase's existing Float model, which already renders
+        // `inf`/`-inf` as first-class values (see `formats::float_fmt`).
+        (ScalarKind::Number, DocScalar::Int(i)) => {
+            Some(DocScalar::Float(i.to_f64().unwrap_or(f64::INFINITY)))
+        }
         (ScalarKind::Number, DocScalar::Float(_)) => Some(value.clone()),
         (ScalarKind::Date, DocScalar::Str(s)) if crate::schema::is_iso_date(s) => {
             Some(value.clone())

--- a/omnist/src/materialize/tests.rs
+++ b/omnist/src/materialize/tests.rs
@@ -52,7 +52,7 @@ fn string_field_accepts_string_as_is() {
     let schema = scalar_schema();
     let node = edges(vec![
         ("s", leaf(DocScalar::Str("hi".into()))),
-        ("i", leaf(DocScalar::Int(1))),
+        ("i", leaf(DocScalar::Int((1).into()))),
         ("n", leaf(DocScalar::Float(1.0))),
         ("b", leaf(DocScalar::Bool(true))),
         ("d", leaf(DocScalar::Str("2024-01-01".into()))),
@@ -85,7 +85,7 @@ fn integer_field_upgrades_whole_float() {
     let RawNode::Edges(out_edges) = out else {
         panic!("expected edges")
     };
-    assert_eq!(out_edges[1].1, leaf(DocScalar::Int(3)));
+    assert_eq!(out_edges[1].1, leaf(DocScalar::Int((3).into())));
 }
 
 #[test]
@@ -113,8 +113,8 @@ fn number_field_upgrades_int_to_float() {
     let schema = scalar_schema();
     let node = edges(vec![
         ("s", leaf(DocScalar::Str("hi".into()))),
-        ("i", leaf(DocScalar::Int(1))),
-        ("n", leaf(DocScalar::Int(7))),
+        ("i", leaf(DocScalar::Int((1).into()))),
+        ("n", leaf(DocScalar::Int((7).into()))),
         ("b", leaf(DocScalar::Bool(true))),
         ("d", leaf(DocScalar::Str("2024-01-01".into()))),
         ("t", leaf(DocScalar::Str("12:30:00".into()))),
@@ -132,7 +132,7 @@ fn number_field_keeps_float_as_is() {
     let schema = scalar_schema();
     let node = edges(vec![
         ("s", leaf(DocScalar::Str("hi".into()))),
-        ("i", leaf(DocScalar::Int(1))),
+        ("i", leaf(DocScalar::Int((1).into()))),
         ("n", leaf(DocScalar::Float(2.5))),
         ("b", leaf(DocScalar::Bool(true))),
         ("d", leaf(DocScalar::Str("2024-01-01".into()))),
@@ -151,7 +151,7 @@ fn boolean_field_accepts_bool_as_is() {
     let schema = scalar_schema();
     let node = edges(vec![
         ("s", leaf(DocScalar::Str("hi".into()))),
-        ("i", leaf(DocScalar::Int(1))),
+        ("i", leaf(DocScalar::Int((1).into()))),
         ("n", leaf(DocScalar::Float(1.0))),
         ("b", leaf(DocScalar::Bool(false))),
         ("d", leaf(DocScalar::Str("2024-01-01".into()))),
@@ -170,7 +170,7 @@ fn date_field_accepts_valid_iso_date_string() {
     let schema = scalar_schema();
     let node = edges(vec![
         ("s", leaf(DocScalar::Str("hi".into()))),
-        ("i", leaf(DocScalar::Int(1))),
+        ("i", leaf(DocScalar::Int((1).into()))),
         ("n", leaf(DocScalar::Float(1.0))),
         ("b", leaf(DocScalar::Bool(true))),
         ("d", leaf(DocScalar::Str("2024-02-29".into()))),
@@ -185,7 +185,7 @@ fn date_field_rejects_invalid_calendar_date() {
     let schema = scalar_schema();
     let node = edges(vec![
         ("s", leaf(DocScalar::Str("hi".into()))),
-        ("i", leaf(DocScalar::Int(1))),
+        ("i", leaf(DocScalar::Int((1).into()))),
         ("n", leaf(DocScalar::Float(1.0))),
         ("b", leaf(DocScalar::Bool(true))),
         ("d", leaf(DocScalar::Str("2024-02-30".into()))),
@@ -201,7 +201,7 @@ fn time_field_accepts_valid_iso_time_string() {
     let schema = scalar_schema();
     let node = edges(vec![
         ("s", leaf(DocScalar::Str("hi".into()))),
-        ("i", leaf(DocScalar::Int(1))),
+        ("i", leaf(DocScalar::Int((1).into()))),
         ("n", leaf(DocScalar::Float(1.0))),
         ("b", leaf(DocScalar::Bool(true))),
         ("d", leaf(DocScalar::Str("2024-01-01".into()))),
@@ -216,7 +216,7 @@ fn datetime_field_rejects_a_bare_date_string() {
     let schema = scalar_schema();
     let node = edges(vec![
         ("s", leaf(DocScalar::Str("hi".into()))),
-        ("i", leaf(DocScalar::Int(1))),
+        ("i", leaf(DocScalar::Int((1).into()))),
         ("n", leaf(DocScalar::Float(1.0))),
         ("b", leaf(DocScalar::Bool(true))),
         ("d", leaf(DocScalar::Str("2024-01-01".into()))),
@@ -232,7 +232,7 @@ fn nullable_field_accepts_null_non_nullable_rejects_it() {
     let schema = scalar_schema();
     let mut pairs = vec![
         ("s", leaf(DocScalar::Str("hi".into()))),
-        ("i", leaf(DocScalar::Int(1))),
+        ("i", leaf(DocScalar::Int((1).into()))),
         ("n", leaf(DocScalar::Float(1.0))),
         ("b", leaf(DocScalar::Bool(true))),
         ("d", leaf(DocScalar::Str("2024-01-01".into()))),
@@ -246,7 +246,7 @@ fn nullable_field_accepts_null_non_nullable_rejects_it() {
     // Now put null in a non-nullable slot.
     let bad = edges(vec![
         ("s", leaf(DocScalar::Null)),
-        ("i", leaf(DocScalar::Int(1))),
+        ("i", leaf(DocScalar::Int((1).into()))),
         ("n", leaf(DocScalar::Float(1.0))),
         ("b", leaf(DocScalar::Bool(true))),
         ("d", leaf(DocScalar::Str("2024-01-01".into()))),
@@ -271,13 +271,13 @@ fn collects_every_problem_not_just_the_first() {
     // Three independent problems: missing "s" (cardinality), an
     // unexpected field, and a type-mismatch on "b".
     let node = edges(vec![
-        ("i", leaf(DocScalar::Int(1))),
+        ("i", leaf(DocScalar::Int((1).into()))),
         ("n", leaf(DocScalar::Float(1.0))),
         ("b", leaf(DocScalar::Str("not a bool".into()))),
         ("d", leaf(DocScalar::Str("2024-01-01".into()))),
         ("t", leaf(DocScalar::Str("12:30:00".into()))),
         ("dt", leaf(DocScalar::Str("2024-01-01T12:30:00".into()))),
-        ("bogus", leaf(DocScalar::Int(1))),
+        ("bogus", leaf(DocScalar::Int((1).into()))),
     ]);
     let err = materialize(&node, Some(&schema)).unwrap_err();
     assert_eq!(err.errors().len(), 3, "{:#?}", err.errors());
@@ -305,8 +305,11 @@ fn collects_every_problem_not_just_the_first() {
 fn shape_mismatch_when_scalar_expected_but_object_given() {
     let schema = scalar_schema();
     let node = edges(vec![
-        ("s", edges(vec![("nested", leaf(DocScalar::Int(1)))])),
-        ("i", leaf(DocScalar::Int(1))),
+        (
+            "s",
+            edges(vec![("nested", leaf(DocScalar::Int((1).into())))]),
+        ),
+        ("i", leaf(DocScalar::Int((1).into()))),
         ("n", leaf(DocScalar::Float(1.0))),
         ("b", leaf(DocScalar::Bool(true))),
         ("d", leaf(DocScalar::Str("2024-01-01".into()))),
@@ -331,7 +334,7 @@ fn shape_mismatch_when_object_expected_but_scalar_given() {
     env.insert("Child".to_string(), child);
     let schema = Schema::new(Ref::new("Root"), env).unwrap();
 
-    let node = edges(vec![("child", leaf(DocScalar::Int(1)))]);
+    let node = edges(vec![("child", leaf(DocScalar::Int((1).into())))]);
     let err = materialize(&node, Some(&schema)).unwrap_err();
     assert!(
         err.errors()
@@ -372,7 +375,7 @@ fn any_field_passes_scalar_and_object_nodes_through_untouched() {
     env.insert("Root".to_string(), root);
     let schema = Schema::new(Ref::new("Root"), env).unwrap();
 
-    let scalar_node = edges(vec![("x", leaf(DocScalar::Int(1)))]);
+    let scalar_node = edges(vec![("x", leaf(DocScalar::Int((1).into())))]);
     let out = materialize(&scalar_node, Some(&schema)).unwrap();
     assert_eq!(out, scalar_node);
 

--- a/omnist/src/oml/scanner.rs
+++ b/omnist/src/oml/scanner.rs
@@ -25,7 +25,7 @@
 //! already canonical.
 
 use crate::error::ParseError;
-use crate::formats::int_cap::{MAX_INT_DIGITS, out_of_range_message, over_cap_message};
+use crate::formats::int_cap::{MAX_INT_DIGITS, over_cap_message};
 use crate::schema::{
     canonicalize_iso_datetime, canonicalize_iso_time, is_iso_date, is_iso_datetime, is_iso_time,
 };
@@ -53,7 +53,7 @@ pub(super) enum TokKind {
     /// `[A-Za-z_][A-Za-z0-9_-]*` -- may be `null`/`true`/`false`, a bare
     /// label, or (as a scalar) a "bare word" error.
     Ident(String),
-    Int(i64),
+    Int(num_bigint::BigInt),
     Float(f64),
 }
 
@@ -587,9 +587,12 @@ impl<'a> Scanner<'a> {
             if digits.len() > MAX_INT_DIGITS {
                 return Err(self.error_at(start, over_cap_message("", digits.len())));
             }
-            let v: i64 = text
-                .parse()
-                .map_err(|_| self.error_at(start, out_of_range_message("", text)))?;
+            // Arbitrary-precision (issue #104): `text` is exclusively
+            // ASCII digits with an optional leading `-` by construction,
+            // which `BigInt::parse_bytes` always parses.
+            let v = num_bigint::BigInt::parse_bytes(text.as_bytes(), 10).expect(
+                "scanner only emits digit-shaped text, which BigInt::parse_bytes always parses",
+            );
             Ok((TokKind::Int(v), start, end))
         }
     }

--- a/omnist/src/oml/tests.rs
+++ b/omnist/src/oml/tests.rs
@@ -40,9 +40,9 @@ fn string_with_escapes_round_trips() {
 #[test]
 fn integer_round_trips_positive_and_negative() {
     roundtrip_value(&obj(&[
-        ("a", Value::Int(42)),
-        ("b", Value::Int(-42)),
-        ("c", Value::Int(0)),
+        ("a", Value::Int((42).into())),
+        ("b", Value::Int((-42).into())),
+        ("c", Value::Int((0).into())),
     ]));
 }
 
@@ -182,7 +182,7 @@ fn datetime_round_trips_with_and_without_utc_offset() {
 fn nested_object_round_trips() {
     roundtrip_value(&obj(&[(
         "a",
-        obj(&[("b", Value::Int(1)), ("c", Value::Str("x".into()))]),
+        obj(&[("b", Value::Int((1).into())), ("c", Value::Str("x".into()))]),
     )]));
 }
 
@@ -205,7 +205,7 @@ fn empty_document_round_trips() {
 
 #[test]
 fn bare_top_level_scalar_round_trips() {
-    let doc = Doc::of(&Value::Int(7)).unwrap();
+    let doc = Doc::of(&Value::Int((7).into())).unwrap();
     let text = write_oml(&doc.to_raw(), 2).unwrap();
     assert_eq!(text, "7");
     let parsed = Doc::from_raw(read_oml(&text).unwrap()).unwrap();
@@ -219,15 +219,15 @@ fn interleaved_repeated_labels_round_trip_exactly_via_raw_node() {
     let raw = RawNode::Edges(vec![
         (
             "b".to_string(),
-            RawNode::Leaf(crate::document::Scalar::Int(1)),
+            RawNode::Leaf(crate::document::Scalar::Int((1).into())),
         ),
         (
             "c".to_string(),
-            RawNode::Leaf(crate::document::Scalar::Int(2)),
+            RawNode::Leaf(crate::document::Scalar::Int((2).into())),
         ),
         (
             "b".to_string(),
-            RawNode::Leaf(crate::document::Scalar::Int(3)),
+            RawNode::Leaf(crate::document::Scalar::Int((3).into())),
         ),
     ]);
     let text = write_oml(&raw, 2).unwrap();
@@ -242,7 +242,7 @@ fn interleaved_repeated_labels_round_trip_exactly_via_raw_node() {
 #[test]
 fn write_oml_calls_the_shared_depth_guard() {
     fn nest_raw(levels: usize) -> RawNode {
-        let mut n = RawNode::Leaf(crate::document::Scalar::Int(0));
+        let mut n = RawNode::Leaf(crate::document::Scalar::Int((0).into()));
         for _ in 0..levels {
             n = RawNode::Edges(vec![("a".to_string(), n)]);
         }
@@ -382,7 +382,7 @@ fn write_temporal_leaf_falls_back_to_write_scalar_for_a_non_str_scalar() {
     // directly so the fallback arm is real, tested code, not a dead
     // branch.
     assert_eq!(
-        writer::write_temporal_leaf(&crate::document::Scalar::Int(5)),
+        writer::write_temporal_leaf(&crate::document::Scalar::Int((5).into())),
         "5"
     );
 }
@@ -507,7 +507,7 @@ fn capitalized_reserved_words_are_bare_idents_not_keywords() {
 #[test]
 fn quoted_reserved_words_are_valid_labels_and_round_trip() {
     for label in ["nan", "inf", "-inf", "null", "true", "false"] {
-        roundtrip_value(&obj(&[(label, Value::Int(1))]));
+        roundtrip_value(&obj(&[(label, Value::Int((1).into()))]));
     }
 }
 
@@ -588,14 +588,18 @@ fn integer_digit_cap_is_enforced() {
 }
 
 #[test]
-fn integer_at_the_digit_cap_boundary_is_accepted_by_the_scanner_even_if_i64_overflows() {
-    // Exactly MAX_INT_DIGITS digits passes the cap check; i64 can't hold a
-    // 4300-digit number, so this is a distinct, later error -- proving the
-    // cap and the i64-range check are two separate failure modes.
+fn integer_at_the_digit_cap_boundary_parses() {
+    // Exactly MAX_INT_DIGITS digits passes the cap check, and (issue #104)
+    // `Scalar::Int` is arbitrary-precision, so this is now a real,
+    // successfully-parsed value, not an i64-range error.
     let digits = "1".repeat(MAX_INT_DIGITS);
     let src = format!("a: {digits}");
-    let err = read_oml(&src).unwrap_err();
-    assert!(err.message.contains("out of range"));
+    let parsed = Doc::from_raw(read_oml(&src).unwrap()).unwrap();
+    let value = parsed.root().child("a").unwrap().value().unwrap();
+    assert!(
+        matches!(value, crate::document::Scalar::Int(i) if i.to_string().len() == MAX_INT_DIGITS),
+        "got {value:?}"
+    );
 }
 
 #[test]
@@ -611,9 +615,17 @@ fn integer_cap_does_not_false_positive_on_a_long_identifier() {
 }
 
 #[test]
-fn out_of_range_integer_reports_a_clear_error() {
-    let err = read_oml("a: 99999999999999999999").unwrap_err();
-    assert!(err.message.contains("out of range"));
+fn beyond_i64_integer_parses_arbitrary_precision() {
+    // Issue #104: no i64 ceiling anymore -- a 20-digit literal is a real,
+    // correctly-parsed value.
+    let parsed = Doc::from_raw(read_oml("a: 99999999999999999999").unwrap()).unwrap();
+    let value = parsed.root().child("a").unwrap().value().unwrap();
+    assert_eq!(
+        value,
+        &crate::document::Scalar::Int(
+            num_bigint::BigInt::parse_bytes(b"99999999999999999999", 10).unwrap()
+        )
+    );
 }
 
 #[test]
@@ -715,11 +727,11 @@ fn write_oml_compact_joins_edges_with_semicolons() {
     let raw = RawNode::Edges(vec![
         (
             "a".to_string(),
-            RawNode::Leaf(crate::document::Scalar::Int(1)),
+            RawNode::Leaf(crate::document::Scalar::Int((1).into())),
         ),
         (
             "b".to_string(),
-            RawNode::Leaf(crate::document::Scalar::Int(2)),
+            RawNode::Leaf(crate::document::Scalar::Int((2).into())),
         ),
     ]);
     assert_eq!(write_oml_compact(&raw).unwrap(), "a: 1; b: 2");
@@ -731,7 +743,7 @@ fn write_oml_pretty_indents_nested_objects() {
         "a".to_string(),
         RawNode::Edges(vec![(
             "b".to_string(),
-            RawNode::Leaf(crate::document::Scalar::Int(1)),
+            RawNode::Leaf(crate::document::Scalar::Int((1).into())),
         )]),
     )]);
     assert_eq!(write_oml(&raw, 2).unwrap(), "a: {\n  b: 1\n}");
@@ -749,15 +761,15 @@ fn labels_needing_quotes_are_quoted_on_write() {
     let raw = RawNode::Edges(vec![
         (
             "has space".to_string(),
-            RawNode::Leaf(crate::document::Scalar::Int(1)),
+            RawNode::Leaf(crate::document::Scalar::Int((1).into())),
         ),
         (
             "null".to_string(),
-            RawNode::Leaf(crate::document::Scalar::Int(2)),
+            RawNode::Leaf(crate::document::Scalar::Int((2).into())),
         ),
         (
             "1leading".to_string(),
-            RawNode::Leaf(crate::document::Scalar::Int(3)),
+            RawNode::Leaf(crate::document::Scalar::Int((3).into())),
         ),
     ]);
     let text = write_oml(&raw, 2).unwrap();
@@ -770,7 +782,7 @@ fn labels_needing_quotes_are_quoted_on_write() {
 fn bare_identifier_label_is_written_unquoted() {
     let raw = RawNode::Edges(vec![(
         "under_score-and-dash".to_string(),
-        RawNode::Leaf(crate::document::Scalar::Int(1)),
+        RawNode::Leaf(crate::document::Scalar::Int((1).into())),
     )]);
     assert_eq!(write_oml(&raw, 2).unwrap(), "under_score-and-dash: 1");
 }
@@ -837,7 +849,7 @@ fn multibyte_content_inside_a_comment_does_not_corrupt_subsequent_scanning() {
         RawNode::Edges(edges) => {
             assert_eq!(
                 edges,
-                vec![("a".to_string(), RawNode::Leaf(Scalar::Int(1)))]
+                vec![("a".to_string(), RawNode::Leaf(Scalar::Int((1).into())))]
             );
         }
         other => panic!("expected edges, got {other:?}"),
@@ -900,14 +912,14 @@ fn array_of_brace_subtrees_round_trips() {
             "item".to_string(),
             RawNode::Edges(vec![(
                 "v".to_string(),
-                RawNode::Leaf(crate::document::Scalar::Int(1)),
+                RawNode::Leaf(crate::document::Scalar::Int((1).into())),
             )]),
         ),
         (
             "item".to_string(),
             RawNode::Edges(vec![(
                 "v".to_string(),
-                RawNode::Leaf(crate::document::Scalar::Int(2)),
+                RawNode::Leaf(crate::document::Scalar::Int((2).into())),
             )]),
         ),
     ]);
@@ -1001,7 +1013,7 @@ fn four_digits_not_followed_by_dash_is_a_plain_integer() {
         RawNode::Edges(edges) => {
             assert_eq!(
                 edges[0].1,
-                RawNode::Leaf(crate::document::Scalar::Int(1234))
+                RawNode::Leaf(crate::document::Scalar::Int((1234).into()))
             );
         }
         other => panic!("expected edges, got {other:?}"),
@@ -1023,7 +1035,10 @@ fn two_digit_integer_is_not_mistaken_for_a_time() {
     let node = read_oml("a: 12").unwrap();
     match node {
         RawNode::Edges(edges) => {
-            assert_eq!(edges[0].1, RawNode::Leaf(crate::document::Scalar::Int(12)));
+            assert_eq!(
+                edges[0].1,
+                RawNode::Leaf(crate::document::Scalar::Int((12).into()))
+            );
         }
         other => panic!("expected edges, got {other:?}"),
     }
@@ -1033,7 +1048,7 @@ fn two_digit_integer_is_not_mistaken_for_a_time() {
 
 #[test]
 fn write_oml_compact_on_a_bare_leaf_node() {
-    let raw = RawNode::Leaf(crate::document::Scalar::Int(5));
+    let raw = RawNode::Leaf(crate::document::Scalar::Int((5).into()));
     assert_eq!(write_oml(&raw, 2).unwrap(), "5");
     assert_eq!(write_oml_compact(&raw).unwrap(), "5");
 }
@@ -1054,11 +1069,11 @@ fn write_oml_pretty_on_multiple_top_level_edges() {
     let raw = RawNode::Edges(vec![
         (
             "a".to_string(),
-            RawNode::Leaf(crate::document::Scalar::Int(1)),
+            RawNode::Leaf(crate::document::Scalar::Int((1).into())),
         ),
         (
             "b".to_string(),
-            RawNode::Leaf(crate::document::Scalar::Int(2)),
+            RawNode::Leaf(crate::document::Scalar::Int((2).into())),
         ),
     ]);
     assert_eq!(write_oml(&raw, 2).unwrap(), "a: 1\nb: 2");
@@ -1178,7 +1193,10 @@ fn quoted_string_label_at_the_top_level_is_recognized_as_an_edge() {
     match node {
         RawNode::Edges(edges) => {
             assert_eq!(edges[0].0, "a b");
-            assert_eq!(edges[0].1, RawNode::Leaf(crate::document::Scalar::Int(1)));
+            assert_eq!(
+                edges[0].1,
+                RawNode::Leaf(crate::document::Scalar::Int((1).into()))
+            );
         }
         other => panic!("expected edges, got {other:?}"),
     }
@@ -1221,7 +1239,7 @@ fn capitalized_null_true_false_is_a_bare_ident_not_the_keyword() {
     for word in ["Null", "True", "False", "NULL", "TRUE", "FALSE"] {
         let raw = RawNode::Edges(vec![(
             word.to_string(),
-            RawNode::Leaf(crate::document::Scalar::Int(1)),
+            RawNode::Leaf(crate::document::Scalar::Int((1).into())),
         )]);
         let text = write_oml(&raw, 2).unwrap();
         assert_eq!(
@@ -1253,7 +1271,7 @@ fn capitalized_nan_inf_is_a_bare_ident_not_the_keyword() {
     for word in ["NAN", "INF", "NaN", "Inf"] {
         let raw = RawNode::Edges(vec![(
             word.to_string(),
-            RawNode::Leaf(crate::document::Scalar::Int(1)),
+            RawNode::Leaf(crate::document::Scalar::Int((1).into())),
         )]);
         let text = write_oml(&raw, 2).unwrap();
         assert_eq!(
@@ -1325,7 +1343,7 @@ fn quoted_reserved_spelling_is_a_valid_label_and_round_trips() {
     for word in ["null", "true", "false", "nan", "inf", "-inf"] {
         let raw = RawNode::Edges(vec![(
             word.to_string(),
-            RawNode::Leaf(crate::document::Scalar::Int(1)),
+            RawNode::Leaf(crate::document::Scalar::Int((1).into())),
         )]);
         let text = write_oml(&raw, 2).unwrap();
         // None of these are valid bare labels (either RESERVED, or -- for

--- a/omnist/src/schema.rs
+++ b/omnist/src/schema.rs
@@ -1104,13 +1104,13 @@ mod tests {
     fn valid_service_doc() -> Value {
         obj(&[
             ("host", Value::Str("api.internal".into())),
-            ("port", Value::Int(8443)),
+            ("port", Value::Int((8443).into())),
             (
                 "databases",
                 Value::Array(vec![obj(&[
                     ("type", Value::Str("prod".into())),
                     ("server", Value::Str("db1".into())),
-                    ("port", Value::Int(5432)),
+                    ("port", Value::Int((5432).into())),
                 ])]),
             ),
             (
@@ -1136,7 +1136,10 @@ mod tests {
     #[test]
     fn cardinality_rejects_too_few_databases() {
         let schema = service_schema();
-        let v = obj(&[("host", Value::Str("h".into())), ("port", Value::Int(1))]);
+        let v = obj(&[
+            ("host", Value::Str("h".into())),
+            ("port", Value::Int((1).into())),
+        ]);
         let doc = Doc::of(&v).unwrap();
         let res = schema.validate(&doc.root());
         assert!(!res.ok());
@@ -1156,12 +1159,12 @@ mod tests {
             (
                 "databases",
                 Value::Array(vec![obj(&[
-                    ("port", Value::Int(1)),
+                    ("port", Value::Int((1).into())),
                     ("type", Value::Str("t".into())),
                     ("server", Value::Str("s".into())),
                 ])]),
             ),
-            ("port", Value::Int(8443)),
+            ("port", Value::Int((8443).into())),
             ("host", Value::Str("h".into())),
         ]);
         let doc = Doc::of(&v).unwrap();
@@ -1175,7 +1178,7 @@ mod tests {
         let schema = service_schema();
         let mut v = valid_service_doc();
         if let Value::Object(m) = &mut v {
-            m.insert("extra".to_string(), Value::Int(1));
+            m.insert("extra".to_string(), Value::Int((1).into()));
         }
         let doc = Doc::of(&v).unwrap();
         let res = schema.validate(&doc.root());
@@ -1194,13 +1197,13 @@ mod tests {
         let schema = service_schema();
         let v = obj(&[
             ("host", obj(&[])),
-            ("port", Value::Int(1)),
+            ("port", Value::Int((1).into())),
             (
                 "databases",
                 Value::Array(vec![obj(&[
                     ("type", Value::Str("t".into())),
                     ("server", Value::Str("s".into())),
-                    ("port", Value::Int(1)),
+                    ("port", Value::Int((1).into())),
                 ])]),
             ),
         ]);
@@ -1218,7 +1221,7 @@ mod tests {
         let mut env = Map::new();
         env.insert("Root".to_string(), Record::new(vec![]).unwrap());
         let schema = Schema::new(Ref::new("Root"), env).unwrap();
-        let doc = Doc::of(&Value::Int(1)).unwrap();
+        let doc = Doc::of(&Value::Int((1).into())).unwrap();
         let res = schema.validate(&doc.root());
         assert!(!res.ok());
         assert_eq!(res.errors()[0].code, ErrorCode::ShapeMismatch);
@@ -1290,7 +1293,10 @@ mod tests {
 
     #[test]
     fn integer_satisfies_number_but_not_vice_versa() {
-        assert!(matches_kind(&DocScalar::Int(3), ScalarKind::Number));
+        assert!(matches_kind(
+            &DocScalar::Int((3).into()),
+            ScalarKind::Number
+        ));
         assert!(!matches_kind(&DocScalar::Float(3.0), ScalarKind::Integer));
     }
 
@@ -1421,8 +1427,8 @@ mod tests {
             &DocScalar::Str("25:00:00".into()),
             ScalarKind::Time
         ));
-        assert!(!matches_kind(&DocScalar::Int(1), ScalarKind::Date));
-        assert!(!matches_kind(&DocScalar::Int(1), ScalarKind::Time));
+        assert!(!matches_kind(&DocScalar::Int((1).into()), ScalarKind::Date));
+        assert!(!matches_kind(&DocScalar::Int((1).into()), ScalarKind::Time));
     }
 
     #[test]
@@ -1453,11 +1459,11 @@ mod tests {
         // case in a separate `[0,]`-cardinality field below.
         for v in [
             Value::Str("hi".into()),
-            Value::Int(1),
+            Value::Int((1).into()),
             Value::Float(1.5),
             Value::Bool(true),
             Value::Null,
-            obj(&[("nested", Value::Int(1))]),
+            obj(&[("nested", Value::Int((1).into()))]),
         ] {
             let doc = Doc::of(&obj(&[("x", v.clone())])).unwrap();
             assert!(schema.accepts(&doc.root()), "any field rejected {v:?}");
@@ -1474,7 +1480,7 @@ mod tests {
         let schema = Schema::new(Ref::new("Root"), env).unwrap();
         let doc = Doc::of(&obj(&[(
             "x",
-            Value::Array(vec![Value::Int(1), Value::Str("mixed".into())]),
+            Value::Array(vec![Value::Int((1).into()), Value::Str("mixed".into())]),
         )]))
         .unwrap();
         assert!(schema.accepts(&doc.root()));
@@ -1518,7 +1524,7 @@ mod tests {
     fn value_kind_name_covers_every_variant() {
         assert_eq!(value_kind_name(&DocScalar::Null), "null");
         assert_eq!(value_kind_name(&DocScalar::Bool(true)), "boolean");
-        assert_eq!(value_kind_name(&DocScalar::Int(1)), "integer");
+        assert_eq!(value_kind_name(&DocScalar::Int((1).into())), "integer");
         assert_eq!(value_kind_name(&DocScalar::Float(1.0)), "number");
         assert_eq!(value_kind_name(&DocScalar::Str("x".into())), "string");
     }

--- a/omnist/src/tests.rs
+++ b/omnist/src/tests.rs
@@ -11,7 +11,7 @@ use super::*;
 
 #[test]
 fn version_matches_cargo_toml() {
-    assert_eq!(VERSION, "0.1.1-alpha");
+    assert_eq!(VERSION, "0.1.2-alpha");
 }
 
 // -- cross-op characterization: infer + materialize (issue #14) ------------
@@ -36,7 +36,7 @@ fn materialize_accepts_infers_own_source_data() {
     let samples = vec![
         document::Doc::of(&obj(&[
             ("name", Value::Str("alice".into())),
-            ("age", Value::Int(30)),
+            ("age", Value::Int((30).into())),
             (
                 "address",
                 obj(&[
@@ -89,7 +89,7 @@ fn materialize_of_infer_upgrades_an_integer_number_mix_to_number() {
     }
 
     let samples = vec![
-        document::Doc::of(&obj(&[("price", Value::Int(3))])).unwrap(),
+        document::Doc::of(&obj(&[("price", Value::Int((3).into()))])).unwrap(),
         document::Doc::of(&obj(&[("price", Value::Float(3.5))])).unwrap(),
     ];
     let schema = infer(&samples, "Root").unwrap();

--- a/omnist/tests/fuzz.rs
+++ b/omnist/tests/fuzz.rs
@@ -120,8 +120,9 @@ fn arb_scalar() -> impl Strategy<Value = Value> {
         any::<bool>().prop_map(Value::Bool),
         // Bounded well away from i64::MAX/MIN edge weirdness in most
         // cases, plus a dedicated extreme-integer arm.
-        (-1_000_000i64..1_000_000).prop_map(Value::Int),
-        prop_oneof![Just(i64::MAX), Just(i64::MIN), Just(0i64), Just(-1i64),].prop_map(Value::Int),
+        (-1_000_000i64..1_000_000).prop_map(|i: i64| Value::Int(i.into())),
+        prop_oneof![Just(i64::MAX), Just(i64::MIN), Just(0i64), Just(-1i64),]
+            .prop_map(|i: i64| Value::Int(i.into())),
         (-1e6f64..1e6)
             .prop_filter("finite", |f| f.is_finite())
             .prop_map(Value::Float),

--- a/omnist/tests/parity.rs
+++ b/omnist/tests/parity.rs
@@ -84,7 +84,9 @@ fn decode_raw(v: &J) -> RawNode {
         return RawNode::Leaf(Scalar::Bool(*b));
     }
     if let Some(n) = obj.get("$int") {
-        return RawNode::Leaf(Scalar::Int(n.as_i64().expect("$int must fit in i64")));
+        return RawNode::Leaf(Scalar::Int(
+            n.as_i64().expect("$int must fit in i64").into(),
+        ));
     }
     if let Some(n) = obj.get("$float") {
         let f = match n {
@@ -790,7 +792,7 @@ fn parity_corpus_replays_every_fixture_against_rust() {
 /// `deep_node(depth)` mirrors the Python extractor's `deep_node` helper
 /// exactly: `depth` levels of `[("a", ...)]` wrapping a leaf `1`.
 fn deep_node(depth: usize) -> RawNode {
-    let mut node = RawNode::Leaf(Scalar::Int(1));
+    let mut node = RawNode::Leaf(Scalar::Int(1.into()));
     for _ in 0..depth {
         node = RawNode::Edges(vec![("a".to_string(), node)]);
     }
@@ -812,7 +814,7 @@ fn json_object_to_raw(v: &J) -> RawNode {
         match v {
             J::Null => Scalar::Null,
             J::Bool(b) => Scalar::Bool(*b),
-            J::Number(n) if n.is_i64() => Scalar::Int(n.as_i64().unwrap()),
+            J::Number(n) if n.is_i64() => Scalar::Int(n.as_i64().unwrap().into()),
             J::Number(n) => Scalar::Float(n.as_f64().unwrap()),
             J::String(s) => Scalar::Str(s.clone()),
             other => panic!("json_object_to_raw: unsupported scalar {other:?}"),
@@ -858,7 +860,7 @@ fn scalar_value_from_enc(v: &J) -> Value {
         return Value::Bool(*b);
     }
     if let Some(n) = obj.get("$int") {
-        return Value::Int(n.as_i64().expect("$int must fit in i64"));
+        return Value::Int(n.as_i64().expect("$int must fit in i64").into());
     }
     if let Some(n) = obj.get("$float") {
         let f = match n {

--- a/src/conformance.md
+++ b/src/conformance.md
@@ -3,7 +3,9 @@
 This port has its own conformance-test harness (`tools/conformance/`)
 against [omnist-spec](https://github.com/omnist-dev/omnist-spec), the
 language-agnostic upstream specification. It vendors omnist-spec as a
-pinned git submodule (`vendor/omnist-spec`, currently `v0.1.1-alpha`) and
+pinned git submodule (`vendor/omnist-spec`, currently commit `f93c569`,
+past the `v0.2.2-alpha` tag -- pinned to the exact commit adding issue
+#104's conformance vector, ahead of any tag that includes it yet) and
 runs entirely against this crate's own library code -- it does not depend
 on the Python or TypeScript ports' implementations.
 
@@ -16,7 +18,7 @@ reporting rule:
 - **Track 1** (`vendor/omnist-spec/conformance/fixtures/`, directory-per-fixture,
   11 operations): **19 passed, 0 failed, 0 skipped**.
 - **Track 2** (`vendor/omnist-spec/test-suite/`, JSON-vector suite, 14-operation
-  vocabulary): **124 passed, 0 failed, 22 skipped** (of 146 vectors).
+  vocabulary): **129 passed, 0 failed, 23 skipped** (of 152 vectors).
 
 Zero real fails on either track as of this writing. Run it yourself:
 
@@ -72,8 +74,8 @@ not implied parity
 ## Real bugs this harness found and fixed
 
 Building this harness against the real spec (rather than trusting the
-Python/TypeScript ports as ground truth) found six real product bugs,
-all fixed across this port's `0.1.0-alpha`/`0.1.1-alpha`:
+Python/TypeScript ports as ground truth) found seven real product bugs,
+all fixed across this port's `0.1.0-alpha`/`0.1.1-alpha` releases:
 
 - **XML reader was type-coercing leaf text** (int/float/bool) at parse
   time, contradicting the spec -- XML has no typed literals. Fixed:
@@ -106,6 +108,24 @@ all fixed across this port's `0.1.0-alpha`/`0.1.1-alpha`:
   structurally unreachable given this port's `any`-scoping decision (see
   [`limitations.md`](limitations.md#the-any-type-scoping-gap-deferred-not-forgotten));
   reclassified from fail to a cited skip rather than a product fix.
+- **`Scalar::Int(i64)` rejected valid arbitrary-precision integer
+  literals** -- omnist-spec section 2.2 defines `integer` as
+  arbitrary-precision (bounded only by the shared 4,300-digit cap), not
+  fixed-width; a 20+ digit OML literal was rejected outright with no
+  digit-cap override in play, a real grammar-acceptance bug (spec
+  section 9.2), not a permitted narrower-limit variation. Not found by
+  this harness on its own -- surfaced by a maintainer-prompted
+  ledger-legitimacy audit ("is this a genuine language limitation or an
+  unexamined shortcut") on the `omnist-spec` side, which added the vector
+  this fix now passes for real. Fixed by moving `Scalar::Int`/`Value::Int`
+  onto `num_bigint::BigInt`; see
+  [Limitations](limitations.md#scalarint-is-arbitrary-precision-issue-104).
+  Found and fixed along the way, not assumed mechanical: the YAML legacy
+  sexagesimal literal's fold used to rely on `i64` overflow as an
+  incidental size bound -- a naive `BigInt` swap would have silently
+  removed it, letting a many-`:`-group literal build an arbitrarily large
+  integer with nothing stopping it. Fixed by enforcing the existing
+  digit cap explicitly on the fold's result instead.
 
 None of these required filing against omnist-spec, Python, or
 TypeScript -- every real fail traced back to an omnist-rs bug when

--- a/src/formats/json.md
+++ b/src/formats/json.md
@@ -37,15 +37,14 @@ time it reaches this codec, so there is nothing left to adjust or report
 here, unlike Python (which stringifies a live `datetime.date`/`time` object
 and records a `temporal.stringified` warning).
 
-## Integer digit cap and the `i64` representational limit
+## Integer digit cap (arbitrary-precision, matching Python -- issue #104)
 
 A JSON integer literal over **4300 digits** is a `ParseError` (mirrors
 CPython's `sys.set_int_max_str_digits` guard, which fires inside
-`json.loads` before Python ever sees the value). Because this port's
-`Scalar::Int` is `i64` (max ~19 significant digits), any literal over 19
-digits fails first with "out of range for a 64-bit integer" -- the
-4300-digit cap essentially never fires in practice for this port, but is
-kept anyway for parity with the same guard `oml.rs`/`yaml.rs`/`toml.rs`
-share. Python's reference, by contrast, holds arbitrary-precision `int`s
-under the 4300-digit cap with no 64-bit ceiling at all -- a disclosed
-Rust-specific representational gap, not a bug.
+`json.loads` before Python ever sees the value). Under that cap, this
+port's `Scalar::Int`/`Value::Int` hold the value exactly, at any size --
+`num_bigint::BigInt`, not a fixed-width integer -- matching Python's own
+arbitrary-precision `int` with no additional ceiling. (Previously
+`i64`-backed, ~19 significant digits; that was a real spec-conformance
+bug, not a disclosed representational gap -- see
+[Limitations](../limitations.md#scalarint-is-arbitrary-precision-issue-104).)

--- a/src/formats/toml.md
+++ b/src/formats/toml.md
@@ -31,7 +31,7 @@ live-confirmed against `tomli_w.dumps` (Python's reference TOML writer) to
 match exactly, path-for-path. `strict` mode raises even though the severity
 is only `Warning`.
 
-## Integer digit cap, and a disclosed hex/octal/binary divergence from Python
+## Integer digit cap, and a real, external `i64` ceiling from `toml_edit`
 
 Live-confirmed against `tomllib.loads`: a **decimal** integer literal
 follows the identical 4300-digit `sys.set_int_max_str_digits` cap
@@ -40,15 +40,24 @@ genuine exception in Python** -- `tomllib.loads("x = 0x" + "f" * 10000)`
 parses successfully with no error at all, because CPython's digit-limit
 guard explicitly exempts power-of-two bases.
 
-This port does **not** replicate that decimal/non-decimal split: every
-radix goes through the same 4300-digit cap, because the underlying
-`toml_edit` crate itself enforces a strict `i64` range at parse time
-regardless of radix -- there is no path here for an oversized hex/octal/
-binary literal to reach `Scalar::Int` uncapped the way Python's
-arbitrary-precision `int` does. This is a **disclosed divergence from
-Python**, not a parity gap to close: `Scalar::Int` is `i64`-backed
-regardless of a literal's original radix, so an "uncapped hex" path would
-still have to fail somewhere past 64 bits either way.
+This port does **not** replicate that decimal/non-decimal split, but for
+a different reason than it used to (issue #104: `Scalar::Int`/`Value::Int`
+are arbitrary-precision `BigInt`s now, not `i64`). The underlying
+`toml_edit` crate's own `Integer` type is `i64`-backed regardless of
+radix (the TOML 1.0 format spec itself documents 64-bit signed
+integers), so **reading** a >19-digit literal of any radix from TOML
+*source text* fails in `toml_edit`'s own parser, before this codec's
+`Scalar` conversion ever runs -- a real, external, still-current
+divergence from Python's arbitrary-precision `int`, not something this
+port's own representation choice can lift. Live-confirmed:
+`convert --from toml` on `n = 99999999999999999999999999` fails with
+`"integer literal ... is out of range for a 64-bit integer"`.
+**Writing** an oversized `Scalar::Int` *to* TOML, by contrast, succeeds
+-- this codec's writer renders integers as plain digit text rather than
+going through `toml_edit`'s typed API, so the ceiling is read-side only;
+live-confirmed the same 26-digit value round-trips out via
+`convert --from oml --to toml` with no error, it just can't be read back
+in through TOML afterward.
 
 ## Native temporal types, truncated (not rounded) sub-microsecond precision
 

--- a/src/formats/yaml.md
+++ b/src/formats/yaml.md
@@ -87,5 +87,10 @@ omnist-rs issue #88, found and fixed alongside #87 above.
 ## Integer digit cap
 
 Same 4300-digit cap as `json.rs`/`oml.rs`/`toml.rs`, applied to a plain
-decimal integer scalar's digit run before parsing; the same `i64`
-representational ceiling applies (see [formats/json.md](json.md)).
+decimal integer scalar's digit run before parsing; arbitrary-precision
+above that (see [formats/json.md](json.md#integer-digit-cap-arbitrary-precision-matching-python----issue-104)).
+The legacy sexagesimal fold (above) enforces the identical cap on its
+*folded result*, not any one group -- issue #104: an unbounded
+`BigInt` fold with no such check would let a many-group literal build an
+arbitrarily large integer, a resource-exhaustion regression the fold's
+old `i64` overflow used to prevent as an unplanned side effect.

--- a/src/limitations.md
+++ b/src/limitations.md
@@ -40,29 +40,30 @@ Closing this gap is 1.0-gating work, not a bug to fix incrementally --
 see the sibling `omnist` project's own `any`-openness decision, which this
 port's scoping deliberately mirrors rather than resolves independently.
 
-## Representational limits from `Scalar::Int` being `i64`
+## `Scalar::Int` is arbitrary-precision (issue #104)
 
-Every format codec shares one representational ceiling this port's Python
-and TypeScript siblings don't have: `omnist::document::Scalar::Int` is a
-plain `i64` (max ~19 significant decimal digits), not an arbitrary-
-precision integer. Each format's own page documents the specific
-consequence:
+`omnist::document::Scalar::Int` and `Value::Int` are backed by
+`num_bigint::BigInt`, not a fixed-width integer -- matching omnist-spec
+[section 2.2](https://github.com/omnist-dev/omnist-spec/blob/main/docs/02-document-model.md#22-values)'s
+requirement that `integer` be arbitrary-precision, and Python's/Go's own
+representations (`int`, `*big.Int`). This was previously `i64` (max ~19
+significant decimal digits) -- a real spec-conformance bug, not a
+disclosed permitted variation, since a 20+ digit literal under the shared
+4,300-digit security cap was rejected outright with no
+`declared_max_int_digits` override in play (omnist-spec ledger entry D-9).
+Fixed; see each format's own page for anything still worth knowing:
 
-- [formats/json.md](formats/json.md), [formats/yaml.md](formats/yaml.md) --
-  a decimal integer literal over 19 digits (but under the shared
-  4300-digit security cap) is a `ParseError` ("out of range for a 64-bit
-  integer"), where Python holds it as an exact arbitrary-precision `int`.
-- [formats/toml.md](formats/toml.md) -- the same cap is applied uniformly
-  to hex/octal/binary literals too, a disclosed divergence from Python
-  (which exempts those radixes from its digit-limit guard entirely).
-- [formats/xml.md](formats/xml.md) -- an over-`i64` numeral falls through
-  to `Scalar::Float` instead of erroring, mirroring Python's own
-  int-then-float coercion fallback, just with a narrower `Scalar::Int`.
-
-None of this is a bug: it is the direct, disclosed consequence of issue
-#4's Document-model architecture decision (`Scalar` has exactly five
-variants, `Int` is `i64`), applied consistently across every codec rather
-than special-cased away.
+- [formats/toml.md](formats/toml.md) -- **one real, external divergence
+  remains**: `toml_edit`, the crate this port's TOML codec is built on,
+  has its own `i64`-backed integer type (the TOML 1.0 format spec itself
+  documents 64-bit signed integers), so a >19-digit integer literal in
+  TOML *source text* is still rejected -- by `toml_edit`'s own parser,
+  before this port's `Scalar` is ever involved. Writing an
+  arbitrary-precision `Scalar::Int` *to* TOML still succeeds (this
+  codec's writer renders integers as plain digit text, not through
+  `toml_edit`'s typed API), so the asymmetry is read-side only: such a
+  value round-trips out but not back in through TOML specifically. Every
+  other format (JSON, YAML, OML) has no such ceiling.
 
 ## No native temporal `Scalar` variant
 

--- a/src/quickstart.md
+++ b/src/quickstart.md
@@ -2,7 +2,7 @@
 
 ```toml
 [dependencies]
-omnist = "0.1.1-alpha"
+omnist = "0.1.2-alpha"
 ```
 <!-- doc-illustrative -->
 

--- a/tools/check-doc-examples/Cargo.toml
+++ b/tools/check-doc-examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "check-doc-examples"
-version = "0.1.1-alpha"
+version = "0.1.2-alpha"
 edition = "2024"
 description = "CI gate: every new/changed fenced code block in docs/*.md needs a verified-by or doc-illustrative marker."
 license = "Apache-2.0"

--- a/tools/conformance/Cargo.toml
+++ b/tools/conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conformance"
-version = "0.1.1-alpha"
+version = "0.1.2-alpha"
 edition = "2024"
 description = "omnist-rs's own conformance-test harness against omnist-spec (issue #82): referee + Track 1 fixture runner + Track 2 vector runner, consuming the pinned vendor/omnist-spec submodule directly, never depending on Python's or TypeScript's implementation."
 license = "Apache-2.0"
@@ -23,5 +23,11 @@ name = "vector_runner"
 path = "src/bin/vector_runner.rs"
 
 [dependencies]
+num-bigint = "0.4"
 omnist = { path = "../../omnist" }
-serde_json = "1"
+# arbitrary_precision: a vector's integer-kind value can legitimately be a
+# bare JSON number literal beyond i64/f64 range (issue #104's own
+# arbitrary-precision-integer vectors) -- without this feature, serde_json
+# silently loses precision decoding such a literal into its default
+# f64-backed Number, defeating the vector's own point.
+serde_json = { version = "1", features = ["arbitrary_precision"] }

--- a/tools/conformance/src/bin/vector_runner.rs
+++ b/tools/conformance/src/bin/vector_runner.rs
@@ -220,12 +220,20 @@ fn decode_scalar(kind: Option<&str>, value: &Json) -> Scalar {
         None => Scalar::Null,
         Some("boolean") => Scalar::Bool(value.as_bool().expect("boolean-kind value is a bool")),
         Some("integer") => {
-            let n = if let Some(s) = value.as_str() {
-                s.parse::<i64>().expect("integer-kind string value parses")
-            } else {
-                value.as_i64().expect("integer-kind value is an i64")
-            };
-            Scalar::Int(n)
+            // A vector's integer-kind value may be a quoted string or a
+            // bare JSON number literal beyond i64 range (issue #104's
+            // arbitrary-precision vectors) -- `Number::to_string()` under
+            // `arbitrary_precision` (this crate's Cargo.toml) preserves
+            // the exact source digits either way, so both forms funnel
+            // through the same `BigInt` parse.
+            let text = value
+                .as_str()
+                .map(str::to_string)
+                .or_else(|| value.as_number().map(|n| n.to_string()))
+                .expect("integer-kind value is a string or a number");
+            num_bigint::BigInt::parse_bytes(text.as_bytes(), 10)
+                .map(Scalar::Int)
+                .expect("integer-kind value parses as a decimal integer")
         }
         Some("number") => {
             let n = if let Some(s) = value.as_str() {
@@ -885,44 +893,43 @@ mod tests {
     use super::*;
 
     #[test]
-    fn vector_count_is_146() {
-        // 139 -> 146 via vendor/omnist-spec v0.1.0-alpha -> v0.1.1-alpha
-        // (issue #99): 6 new `formats-oml/oml.json` vectors testing a
-        // plain string that merely looks temporal-shaped staying quoted
-        // on OML write, vs. a genuinely temporal-kinded value writing
-        // bare.
+    fn vector_count_is_152() {
+        // 146 -> 152 via vendor/omnist-spec v0.1.1-alpha -> commit f93c569
+        // (issue #104: arbitrary-precision `Scalar::Int`). The submodule
+        // pin bump brings in several bundled, otherwise-unrelated
+        // omnist-spec changes past the D-9 vector this issue actually
+        // needed (`git diff <old-pin> f93c569 --stat -- test-suite/`
+        // shows `document-model/limits.json`, `extract/extract.json`,
+        // `formats-json/json.json`, `infer/infer.json`, and
+        // `osd-grammar/grammar.json` all changed) -- not decomposed
+        // vector-by-vector here since several are genuinely unrelated to
+        // this fix, matching this file's own precedent (issue #99's pin
+        // bump bundled an unrelated NaN/Infinity vector the same way).
         let vectors = iter_vectors(&suite_dir());
-        assert_eq!(vectors.len(), 146);
+        assert_eq!(vectors.len(), 152);
     }
 
     /// Full-suite regression guard: runs every real vector through every
     /// driver (also this file's real coverage-driving test, since
     /// `main`/`main_with_dir` itself is process-entry-point code no test
     /// calls directly). The exact counts are this step's honest,
-    /// freshly-reproduced measurement -- history through (117, 0, 22) at
-    /// 139 vectors covered by earlier PRs (#86/#87/#88/#89, issue #82).
-    /// Now (124, 0, 22) at 146 vectors: vendor/omnist-spec bumped
-    /// v0.1.0-alpha -> v0.1.1-alpha, adding 7 new vectors total, all 7
-    /// newly passing (diffed pass-list vector-by-vector against the old
-    /// pin, not assumed) -- 6 in `formats-oml/oml.json` (issue #99's own
-    /// vectors: a plain string that merely looks temporal-shaped stays
-    /// quoted on OML write, a genuinely temporal-kinded value writes
-    /// bare) plus 1 unrelated one,
-    /// `formats-json/basic/nan-substituted-with-null-and-reported`, from
-    /// a *different* omnist-spec fix bundled into the same tag
-    /// (omnist-spec#30/#31, NaN/Infinity vector encoding) -- Rust's
-    /// `write_json` already substitutes `null` for NaN correctly, this
-    /// vector just wasn't representable/testable before that upstream
-    /// fix. Every count here is freshly reproduced by running the
-    /// harness, not computed by hand. Pinned so a future change that
-    /// silently regresses pass/fail/skip counts is caught, not a "this
-    /// must always be 0 fails" gate.
+    /// freshly-reproduced measurement -- history through (124, 0, 22) at
+    /// 146 vectors (issue #99). Now (129, 0, 23) at 152 vectors after
+    /// issue #104 (`Scalar::Int`/`Value::Int` arbitrary-precision via
+    /// `num_bigint::BigInt`) plus the bundled unrelated spec changes
+    /// noted on `vector_count_is_152` above. Confirmed the vector this
+    /// issue actually targets passes for real, not assumed:
+    /// `document-model/limits/integer-beyond-fixed-width-still-parses-under-default-limit`
+    /// is a real `[PASS]` in a fresh run. Every count here is freshly
+    /// reproduced by running the harness, not computed by hand. Pinned
+    /// so a future change that silently regresses pass/fail/skip counts
+    /// is caught, not a "this must always be 0 fails" gate.
     #[test]
     fn full_suite_counts_match_the_measured_baseline() {
         let (passed, failed, skipped) = run_all(&suite_dir());
         assert_eq!(
             (passed, failed, skipped),
-            (124, 0, 22),
+            (129, 0, 23),
             "vector pass/fail/skip counts changed -- if this is an intentional fix or a new \
              vector, update the pinned baseline; if not, something regressed"
         );
@@ -1008,7 +1015,10 @@ mod tests {
     #[test]
     fn decode_scalar_accepts_string_encoded_integer_and_number() {
         let node = json!({"scalar": {"kind": "integer", "value": "42"}});
-        assert_eq!(decode_document(&node), RawNode::Leaf(Scalar::Int(42)));
+        assert_eq!(
+            decode_document(&node),
+            RawNode::Leaf(Scalar::Int(42.into()))
+        );
         let node = json!({"scalar": {"kind": "number", "value": "1.5"}});
         assert_eq!(decode_document(&node), RawNode::Leaf(Scalar::Float(1.5)));
     }


### PR DESCRIPTION
fix: Scalar::Int/Value::Int are arbitrary-precision, not i64 (#104)

omnist-spec section 2.2 defines `integer` as arbitrary-precision, bounded
only by the shared 4,300-digit security cap -- not a fixed-width type.
`Scalar::Int(i64)` rejected any literal past ~19 digits outright, even
comfortably under the cap with no declared_max_int_digits override in
play: a real grammar-acceptance forbidden-variation bug (spec section
9.2), not a permitted narrower-limit variation. Confirmed live before
the fix; surfaced by a maintainer-prompted ledger-legitimacy audit on
the omnist-spec side (D-9), not by this port's own conformance run
(which was fully green despite the bug, since no vector tested it until
D-9 added one).

Design posted to the issue before implementing. Representation:
num_bigint::BigInt, matching Python's native int and omnist-go's
*big.Int. Scope, verified rather than assumed "mechanical":

- document.rs: Scalar::Int/Value::Int both become BigInt.
- oml/scanner.rs, formats/json.rs, formats/yaml.rs's plain-integer
  parser: swapped i64::from_str for BigInt::parse_bytes after the
  existing digit-cap check, which is now the only real bound (an i64
  parse failure past the cap is structurally impossible with BigInt, so
  the old "fits the cap but not an i64" error path and its
  out_of_range_message call sites are removed as genuinely dead, not
  pragma'd).
- formats/yaml.rs's legacy sexagesimal fold (parse_sexagesimal_int):
  the one site where a naive BigInt swap would have introduced a real
  regression. The old i64 accumulator's checked_mul/checked_add
  overflow was incidentally acting as a size bound on a many-`:`-group
  literal; switching to unbounded BigInt arithmetic alone would have
  silently removed it. Fixed by enforcing the existing MAX_INT_DIGITS
  cap explicitly on the fold's result. Adversarially verified: disabled
  the new check, confirmed a 2500-group literal builds an astronomically
  large integer with no test catching it, restored the check, confirmed
  the guard test genuinely fails without it and passes with it.
- materialize.rs's float<->int upgrade table: the i64::MIN/MAX range
  check on Float->Integer is deleted (BigInt has no range limit, so any
  finite whole-number float upgrades now); Integer->Number uses
  BigInt::to_f64, saturating to +/-infinity for a value beyond f64's
  finite range rather than failing, matching this codebase's existing
  Float model (inf/-inf already first-class).
- formats/toml.rs: toml_edit's own Integer type is i64-backed regardless
  of this port's Scalar representation (the TOML 1.0 format spec itself
  documents 64-bit integers) -- a real, external, still-current
  divergence on the read side only. Verified live both directions:
  reading an oversized TOML integer literal still fails in toml_edit's
  own parser; writing an oversized Scalar::Int to TOML succeeds (this
  codec's writer renders integers as plain digit text, not through
  toml_edit's typed API), so the ceiling is asymmetric -- documented in
  docs/formats/toml.md, not silently ignored or over-claimed as fixed.
- tools/conformance: added the missing arbitrary_precision feature to
  serde_json (a vector's integer-kind value can be a bare JSON number
  literal beyond f64's exact range) and fixed decode_scalar to extract
  the literal digit text and parse via BigInt instead of losing
  precision through the default Number type.

Conformance: submodule pinned to omnist-spec commit f93c569 (past
v0.2.2-alpha, the exact commit adding this issue's vector -- no tag
includes it yet). Track 2: 124/0/22 (146 vectors) -> 129/0/23 (152
vectors); confirmed the target vector itself passes for real
(document-model/limits/integer-beyond-fixed-width-still-parses-under-default-limit),
and confirmed the pin bump bundles several other, genuinely unrelated
omnist-spec changes rather than assuming a full decomposition.

~250 mechanical literal-wrapping sites (Scalar::Int(1) -> BigInt, etc.)
across the workspace's tests/examples/fuzz harness, plus 9 tests whose
own premise was the bug being fixed here, rewritten to assert the now-
correct behavior (arbitrary-precision literals parse successfully) with
one new adversarial regression test for the sexagesimal digit-cap fix.

docs/limitations.md's stale "Representational limits from Scalar::Int
being i64" section rewritten (it previously described the bug's
consequences as "not a bug... a disclosed permanent divergence," which
was itself wrong); docs/formats/{json,yaml,toml}.md updated;
docs/conformance.md reports this as the seventh real bug this harness's
existence has surfaced.

Version bump: every workspace crate 0.1.1-alpha -> 0.1.2-alpha.

Not in scope: the reopened D-7(1) question (adding Date/Time/DateTime
Scalar variants) -- filed separately as issue #105, not bundled here.
