### PR TITLE
docs: generate rustdoc alongside mdBook and enforce missing_docs (#110)

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -5,12 +5,20 @@ on:
     paths:
       - "book.toml"
       - "src/**"
+      - "omnist/**"
+      - "omnist-cli/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
       - ".github/workflows/book.yml"
   push:
     branches: [main]
     paths:
       - "book.toml"
       - "src/**"
+      - "omnist/**"
+      - "omnist-cli/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
       - ".github/workflows/book.yml"
 
 permissions:
@@ -27,12 +35,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
       - name: install mdbook
         uses: peaceiris/actions-mdbook@v2
         with:
           mdbook-version: "latest"
       - name: mdbook build
         run: mdbook build
+      - name: generate rustdoc
+        run: |
+          cargo doc --no-deps --workspace
+          mkdir -p book/api
+          cp -r target/doc/* book/api/
       - name: add custom domain CNAME
         run: echo "rs.omnist.dev" > book/CNAME
       - name: upload pages artifact

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,7 @@
 # API reference
 
+> **Rustdoc API Reference**: Generated rustdoc documentation for all workspace crates is available at [**`api/omnist/index.html`**](api/omnist/index.html).
+
 This page enumerates the `omnist` crate's public surface: every exported
 type, function, and method, grouped by area. Signatures are copied from the
 current source (`omnist/src/*.rs`); doc comments are condensed, not

--- a/omnist-cli/src/lib.rs
+++ b/omnist-cli/src/lib.rs
@@ -29,6 +29,9 @@
 //!   schema-less read, exactly mirroring Python's `_materialize(node,
 //!   schema)` call inside each reader.
 
+#![deny(missing_docs)]
+#![warn(rustdoc::all)]
+
 use std::io::{self, Read, Write};
 
 use clap::{Parser, Subcommand, ValueEnum};
@@ -40,6 +43,7 @@ use omnist::{OmnistError, WriteError, WriteReport};
 // Argument parsing
 // ---------------------------------------------------------------------------
 
+/// Command-line arguments parser for the `omnist` CLI.
 #[derive(Parser, Debug)]
 #[command(
     name = "omnist",
@@ -48,10 +52,12 @@ use omnist::{OmnistError, WriteError, WriteReport};
              read, validate, and write any of them."
 )]
 pub struct Cli {
+    /// Subcommand to execute.
     #[command(subcommand)]
     pub command: Command,
 }
 
+/// Top-level subcommands supported by `omnist`.
 #[derive(Subcommand, Debug)]
 pub enum Command {
     /// Canonicalize an OML document (the only format with no other tool for this).
@@ -69,190 +75,280 @@ pub enum Command {
     Schema(SchemaCommand),
 }
 
+/// Supported document format codecs for CLI input and output.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 pub enum Fmt {
+    /// The JSON format codec.
     Json,
+    /// The YAML format codec.
     Yaml,
+    /// The TOML format codec.
     Toml,
+    /// The XML format codec.
     Xml,
+    /// The OML format codec.
     Oml,
 }
 
+/// Output encoding for boolean or report results.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum, Default)]
 pub enum ResultFormat {
+    /// Plain text output format.
     #[default]
     Text,
+    /// JSON result encoding.
     Json,
+    /// OML result encoding.
     Oml,
 }
 
+/// Severity threshold filter for schema lint findings.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum, Default)]
 pub enum LintSeverity {
+    /// Include all informational findings and warnings.
     #[default]
     Info,
+    /// Report warnings only.
     Warning,
 }
 
+/// Arguments for the `format` command (canonicalize OML).
 #[derive(clap::Args, Debug)]
 pub struct FormatArgs {
     /// OML file, or - for stdin
     pub input: String,
+    /// Emit single-line compact OML output.
     #[arg(long)]
     pub compact: bool,
+    /// Not yet supported; accepted for CLI compatibility.
     #[arg(long)]
     pub arrays: bool,
+    /// Output destination file path (defaults to standard output if omitted).
     #[arg(short, long)]
     pub output: Option<String>,
+    /// Emit structured JSON output.
     #[arg(long)]
     pub json: bool,
 }
 
+/// Arguments for the `convert` command (convert document between formats).
 #[derive(clap::Args, Debug)]
 pub struct ConvertArgs {
+    /// Input document file path, or - for stdin.
     pub input: String,
+    /// Input document format codec.
     #[arg(long = "from", value_enum)]
     pub from: Fmt,
+    /// Output document format codec.
     #[arg(long = "to", value_enum)]
     pub to: Fmt,
+    /// Optional OSD schema file path for schema-directed materialization.
     #[arg(long)]
     pub schema: Option<String>,
+    /// Fail immediately if any lossy conversion adjustment occurs.
     #[arg(long)]
     pub strict: bool,
+    /// Emit write adjustment report to standard error.
     #[arg(long)]
     pub report: bool,
+    /// Format for report output (`text`, `json`, `oml`).
     #[arg(long = "result-format", value_enum, default_value_t = ResultFormat::Text)]
     pub result_format: ResultFormat,
+    /// Emit single-line compact OML output when converting to OML.
     #[arg(long)]
     pub compact: bool,
+    /// Not yet supported; accepted for CLI compatibility.
     #[arg(long)]
     pub arrays: bool,
+    /// Output destination file path (defaults to standard output if omitted).
     #[arg(short, long)]
     pub output: Option<String>,
+    /// Emit structured JSON output.
     #[arg(long)]
     pub json: bool,
 }
 
+/// Arguments for the `check` command (simulate write and report adjustments).
 #[derive(clap::Args, Debug)]
 pub struct CheckArgs {
+    /// Input document file path, or - for stdin.
     pub input: String,
+    /// Input document format codec.
     #[arg(long = "from", value_enum)]
     pub from: Fmt,
+    /// Target document format codec to simulate writing to.
     #[arg(long = "to", value_enum)]
     pub to: Fmt,
+    /// Fail with non-zero exit code if any adjustment would be made.
     #[arg(long)]
     pub strict: bool,
+    /// Format for adjustment report output (`text`, `json`, `oml`).
     #[arg(long = "result-format", value_enum, default_value_t = ResultFormat::Text)]
     pub result_format: ResultFormat,
+    /// Emit structured JSON output.
     #[arg(long)]
     pub json: bool,
 }
 
+/// Arguments for the `validate` command (validate document against a schema).
 #[derive(clap::Args, Debug)]
 pub struct ValidateArgs {
+    /// Input document file path, or - for stdin.
     pub input: String,
+    /// Input document format codec.
     #[arg(long = "from", value_enum)]
     pub from: Fmt,
+    /// OSD schema file path to validate against.
     #[arg(long)]
     pub schema: String,
+    /// Format for validation result output (`text`, `json`, `oml`).
     #[arg(long = "result-format", value_enum, default_value_t = ResultFormat::Text)]
     pub result_format: ResultFormat,
+    /// Emit structured JSON output.
     #[arg(long)]
     pub json: bool,
 }
 
+/// Arguments for the `infer` command (infer OSD schema from example documents).
 #[derive(clap::Args, Debug)]
 pub struct InferArgs {
+    /// One or more example document file paths.
     #[arg(required = true)]
     pub input: Vec<String>,
+    /// Input document format codec for all examples.
     #[arg(long = "from", value_enum)]
     pub from: Fmt,
+    /// Emit single-line compact OSD schema output.
     #[arg(long)]
     pub compact: bool,
+    /// Not yet supported; accepted for CLI compatibility.
     #[arg(long)]
     pub arrays: bool,
+    /// Open ambiguous polymorphic fields as `any` instead of failing.
     #[arg(long = "allow-any")]
     pub allow_any: bool,
+    /// Output destination file path (defaults to standard output if omitted).
     #[arg(short, long)]
     pub output: Option<String>,
+    /// Emit structured JSON output.
     #[arg(long)]
     pub json: bool,
 }
 
+/// Schema algebra and utility subcommands.
 #[derive(Subcommand, Debug)]
 pub enum SchemaCommand {
+    /// Canonicalize OSD schema syntax.
     Format(SchemaFormatArgs),
+    /// Normalize schema into minimal, canonical form (spec §6.8).
     Normalize(SchemaFormatArgs),
+    /// Prune unreachable records from schema environment (spec §6.7).
     Prune(SchemaPruneArgs),
+    /// Test whether schema accepts no non-empty documents.
     #[command(name = "is-empty")]
     IsEmpty(SchemaResultArgs),
+    /// Extract minimal subschema covering given labels (spec §6.10).
     Extract(SchemaExtractArgs),
+    /// Run structural lint checks over schema.
     Lint(SchemaLintArgs),
+    /// Check whether schema A is compatible with schema B (spec §6.6).
     #[command(name = "compatible-with")]
     CompatibleWith(SchemaPairArgs),
+    /// Check whether schema A and schema B are semantically equivalent (spec §6.9).
     Equivalent(SchemaPairArgs),
 }
 
+/// Arguments for schema formatting or normalization commands.
 #[derive(clap::Args, Debug)]
 pub struct SchemaFormatArgs {
+    /// OSD schema file path.
     pub schema_file: String,
+    /// Emit single-line compact OSD schema output.
     #[arg(long)]
     pub compact: bool,
+    /// Not yet supported; accepted for CLI compatibility.
     #[arg(long)]
     pub arrays: bool,
+    /// Output destination file path (defaults to standard output if omitted).
     #[arg(short, long)]
     pub output: Option<String>,
+    /// Emit structured JSON output.
     #[arg(long)]
     pub json: bool,
 }
 
+/// Arguments for the `schema prune` command.
 #[derive(clap::Args, Debug)]
 pub struct SchemaPruneArgs {
+    /// OSD schema file path.
     pub schema_file: String,
+    /// Emit single-line compact OSD schema output.
     #[arg(long)]
     pub compact: bool,
+    /// Output destination file path (defaults to standard output if omitted).
     #[arg(short, long)]
     pub output: Option<String>,
+    /// Emit structured JSON output.
     #[arg(long)]
     pub json: bool,
 }
 
+/// Arguments for schema boolean result commands.
 #[derive(clap::Args, Debug)]
 pub struct SchemaResultArgs {
+    /// OSD schema file path.
     pub schema_file: String,
+    /// Format for result output (`text`, `json`, `oml`).
     #[arg(long = "result-format", value_enum, default_value_t = ResultFormat::Text)]
     pub result_format: ResultFormat,
+    /// Emit structured JSON output.
     #[arg(long)]
     pub json: bool,
 }
 
+/// Arguments for the `schema extract` command.
 #[derive(clap::Args, Debug)]
 pub struct SchemaExtractArgs {
+    /// OSD schema file path.
     pub schema_file: String,
+    /// Comma-separated list of field labels to retain in extracted subschema.
     #[arg(long)]
     pub keep: String,
+    /// Emit single-line compact OSD schema output.
     #[arg(long)]
     pub compact: bool,
+    /// Output destination file path (defaults to standard output if omitted).
     #[arg(short, long)]
     pub output: Option<String>,
+    /// Emit structured JSON output.
     #[arg(long)]
     pub json: bool,
 }
 
+/// Arguments for the `schema lint` command.
 #[derive(clap::Args, Debug)]
 pub struct SchemaLintArgs {
+    /// OSD schema file path.
     pub schema_file: String,
+    /// Minimum severity threshold to report (`info` or `warning`).
     #[arg(long, value_enum, default_value_t = LintSeverity::Info)]
     pub severity: LintSeverity,
+    /// Emit structured JSON output.
     #[arg(long)]
     pub json: bool,
 }
 
+/// Arguments for pairwise schema comparison commands (`compatible-with`, `equivalent`).
 #[derive(clap::Args, Debug)]
 pub struct SchemaPairArgs {
+    /// First OSD schema file path.
     pub a: String,
+    /// Second OSD schema file path.
     pub b: String,
+    /// Format for comparison result output (`text`, `json`, `oml`).
     #[arg(long = "result-format", value_enum, default_value_t = ResultFormat::Text)]
     pub result_format: ResultFormat,
+    /// Emit structured JSON output.
     #[arg(long)]
     pub json: bool,
 }

--- a/omnist-cli/src/main.rs
+++ b/omnist-cli/src/main.rs
@@ -1,3 +1,5 @@
+//! Entrypoint binary for the `omnist` CLI.
+
 use clap::Parser;
 use omnist_cli::{Cli, run};
 

--- a/omnist/src/document.rs
+++ b/omnist/src/document.rs
@@ -44,7 +44,7 @@ pub const MAX_DEPTH: usize = 200;
 /// Maximum total node count for a single Document (matches the reference
 /// default in omnist-spec docs/02-document-model.md Sec2.4: a depth limit
 /// alone doesn't bound a shallow-but-enormous document, e.g. a million
-/// sibling edges at depth 1). Enforced once, in [`push`], the single arena
+/// sibling edges at depth 1). Enforced once, in `push`, the single arena
 /// choke point every construction path (`build_node`, `push_raw`) funnels
 /// through -- see omnist-rs#78: previously the only node-count guard in
 /// this crate was scoped narrowly to `formats::yaml`'s anchor/alias
@@ -81,13 +81,21 @@ pub struct NodeId(usize);
 /// replaces.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Scalar {
+    /// Null scalar value (spec §2.2).
     Null,
+    /// Boolean scalar value (spec §2.2).
     Bool(bool),
+    /// Arbitrary-precision integer scalar value (spec §2.2).
     Int(num_bigint::BigInt),
+    /// IEEE 754 floating point scalar value (spec §2.2).
     Float(f64),
+    /// UTF-8 string scalar value (spec §2.2).
     Str(String),
+    /// ISO 8601 calendar date (`YYYY-MM-DD`, spec §2.2).
     Date(String),
+    /// ISO 8601 clock time (`hh:mm:ss`, spec §2.2).
     Time(String),
+    /// ISO 8601 date-time (`YYYY-MM-DDThh:mm:ss`, spec §2.2).
     Datetime(String),
 }
 
@@ -111,18 +119,27 @@ impl fmt::Display for Scalar {
 /// Document model treats as data, not incidental — survives construction.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value {
+    /// Null value.
     Null,
+    /// Boolean value.
     Bool(bool),
+    /// Arbitrary-precision integer value.
     Int(num_bigint::BigInt),
+    /// Floating point value.
     Float(f64),
+    /// String value.
     Str(String),
     /// See [`Scalar::Date`]/[`Scalar::Time`]/[`Scalar::Datetime`] (issue
     /// #105) -- always already shape-validated and canonical, same
     /// invariant.
     Date(String),
+    /// ISO time value, matching [`Scalar::Time`].
     Time(String),
+    /// ISO datetime value, matching [`Scalar::Datetime`].
     Datetime(String),
+    /// Heterogeneous array value.
     Array(Vec<Value>),
+    /// Key-value object mapping.
     Object(IndexMap<String, Value>),
 }
 
@@ -520,18 +537,22 @@ impl Doc {
 pub struct Cursor<'a> {
     doc: &'a Doc,
     id: NodeId,
+    /// The path of this cursor within the document.
     pub path: String,
 }
 
 impl<'a> Cursor<'a> {
+    /// The internal [`NodeId`] of the referenced node.
     pub fn id(&self) -> NodeId {
         self.id
     }
 
+    /// Returns `true` iff this node is a leaf holding a scalar.
     pub fn is_leaf(&self) -> bool {
         matches!(self.doc.entry(self.id).data, NodeData::Leaf(_))
     }
 
+    /// Returns the scalar value if this is a leaf node, or `Err` if it is an internal edge node.
     pub fn value(&self) -> Result<&'a Scalar, DocumentError> {
         match &self.doc.entry(self.id).data {
             NodeData::Leaf(s) => Ok(s),
@@ -539,6 +560,7 @@ impl<'a> Cursor<'a> {
         }
     }
 
+    /// Returns the outgoing labeled edges if this is an internal node, or `Err` if it is a leaf.
     pub fn edges(&self) -> Result<Vec<(String, Cursor<'a>)>, DocumentError> {
         match &self.doc.entry(self.id).data {
             NodeData::Internal(edges) => {
@@ -598,6 +620,7 @@ impl<'a> Cursor<'a> {
         }
     }
 
+    /// Returns a deduplicated list of child edge labels.
     pub fn labels(&self) -> Vec<String> {
         let mut seen = std::collections::HashSet::new();
         let mut out = Vec::new();
@@ -611,6 +634,7 @@ impl<'a> Cursor<'a> {
         out
     }
 
+    /// Returns all child cursors along edges with the given `label`.
     pub fn get(&self, label: &str) -> Vec<Cursor<'a>> {
         self.edges()
             .into_iter()
@@ -620,6 +644,7 @@ impl<'a> Cursor<'a> {
             .collect()
     }
 
+    /// Returns the single child cursor for `label`, or `Err` if there are 0 or >1 matching edges.
     pub fn get_one(&self, label: &str) -> Result<Cursor<'a>, DocumentError> {
         let mut cs = self.get(label);
         if cs.len() != 1 {
@@ -631,6 +656,7 @@ impl<'a> Cursor<'a> {
         Ok(cs.remove(0))
     }
 
+    /// Returns the number of edges with the given `label`.
     pub fn count(&self, label: &str) -> usize {
         if let NodeData::Internal(edges) = &self.doc.entry(self.id).data {
             edges.iter().filter(|(lbl, _)| lbl == label).count()
@@ -661,21 +687,23 @@ impl<'a> Cursor<'a> {
 ///
 /// This is distinct from [`Value`]: `Value::Object`'s `IndexMap` can't hold
 /// a repeated key, so its "repeated label" convention (a `Value::Array`
-/// under one key, per [`child_specs`]) only ever expands to a *contiguous*
+/// under one key, per `child_specs`) only ever expands to a *contiguous*
 /// run of same-label edges. OML is the one format that must round-trip
 /// arbitrary interleaving losslessly (per its own docs: "no adjustment ever
 /// needed"), so its reader/writer (`crate::oml`) builds/walks a `Doc`
 /// through this type instead of going through `Value`.
 #[derive(Debug, Clone, PartialEq)]
 pub enum RawNode {
+    /// A leaf node holding a scalar value.
     Leaf(Scalar),
+    /// An internal node holding labeled outgoing edges.
     Edges(Vec<(String, RawNode)>),
 }
 
 impl Doc {
     /// Build a `Doc` from a [`RawNode`], preserving edge order and
     /// interleaving exactly. Depth-guarded via the same
-    /// [`check_write_depth`] every other construction path uses.
+    /// `check_write_depth` every other construction path uses.
     pub fn from_raw(root: RawNode) -> Result<Doc, DocumentError> {
         let mut arena = Vec::new();
         let root_id = push_raw(&mut arena, root, 0)?;

--- a/omnist/src/error.rs
+++ b/omnist/src/error.rs
@@ -19,11 +19,14 @@ use thiserror::Error;
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 #[error("{path}: {message}")]
 pub struct DocumentError {
+    /// The path inside the document where the error occurred.
     pub path: String,
+    /// Human-readable error description.
     pub message: String,
 }
 
 impl DocumentError {
+    /// Construct a new `DocumentError` at the given path.
     pub fn new(path: impl Into<String>, message: impl Into<String>) -> Self {
         Self {
             path: path.into(),
@@ -40,6 +43,7 @@ impl DocumentError {
 pub struct SchemaError(pub String);
 
 impl SchemaError {
+    /// Construct a new `SchemaError`.
     pub fn new(message: impl Into<String>) -> Self {
         Self(message.into())
     }
@@ -52,12 +56,16 @@ impl SchemaError {
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 #[error("line {line}, col {col}: {message}")]
 pub struct ParseError {
+    /// Line number where parsing failed (1-indexed).
     pub line: usize,
+    /// Column number where parsing failed (1-indexed).
     pub col: usize,
+    /// Human-readable parse failure description.
     pub message: String,
 }
 
 impl ParseError {
+    /// Construct a new `ParseError` with position coordinates.
     pub fn new(line: usize, col: usize, message: impl Into<String>) -> Self {
         Self {
             line,
@@ -81,6 +89,7 @@ impl ParseError {
 pub struct FormatError(pub String);
 
 impl FormatError {
+    /// Construct a new `FormatError` for an unknown format name.
     pub fn new(message: impl Into<String>) -> Self {
         Self(message.into())
     }
@@ -98,11 +107,14 @@ impl FormatError {
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 #[error("{message}")]
 pub struct WriteError {
+    /// Human-readable write failure description.
     pub message: String,
+    /// Optional accumulated `WriteReport` when written in strict mode.
     pub report: Option<crate::report::WriteReport>,
 }
 
 impl WriteError {
+    /// Construct a new `WriteError` with no report.
     pub fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
@@ -145,14 +157,17 @@ impl From<DocumentError> for WriteError {
 pub struct MaterializeError(pub crate::schema::ValidationResult);
 
 impl MaterializeError {
+    /// Construct a new `MaterializeError` wrapping a `ValidationResult`.
     pub fn new(result: crate::schema::ValidationResult) -> Self {
         Self(result)
     }
 
+    /// Access the inner `ValidationResult`.
     pub fn result(&self) -> &crate::schema::ValidationResult {
         &self.0
     }
 
+    /// Slice of all validation errors that caused materialization to fail.
     pub fn errors(&self) -> &[crate::schema::ValidationError] {
         self.0.errors()
     }
@@ -161,16 +176,22 @@ impl MaterializeError {
 /// Crate-wide top-level error, mirroring Python's `OmnistError` base class.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum OmnistError {
+    /// An invalid Document operation or structure.
     #[error(transparent)]
     Document(#[from] DocumentError),
+    /// An invalid Schema definition.
     #[error(transparent)]
     Schema(#[from] SchemaError),
+    /// Document failed to conform to target Schema during materialization.
     #[error(transparent)]
     Materialize(#[from] MaterializeError),
+    /// Source text syntax error with line/column coordinates.
     #[error(transparent)]
     Parse(#[from] ParseError),
+    /// Document could not be written to destination format.
     #[error(transparent)]
     Write(#[from] WriteError),
+    /// Format name not recognized in registry.
     #[error(transparent)]
     Format(#[from] FormatError),
 }

--- a/omnist/src/formats/json.rs
+++ b/omnist/src/formats/json.rs
@@ -5,7 +5,7 @@
 //!
 //! [`read_json`] parses JSON text into a [`crate::document::Value`], then
 //! builds a [`Doc`] via [`Doc::of`] -- which calls
-//! [`crate::document::check_write_depth`] internally (see `document.rs`).
+//! `crate::document::check_write_depth` internally (see `document.rs`).
 //! [`write_json`]/[`check_json`] walk an already-built `Doc` (via
 //! `Doc::to_grouped`/`Doc::root`), whose every node was depth-checked at
 //! construction time -- there is nothing left to re-guard on the way out,
@@ -106,7 +106,7 @@ pub fn write_json(
 
 /// Report what writing JSON would adjust, without producing output.
 ///
-/// Walks every leaf via the shared [`crate::formats::visit_grouped`] walker
+/// Walks every leaf via the shared `crate::formats::visit_grouped` walker
 /// (issue #51) rather than a bespoke `collect_leaves` pass; the path
 /// `String` that ends up in a [`crate::report::Adjustment`] is only built
 /// for the (rare) NaN/Infinity leaf -- not for every leaf up front (issue

--- a/omnist/src/formats/toml.rs
+++ b/omnist/src/formats/toml.rs
@@ -17,11 +17,11 @@
 //! Everything omnist-specific stays hand-written Rust, not delegated to the
 //! crate:
 //!
-//! * **Null-adjustment** ([`strip_nulls`]) -- TOML has no `null` at all;
+//! * **Null-adjustment** (`strip_nulls`) -- TOML has no `null` at all;
 //!   dropping a null-valued field/array-item and recording it via
 //!   [`crate::report::WriteReport`] is this module's own logic (see
 //!   "No null" below).
-//! * **Temporal canonicalization** ([`format_datetime`]) -- turning
+//! * **Temporal canonicalization** (`format_datetime`) -- turning
 //!   `toml_edit`'s parsed `Date`/`Time`/`Datetime` structs into this port's
 //!   canonical ISO-string spelling (see "Native temporal types" below).
 //! * **Integer digit cap** -- `toml_edit` itself rejects any integer
@@ -85,7 +85,7 @@
 //! hex/octal/binary.
 //!
 //! This port does **not** replicate that decimal/non-decimal split: every
-//! radix goes through the same [`toml_overflow_error`] recovery and the same
+//! radix goes through the same `toml_overflow_error` recovery and the same
 //! 4300-digit cap, because `toml_edit` itself enforces a strict `i64` range
 //! at parse time regardless of radix (see below) -- there is no path in this
 //! implementation for an oversized hex/octal/binary literal to reach
@@ -106,7 +106,7 @@
 //! original digit run), which is *stricter* than Python's real behavior for
 //! anything between 20 and 4300 digits. To keep this port's observable
 //! integer-literal error behavior matching Python's (not `toml_edit`'s
-//! internal, incidentally-stricter parse limit), [`toml_overflow_error`]
+//! internal, incidentally-stricter parse limit), `toml_overflow_error`
 //! recovers the raw literal text from the failed parse's byte span
 //! (`TomlError::span`) and re-derives the digit count itself, producing the
 //! same two-tier message `json.rs`/`yaml.rs` give ("exceeds the 4300-digit
@@ -127,14 +127,14 @@
 //! `normalize_timestamp` must (YAML's own crate does no such validation).
 //!
 //! [`crate::document::Scalar`] has real `Date`/`Time`/`Datetime` variants
-//! (issue #105) -- [`toml_value_to_value`] reads `toml_edit`'s own already
+//! (issue #105) -- `toml_value_to_value` reads `toml_edit`'s own already
 //! fully-validated `Datetime` struct's `date`/`time` presence to construct
 //! the right one directly (real provenance, not a shape guess), and
-//! [`format_datetime`] renders the canonical ISO spelling either way:
+//! `format_datetime` renders the canonical ISO spelling either way:
 //! zero-padded, `T`-joined, a bare `Z` offset normalized to `+00:00`
 //! (matching `yaml.rs`'s identical normalization -- this port's canonical
 //! temporal strings never contain a literal `Z`, only a numeric offset,
-//! which is what [`crate::schema::is_iso_datetime`]'s regex expects).
+//! which is what `crate::schema::is_iso_datetime`'s regex expects).
 //! Fractional seconds beyond microsecond precision are **truncated, not
 //! rounded**, to six digits -- live-confirmed against `tomllib`:
 //! `00:32:00.9999999` (7 nines) reads as `datetime.time(0, 32, 0, 999999)`
@@ -170,8 +170,8 @@
 //!
 //! [`read_toml`] parses TOML text into a [`crate::document::Value`], then
 //! builds a [`Doc`] via [`Doc::of`] -- which calls
-//! [`crate::document::check_write_depth`] internally (see `document.rs`).
-//! [`write_toml`]/[`check_toml`]/[`strip_nulls`] walk an already-built
+//! `crate::document::check_write_depth` internally (see `document.rs`).
+//! [`write_toml`]/[`check_toml`]/`strip_nulls` walk an already-built
 //! `Doc` (via `Doc::to_grouped`), whose every node was depth-checked at
 //! construction time -- exactly `json.rs`'s reasoning (not `yaml.rs`'s,
 //! which pre-processes raw structures *before* `Doc::of` ever runs) --

--- a/omnist/src/formats/xml.rs
+++ b/omnist/src/formats/xml.rs
@@ -46,7 +46,7 @@
 //! into Clark notation (`{uri}local`) and `_local()` strips the `{uri}`
 //! prefix to get the bare local name. `quick_xml` (used here in
 //! non-namespace-aware mode) does not perform namespace URI resolution;
-//! [`local_name`] instead strips a lexical `prefix:` (up to the last `:`)
+//! `local_name` instead strips a lexical `prefix:` (up to the last `:`)
 //! from a tag, which coincides with Python's behavior for the common case
 //! (a declared, in-scope prefix) but does not resolve prefixes through
 //! `xmlns` declarations the way real namespace-aware processing would.
@@ -86,8 +86,8 @@
 //! `omnist-ts#36`: `writeXml`'s `xmlSanitize` used a **non-global** regex,
 //! so only the *first* XML-illegal character in a string was replaced,
 //! emitting malformed XML for any string with more than one. This module's
-//! [`xml_sanitize`] does not use a substitution regex at all -- it maps
-//! every `char` of the input through [`is_xml_illegal_char`] individually
+//! `xml_sanitize` does not use a substitution regex at all -- it maps
+//! every `char` of the input through `is_xml_illegal_char` individually
 //! (`str::chars().map(...).collect()`), so there is no "first occurrence
 //! only" bug class available in the first place. See
 //! `sanitizes_every_illegal_character_not_just_the_first` for the
@@ -101,12 +101,12 @@
 //! shared `_MAX_DEPTH` constant rather than routing through
 //! `document.py`'s write-side guard) -- this is necessary because,
 //! without it, an adversarially deep input could blow the native Rust call
-//! stack in [`parse_content`]'s own recursion *before* [`Doc::from_raw`]
+//! stack in `parse_content`'s own recursion *before* [`Doc::from_raw`]
 //! ever gets a chance to reject it via
-//! [`crate::document::check_write_depth`]. [`Doc::from_raw`] then applies
+//! `crate::document::check_write_depth`. [`Doc::from_raw`] then applies
 //! its own guard a second time when building the final `Doc` -- a harmless,
 //! redundant confirmation of the same limit, not a second copy of the
-//! guard's logic (it calls the crate's one shared [`check_write_depth`]).
+//! guard's logic (it calls the crate's one shared `check_write_depth`).
 //! [`write_xml`]/[`check_xml`] do not re-guard on the way out, matching
 //! `json.rs`'s reasoning: they walk an already-`Doc`-validated
 //! [`RawNode`], so there is nothing left to guard.

--- a/omnist/src/formats/yaml.rs
+++ b/omnist/src/formats/yaml.rs
@@ -13,7 +13,7 @@
 //! surface for little benefit. Everything omnist-specific is still hand-written
 //! Rust code in this module, not delegated to the crate:
 //!
-//! * **Scalar-tag resolution** ([`resolve_plain_scalar`]) -- `yaml_rust2`'s own
+//! * **Scalar-tag resolution** (`resolve_plain_scalar`) -- `yaml_rust2`'s own
 //!   built-in resolver (`Yaml::from_str`) only recognizes `true`/`false`
 //!   (YAML 1.2 core schema) for booleans. Live-checked against Python's
 //!   `yaml.safe_load` (PyYAML, which this project's Python reference wraps):
@@ -27,7 +27,7 @@
 //!   timestamp against the raw scalar text + style (quoted scalars are never
 //!   auto-typed, matching PyYAML, which only applies implicit resolution to
 //!   plain-style scalars).
-//! * **Merge-key (`<<`) handling** ([`expand_merge_keys`]) -- `yaml_rust2` has
+//! * **Merge-key (`<<`) handling** (`expand_merge_keys`) -- `yaml_rust2` has
 //!   no built-in merge-key support at all (confirmed by reading its source);
 //!   this module implements the YAML merge-key spec directly: an unquoted
 //!   `<<` key's value must be a mapping or a sequence of mappings, merged in
@@ -36,16 +36,16 @@
 //!   module's test suite pins.
 //! * **Depth guard, temporal shape-check, integer digit cap** -- reused from
 //!   [`crate::document`]/[`crate::schema`]/this crate's established
-//!   4300-digit-cap pattern (see [`MAX_INT_DIGITS`]), not reimplemented.
+//!   4300-digit-cap pattern (see `MAX_INT_DIGITS`), not reimplemented.
 //!
 //! ## Depth guard reuse
 //!
 //! Same reasoning as `json.rs`: [`read_yaml`] builds a [`Doc`] via [`Doc::of`],
-//! which calls [`crate::document::check_write_depth`] internally. The merge-
+//! which calls `crate::document::check_write_depth` internally. The merge-
 //! key/alias-resolution pass that runs *before* `Doc::of` also depth-guards
 //! itself (an alias can reference an already-deep subtree, and merging can
 //! grow a mapping before the Document-model depth check ever sees it), reusing
-//! the same [`crate::document::check_write_depth`] guard rather than adding a
+//! the same `crate::document::check_write_depth` guard rather than adding a
 //! second copy. [`write_yaml`]/[`check_yaml`] walk an already-built `Doc` (via
 //! `to_grouped`), whose nodes are already depth-checked, so there is nothing
 //! left to re-guard on the way out.
@@ -59,7 +59,7 @@
 //! time, single-digit month/day, a bare `Z` suffix, no zero-padding) --
 //! Python's PyYAML normalizes any such spelling to a `datetime.date`/
 //! `datetime.datetime` object and then (elsewhere in the pipeline) back to a
-//! canonical ISO string. [`normalize_timestamp`] reproduces that
+//! canonical ISO string. `normalize_timestamp` reproduces that
 //! normalization for the timestamp grammar PyYAML's own
 //! `tag:yaml.org,2002:timestamp` resolver accepts, so a YAML value like
 //! `2001-12-14 21:59:43.10 -5` round-trips to the same canonical
@@ -69,7 +69,7 @@
 //! `2024-02-30`) is a [`ParseError`], not a silent string fallback --
 //! live-confirmed: PyYAML's construction step raises `ValueError` there,
 //! which fails the whole document. Calendar/clock validity itself reuses
-//! [`crate::schema::valid_ymd`]/[`crate::schema::valid_hms`] rather than a
+//! `crate::schema::valid_ymd`/`crate::schema::valid_hms` rather than a
 //! second copy of that logic, even though the *shape* regex is necessarily
 //! separate (looser than `schema.rs`'s).
 //!
@@ -156,7 +156,7 @@ fn count_nodes(node: &Raw) -> usize {
 // ============================================================== Reader
 
 /// The raw shape `yaml_rust2`'s event stream is rebuilt into: a scalar with
-/// its original text and style (style is what [`resolve_plain_scalar`] and
+/// its original text and style (style is what `resolve_plain_scalar` and
 /// merge-key detection both need, and what `yaml_rust2`'s own `Yaml` enum
 /// throws away by pre-resolving plain scalars with its own, PyYAML-incompatible
 /// rules -- see this module's doc comment), or an ordered sequence/mapping.
@@ -829,8 +829,8 @@ fn parse_float_literal(text: &str) -> Result<Value, ParseError> {
 /// `datetime.datetime`'s constructor on the captured fields, which raises a
 /// `ValueError` PyYAML doesn't catch, so the *whole document* fails to parse
 /// rather than quietly typing the value as a string. Calendar-date validity
-/// (leap years, per-month day counts) reuses [`crate::schema::valid_ymd`]/
-/// [`crate::schema::valid_hms`] rather than a second copy of that logic.
+/// (leap years, per-month day counts) reuses `crate::schema::valid_ymd`/
+/// `crate::schema::valid_hms` rather than a second copy of that logic.
 fn normalize_timestamp(text: &str) -> Result<Option<String>, ParseError> {
     static RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
         regex::Regex::new(

--- a/omnist/src/infer.rs
+++ b/omnist/src/infer.rs
@@ -65,7 +65,9 @@ use crate::schema::{Field, FieldType, Record, Ref, Scalar, ScalarKind, Schema};
 /// `AnyFallback` dataclass.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AnyFallback {
+    /// The path location of the field opened as `any`.
     pub location: String,
+    /// Description of why the field fell back to `any`.
     pub reason: String,
 }
 

--- a/omnist/src/lib.rs
+++ b/omnist/src/lib.rs
@@ -1,3 +1,18 @@
+//! # omnist
+//!
+//! Rust implementation of the Omnist data-interchange specification.
+//!
+//! Omnist provides a single canonical, lossless data model ([`document::Doc`])
+//! across five supported formats (JSON, YAML, TOML, XML, and OML), paired with an
+//! algebraic schema language (OSD, [`schema::Schema`]) for schema validation,
+//! type inference, normalization, subschema extraction, and compatibility checking.
+//!
+//! Treat the vendored `omnist-spec` specification as the normative source of
+//! truth for all data model rules, format mappings, and schema algebra.
+
+#![deny(missing_docs)]
+#![warn(rustdoc::all)]
+
 pub mod document;
 pub mod error;
 pub mod formats;
@@ -18,6 +33,7 @@ pub use materialize::materialize;
 pub use registry::{Format, formats, get_format, register_format};
 pub use report::{Adjustment, Severity, WriteReport};
 
+/// The version of the `omnist` crate, matching Cargo.toml.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg(test)]

--- a/omnist/src/materialize.rs
+++ b/omnist/src/materialize.rs
@@ -26,8 +26,7 @@
 //! "upgrading" a temporal field here can only ever mean "is this string
 //! shaped like, and a semantically valid, ISO date/time/datetime" -- it
 //! stays a `Str` either way. That check is exactly
-//! [`crate::schema::is_iso_date`]/[`is_iso_time`][crate::schema::is_iso_time]/
-//! [`is_iso_datetime`][crate::schema::is_iso_datetime], reused here rather
+//! `crate::schema::is_iso_date`/`is_iso_time`/`is_iso_datetime`, reused here rather
 //! than reimplemented -- the exact "validate and materialize must share
 //! one strict parser" pitfall the porting playbook calls out, and the same
 //! functions [`crate::schema::matches_kind`] already uses.

--- a/omnist/src/oml.rs
+++ b/omnist/src/oml.rs
@@ -15,11 +15,11 @@
 //!
 //! ## Layout (issue #53)
 //!
-//! [`scanner`] tokenizes source text, [`parser`] consumes those tokens into
-//! a [`RawNode`], and [`writer`] renders a `RawNode` back to OML-Core
+//! `scanner` tokenizes source text, `parser` consumes those tokens into
+//! a [`RawNode`], and `writer` renders a `RawNode` back to OML-Core
 //! source. This top-level module keeps the module doc overview, the four
 //! `pub fn`s ([`read_oml`], [`write_oml`], [`write_oml_compact`],
-//! [`check_oml`]), and the [`Codec`](crate::formats::Codec) adapter --
+//! [`check_oml`]), and the `Codec` adapter --
 //! nothing about `crate::oml::*` paths changed by the split.
 //!
 //! ## Architecture (per issue #1/#10, "architecture freedom")
@@ -50,7 +50,7 @@
 //! exactly like Python's `write_oml(node)`, which accepts any hand-built
 //! canonical node, not necessarily one that passed through a depth-checked
 //! builder. So the writer calls the shared
-//! [`crate::document::check_write_depth`] guard itself, at every nesting
+//! `crate::document::check_write_depth` guard itself, at every nesting
 //! level, rather than assuming its input already got checked somewhere
 //! upstream -- the exact bug class omnist-ts#37/#70 were: a writer (or a
 //! second writer) that skipped this because *some* builder happened to

--- a/omnist/src/ops/lint.rs
+++ b/omnist/src/ops/lint.rs
@@ -39,9 +39,13 @@ use super::prune::satisfiable_set;
 /// `message` is a human-readable, actionable description.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LintFinding {
+    /// Stable machine-readable diagnostic code.
     pub code: &'static str,
+    /// Severity level (`"warning"` or `"info"`).
     pub severity: &'static str,
+    /// Schema location (e.g. record or field name) of the finding.
     pub location: String,
+    /// Human-readable explanation of the finding.
     pub message: String,
 }
 

--- a/omnist/src/ops/signature.rs
+++ b/omnist/src/ops/signature.rs
@@ -17,8 +17,11 @@ use crate::schema::{FieldType, Record, ScalarKind};
 /// comment), or `Any`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ShapeKey {
+    /// A scalar shape with kind and nullability.
     Scalar(ScalarKind, bool),
+    /// A reference to a record in the environment.
     Ref,
+    /// An `any` type slot.
     Any,
 }
 

--- a/omnist/src/registry.rs
+++ b/omnist/src/registry.rs
@@ -12,8 +12,7 @@
 //! `omnist-cli` `Fmt` enum's approach, or a `match` over the five builtins)
 //! can't express "register a new format at runtime under an arbitrary
 //! name," so this module reaches for the same dynamic-dispatch idiom Rust
-//! uses in place of Python's first-class functions: `Arc<dyn Fn(...) + Send
-//! + Sync>` trait objects, keyed by name in an `IndexMap` behind an
+//! uses in place of Python's first-class functions: `Arc<dyn Fn(...) + Send + Sync>` trait objects, keyed by name in an `IndexMap` behind an
 //! `RwLock` inside a `OnceLock` (this crate's only piece of global mutable
 //! state). `Arc` (not `Box`) so [`get_format`] can hand back an owned,
 //! independently usable [`Format`] without holding the registry lock across
@@ -77,9 +76,13 @@ pub type CheckFn = dyn Fn(&Doc) -> WriteReport + Send + Sync;
 /// `test_plugin_without_check_raises_on_check_format`.
 #[derive(Clone)]
 pub struct Format {
+    /// Registered format name (e.g. `"json"`).
     pub name: String,
+    /// Text to `Doc` reader callable.
     pub read: Arc<ReadFn>,
+    /// `Doc` to text writer callable.
     pub write: Arc<WriteFn>,
+    /// Optional `Doc` write simulation callable.
     pub check: Option<Arc<CheckFn>>,
 }
 
@@ -148,7 +151,7 @@ pub fn register_format(fmt: Format) {
 /// mirrors Python's `get_format`'s `f"unknown format {name!r}; registered:
 /// {known}"` message. Unlike Python, there is no `"(none)"` fallback for an
 /// empty registry: [`register_format`] only ever adds entries and the five
-/// builtins always register on first access (see [`builtins`]), so the
+/// builtins always register on first access (see `builtins`), so the
 /// registry can never actually be empty here -- an untestable dead branch
 /// for that case was deliberately not carried over (playbook's "unreachable
 /// dead code" gap classification), rather than kept under an unreachable

--- a/omnist/src/report.rs
+++ b/omnist/src/report.rs
@@ -57,7 +57,9 @@ pub(crate) fn push_child_path(buf: &mut String, label: &str, index: usize) {
 /// distinguishes them.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Severity {
+    /// Recoverable adjustment (e.g. date written as string).
     Warning,
+    /// Lossy or corrupting adjustment (e.g. NaN written as null).
     Error,
 }
 
@@ -71,6 +73,7 @@ pub struct Adjustment {
     pub code: String,
     /// Human-readable sentence.
     pub message: String,
+    /// The severity level of this adjustment.
     pub severity: Severity,
 }
 
@@ -83,6 +86,7 @@ pub struct WriteReport {
 }
 
 impl WriteReport {
+    /// Create an empty `WriteReport`.
     pub fn new() -> Self {
         Self::default()
     }
@@ -130,14 +134,17 @@ impl WriteReport {
         self.errors().is_empty()
     }
 
+    /// Returns `true` iff no adjustments have been recorded.
     pub fn is_empty(&self) -> bool {
         self.adjustments.is_empty()
     }
 
+    /// Total number of recorded adjustments.
     pub fn len(&self) -> usize {
         self.adjustments.len()
     }
 
+    /// Iterator over all recorded adjustments.
     pub fn iter(&self) -> std::slice::Iter<'_, Adjustment> {
         self.adjustments.iter()
     }

--- a/omnist/src/schema.rs
+++ b/omnist/src/schema.rs
@@ -27,7 +27,7 @@
 //!
 //! ## Temporal shape-check
 //!
-//! [`is_iso_date`], [`is_iso_time`], and [`is_iso_datetime`] are the single
+//! `is_iso_date`, `is_iso_time`, and `is_iso_datetime` are the single
 //! source of truth for "is this string shaped like (and a semantically
 //! valid) date/time/datetime," `pub(crate)` so a future `materialize`/
 //! `infer` module can reuse the exact same check instead of writing a
@@ -247,15 +247,22 @@ fn canonicalize_time_captures(caps: &regex::Captures<'_>) -> String {
 // Scalar
 // ---------------------------------------------------------------------------
 
-/// One of the seven predefined value kinds a [`Scalar`] can hold.
+/// One of the seven predefined value kinds a [`Scalar`] can hold (spec §2.2).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ScalarKind {
+    /// The `string` scalar kind (UTF-8 character string, spec §2.2).
     String,
+    /// The `integer` scalar kind (arbitrary-precision integer, spec §2.2).
     Integer,
+    /// The `number` scalar kind (IEEE 754 double precision float or integer, spec §2.2).
     Number,
+    /// The `boolean` scalar kind (`true` or `false`, spec §2.2).
     Boolean,
+    /// The `date` scalar kind (ISO 8601 calendar date `YYYY-MM-DD`, spec §2.2).
     Date,
+    /// The `time` scalar kind (ISO 8601 clock time `hh:mm:ss`, spec §2.2).
     Time,
+    /// The `datetime` scalar kind (ISO 8601 combined date-time, spec §2.2).
     Datetime,
 }
 
@@ -271,6 +278,7 @@ impl ScalarKind {
         ScalarKind::Datetime,
     ];
 
+    /// Return the canonical OSD name of this scalar kind (`"string"`, `"integer"`, etc., spec §2.2).
     pub fn as_str(&self) -> &'static str {
         match self {
             ScalarKind::String => "string",
@@ -306,6 +314,7 @@ pub struct Scalar {
 }
 
 impl Scalar {
+    /// Construct a new `Scalar` with the given [`ScalarKind`] and nullability flag (spec §2.2, §3).
     pub const fn new(kind: ScalarKind, nullable: bool) -> Self {
         Scalar { kind, nullable }
     }
@@ -316,10 +325,12 @@ impl Scalar {
         Ok(Scalar::new(ScalarKind::parse(name)?, nullable))
     }
 
+    /// The value kind of this scalar.
     pub fn kind(&self) -> ScalarKind {
         self.kind
     }
 
+    /// Whether this scalar accepts `null` values (the `?` suffix in OSD syntax).
     pub fn is_nullable(&self) -> bool {
         self.nullable
     }
@@ -336,12 +347,19 @@ impl std::fmt::Display for Scalar {
     }
 }
 
+/// Non-nullable `string` scalar constant (spec §2.2, §3).
 pub const STRING: Scalar = Scalar::new(ScalarKind::String, false);
+/// Non-nullable `integer` scalar constant (spec §2.2, §3).
 pub const INTEGER: Scalar = Scalar::new(ScalarKind::Integer, false);
+/// Non-nullable `number` scalar constant (spec §2.2, §3).
 pub const NUMBER: Scalar = Scalar::new(ScalarKind::Number, false);
+/// Non-nullable `boolean` scalar constant (spec §2.2, §3).
 pub const BOOLEAN: Scalar = Scalar::new(ScalarKind::Boolean, false);
+/// Non-nullable `date` scalar constant (spec §2.2, §3).
 pub const DATE: Scalar = Scalar::new(ScalarKind::Date, false);
+/// Non-nullable `time` scalar constant (spec §2.2, §3).
 pub const TIME: Scalar = Scalar::new(ScalarKind::Time, false);
+/// Non-nullable `datetime` scalar constant (spec §2.2, §3).
 pub const DATETIME: Scalar = Scalar::new(ScalarKind::Datetime, false);
 
 /// A copy of `scalar` that also accepts `null` (the `?` form).
@@ -356,10 +374,12 @@ pub fn nullable(scalar: Scalar) -> Scalar {
 /// A reference to a named record in a [`Schema`]'s environment.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Ref {
+    /// The name of the target record in the schema environment.
     pub name: String,
 }
 
 impl Ref {
+    /// Construct a new `Ref` pointing to a named record.
     pub fn new(name: impl Into<String>) -> Self {
         Ref { name: name.into() }
     }
@@ -379,8 +399,11 @@ impl std::fmt::Display for Ref {
 /// being folded into either.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum FieldType {
+    /// A scalar type slot.
     Scalar(Scalar),
+    /// A reference to a named record in the schema environment.
     Ref(Ref),
+    /// An `any` type slot accepting any legal document value without validation.
     Any,
 }
 
@@ -404,13 +427,18 @@ impl From<Ref> for FieldType {
 /// occurring `[min, max]` times (`max = None` is unbounded).
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Field {
+    /// The label of the field.
     pub label: String,
+    /// The field's type.
     pub ty: FieldType,
+    /// Minimum occurrence count required.
     pub min: usize,
+    /// Maximum occurrence count allowed (`None` indicates unbounded cardinality).
     pub max: Option<usize>,
 }
 
 impl Field {
+    /// Construct a new `Field` with label, type, and cardinality bounds `[min, max]` (spec §3, §3.3).
     pub fn new(
         label: impl Into<String>,
         ty: impl Into<FieldType>,
@@ -441,6 +469,7 @@ impl Field {
         Field::new(label, ty, 1, Some(1))
     }
 
+    /// Human-readable description of this field's cardinality bounds.
     pub fn cardinality_str(&self) -> String {
         match (self.min, self.max) {
             (1, Some(1)) => "exactly 1".to_string(),
@@ -502,10 +531,12 @@ impl Record {
         Ok(Record { fields, by_label })
     }
 
+    /// The fields of this record in declaration order.
     pub fn fields(&self) -> &[Field] {
         &self.fields
     }
 
+    /// Look up a field by its label.
     pub fn field(&self, label: &str) -> Option<&Field> {
         self.by_label.get(label).map(|&i| &self.fields[i])
     }
@@ -519,14 +550,20 @@ impl Record {
 /// reference's `Error.code` values.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ErrorCode {
+    /// A field was found in the document that is not defined on the record.
     UnexpectedField,
+    /// The number of field occurrences fell outside `[min, max]`.
     Cardinality,
+    /// A value did not match the expected type.
     TypeMismatch,
+    /// A `null` value was encountered for a non-nullable field.
     NullNotAllowed,
+    /// A record was encountered where a scalar was expected, or vice-versa.
     ShapeMismatch,
 }
 
 impl ErrorCode {
+    /// Stable error code string matching `omnist-spec` §5.
     pub fn as_str(&self) -> &'static str {
         match self {
             ErrorCode::UnexpectedField => "unexpected-field",
@@ -541,8 +578,11 @@ impl ErrorCode {
 /// One validation failure: where, what, and a stable code.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ValidationError {
+    /// The path where the validation error occurred.
     pub path: String,
+    /// Human-readable error description.
     pub message: String,
+    /// Stable machine-readable error code.
     pub code: ErrorCode,
 }
 
@@ -554,14 +594,17 @@ pub struct ValidationResult {
 }
 
 impl ValidationResult {
+    /// Create an empty validation result.
     pub fn new() -> Self {
         ValidationResult::default()
     }
 
+    /// Returns `true` if there are no validation errors.
     pub fn ok(&self) -> bool {
         self.errors.is_empty()
     }
 
+    /// Slice of all validation errors collected during validation.
     pub fn errors(&self) -> &[ValidationError] {
         &self.errors
     }
@@ -615,7 +658,7 @@ impl std::fmt::Display for ValidationResult {
 /// corpus, `omnist/tests/parity.rs`, before merge): `Date`/`Time`/
 /// `Datetime` match **either** the real `document::Scalar` variant **or**
 /// a plain `Str` whose text independently shape-validates
-/// ([`is_iso_date`]/[`is_iso_time`]/[`is_iso_datetime`]) -- Python's own
+/// (`is_iso_date`/`is_iso_time`/`is_iso_datetime`) -- Python's own
 /// `matches_kind` does exactly this hybrid check (a real `datetime.date`
 /// object, or a string `_is_iso`-shaped for one), so a JSON- or
 /// XML-sourced document with a date-shaped string field genuinely
@@ -669,9 +712,13 @@ pub(crate) fn value_kind_name(v: &DocScalar) -> &'static str {
 // ---------------------------------------------------------------------------
 
 /// A resolved field type: a record (via a `Ref`), a bare `Scalar`, or `Any`.
+/// A resolved field type: a record (via a `Ref`), a bare `Scalar`, or `Any`.
 pub enum Resolved<'a> {
+    /// A resolved record in the schema environment.
     Record(&'a Record),
+    /// A resolved scalar type.
     Scalar(Scalar),
+    /// A resolved `any` type.
     Any,
 }
 
@@ -717,10 +764,12 @@ impl Schema {
         Ok(())
     }
 
+    /// Reference to the root record of the schema.
     pub fn root(&self) -> &Ref {
         &self.root
     }
 
+    /// Map of named records comprising the schema environment.
     pub fn env(&self) -> &IndexMap<String, Record> {
         &self.env
     }
@@ -779,6 +828,7 @@ impl Schema {
         res
     }
 
+    /// Returns `true` iff `cursor` conforms to this schema with 0 errors (spec §5).
     pub fn accepts(&self, cursor: &document::Cursor<'_>) -> bool {
         self.validate(cursor).ok()
     }

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -5,6 +5,7 @@
 - [Quickstart](./quickstart.md)
 - [User guide](./guide.md)
 - [API reference](./api.md)
+  - [Rustdoc (cargo doc)](./api/omnist/index.html)
 - [CLI reference](./cli.md)
 - [Formats](./formats/index.md)
   - [JSON](./formats/json.md)

--- a/src/api.md
+++ b/src/api.md
@@ -1,5 +1,7 @@
 # API reference
 
+> **Rustdoc API Reference**: Generated rustdoc documentation for all workspace crates is available at [**`api/omnist/index.html`**](api/omnist/index.html).
+
 This page enumerates the `omnist` crate's public surface: every exported
 type, function, and method, grouped by area. Signatures are copied from the
 current source (`omnist/src/*.rs`); doc comments are condensed, not

--- a/src/api/omnist/index.html
+++ b/src/api/omnist/index.html
@@ -1,0 +1,1 @@
+# Rustdoc (cargo doc)


### PR DESCRIPTION
## Summary
Closes #110.

- Generated rustdoc API documentation alongside mdBook in .github/workflows/book.yml deployed to ook/api/.
- Added navigation link in src/SUMMARY.md and reference links in src/api.md and docs/api.md.
- Closed all missing doc-comment gaps across omnist::schema, omnist::document, omnist::error, omnist::infer, omnist::ops::lint, omnist::ops::signature, omnist::registry, omnist::report, and omnist-cli.
- Enabled #![deny(missing_docs)] and #![warn(rustdoc::all)] across workspace crates.
- Fixed all unresolved and private intra-doc links.

## Verification Results
- cargo doc --no-deps --workspace: exit 0, 0 errors
- cargo build --workspace: exit 0, 0 warnings with #![deny(missing_docs)]
- cargo fmt --all -- --check: exit 0
- cargo clippy --workspace --all-targets -- -D warnings: exit 0, 0 warnings
- cargo test --workspace: exit 0, 765 tests passed
- cargo llvm-cov --workspace: exit 0, 11395/11396 lines (99.99%)
- mdbook build + rustdoc copy to ook/api/: verified
- check-doc-examples --base-ref main: exit 0
- Conformance runners: self-test (10/10), runner (19/19), vector_runner (130 passed, 0 failed, 22 skipped)
- Independent verification review: Approved
