### PR TITLE
test: cover Scalar Date/Time/Datetime Display formatting (closes #112)

### DIFF
--- a/omnist/src/tests.rs
+++ b/omnist/src/tests.rs
@@ -14,6 +14,17 @@ fn version_matches_cargo_toml() {
     assert_eq!(VERSION, "0.1.3-alpha");
 }
 
+#[test]
+fn scalar_display_covers_all_temporal_variants() {
+    use document::Scalar;
+    assert_eq!(Scalar::Date("2024-01-01".into()).to_string(), "2024-01-01");
+    assert_eq!(Scalar::Time("12:30:00".into()).to_string(), "12:30:00");
+    assert_eq!(
+        Scalar::Datetime("2024-01-01T12:30:00".into()).to_string(),
+        "2024-01-01T12:30:00"
+    );
+}
+
 // -- cross-op characterization: infer + materialize (issue #14) ------------
 //
 // An inferred schema is drafted *from* a set of samples, so it should always


### PR DESCRIPTION
## Summary
Closes #112.

Adds `scalar_display_covers_all_temporal_variants` to `omnist/src/tests.rs` to exercise `<Scalar as fmt::Display>::fmt` (`to_string()`) on the `Date`, `Time`, and `Datetime` variants introduced by `c0e7be0`.

Strictly modified only test files (`omnist/src/tests.rs`); zero production source files touched.

## Coverage Output
```
TOTAL  21866  119  99.46%  1243  0  100.00%  11395  0  100.00%  0  0  -
```
`cargo llvm-cov clean --workspace && cargo llvm-cov --workspace --fail-under-lines 100` exits with code 0.

## Verification Results
- `cargo llvm-cov clean --workspace && cargo llvm-cov --workspace --fail-under-lines 100`: exit 0 (100.00% line coverage)
- `cargo fmt --all -- --check`: exit 0
- `cargo clippy --workspace --all-targets -- -D warnings`: exit 0
- `cargo test --workspace`: exit 0 (766 tests passed)
- `check-doc-examples --base-ref main`: exit 0
- Conformance runners (`self-test`, `runner`, `vector_runner`): all pass (130/130 vector tests pass)
- Independent verification review: Approved
