### PR TITLE
Support schema-aware XML pretyping for boolean, integer, and number (#114)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -478,6 +478,7 @@ the report.
 ```rust
 // omnist::formats::xml
 pub fn read_xml(text: &str) -> Result<Doc, OmnistError>;
+pub fn read_xml_with_schema(text: &str, schema: &Schema) -> Result<Doc, OmnistError>;
 pub fn write_xml(doc: &Doc, strict: bool, report: Option<&mut WriteReport>)
     -> Result<String, WriteError>;
 pub fn check_xml(doc: &Doc) -> WriteReport;

--- a/docs/formats/xml.md
+++ b/docs/formats/xml.md
@@ -1,6 +1,6 @@
 # XML
 
-`omnist::formats::xml::{read_xml, write_xml, check_xml}`. Ported from
+`omnist::formats::xml::{read_xml, read_xml_with_schema, write_xml, check_xml}`. Ported from
 `~/dev/omnist/omnist/formats.py`'s `read_xml`/`write_xml`/`check_xml`; see
 [`omnist/src/formats/xml.rs`](../../omnist/src/formats/xml.rs)'s module doc
 for the full detail.
@@ -60,15 +60,49 @@ coincides with Python's `ElementTree`-based behavior for the common case
 XML's grammar carries no type information -- `<m>1</m>` and `<m>hi</m>` are
 syntactically identical, a bare text node. `read_xml` builds every leaf as
 a plain string unconditionally; no int/float/bool inference happens at
-parse time. Typing is `materialize`'s job, under a schema, exactly as for
-the other formats.
-
-An earlier version of this module type-inferred leaf text (bool/int/float)
-at parse time, contradicting this and diverging from Python's reference
-`read_xml` -- fixed as `omnist-rs#86` (Python fixed the identical bug in
-its own `read_xml` as `omnist#288`).
+parse time.
 
 Writing a non-string scalar (`bool`/`int`/`float`) to XML now honestly
 reports it: XML has no native typed literals, so it reads back as a
 string, not its original type (`check_xml`'s `value.stringified`
 adjustment).
+
+## Schema-guided pretyping (spec ?2.2 / issue #114)
+
+Because XML text is untyped and `materialize` strictly rejects coercing plain strings to `boolean`/`integer`/`number`, [`read_xml_with_schema`] performs schema-guided pretyping on the raw XML tree before materialization (spec ?2.2 / issue #114).
+
+```rust
+use omnist::formats::xml::read_xml_with_schema;
+use omnist::osd::parse_schema;
+
+let schema_osd = r#"
+record Address  { "street": string, "city": string }
+record LineItem { "sku": string, "qty": integer, "price": number }
+
+record Order {
+    "id":           string,
+    "status":       string,
+    "total":        number,
+    "address":      Address,
+    "items" [1,]:   LineItem,
+    "coupon" [0,1]: string,
+}
+
+record Root { "order": Order }
+root Root
+"#;
+let schema = parse_schema(schema_osd).unwrap();
+
+let xml = r#"<order>
+  <id>A1</id>
+  <status>shipped</status>
+  <total>29.97</total>
+  <address><street>1 Main</street><city>London</city></address>
+  <items><sku>W</sku><qty>3</qty><price>9.99</price></items>
+  <items><sku>G</sku><qty>1</qty><price>9.99</price></items>
+</order>"#;
+
+let doc = read_xml_with_schema(xml, &schema).unwrap();
+assert!(schema.validate(&doc.root()).ok());
+```
+<!-- doc-illustrative -->

--- a/omnist-cli/src/lib.rs
+++ b/omnist-cli/src/lib.rs
@@ -491,12 +491,19 @@ fn io_fail(json: bool, message: &str) -> i32 {
 // Format dispatch helpers
 // ---------------------------------------------------------------------------
 
-fn read_by_fmt(fmt: Fmt, text: &str) -> Result<Doc, OmnistError> {
+fn read_by_fmt(
+    fmt: Fmt,
+    text: &str,
+    schema: Option<&omnist::schema::Schema>,
+) -> Result<Doc, OmnistError> {
     match fmt {
         Fmt::Json => omnist::formats::json::read_json(text),
         Fmt::Yaml => omnist::formats::yaml::read_yaml(text),
         Fmt::Toml => omnist::formats::toml::read_toml(text),
-        Fmt::Xml => omnist::formats::xml::read_xml(text),
+        Fmt::Xml => match schema {
+            Some(s) => omnist::formats::xml::read_xml_with_schema(text, s),
+            None => omnist::formats::xml::read_xml(text),
+        },
         Fmt::Oml => {
             let raw = omnist::oml::read_oml(text)?;
             Ok(Doc::from_raw(raw)?)
@@ -723,16 +730,19 @@ fn cmd_convert(args: ConvertArgs) -> i32 {
         Ok(t) => t,
         Err(e) => return io_fail(args.json, &e),
     };
-    let mut doc = match read_by_fmt(args.from, &text) {
+    let schema = match args.schema.as_deref() {
+        Some(path) => match parse_schema_file(path, args.json) {
+            Ok(s) => Some(s),
+            Err(code) => return code,
+        },
+        None => None,
+    };
+    let mut doc = match read_by_fmt(args.from, &text, schema.as_ref()) {
         Ok(d) => d,
         Err(e) => return generic_fail(args.json, &e),
     };
-    if let Some(schema_path) = &args.schema {
-        let schema = match parse_schema_file(schema_path, args.json) {
-            Ok(s) => s,
-            Err(code) => return code,
-        };
-        let materialized = match omnist::materialize::materialize(&doc.to_raw(), Some(&schema)) {
+    if let Some(schema) = &schema {
+        let materialized = match omnist::materialize::materialize(&doc.to_raw(), Some(schema)) {
             Ok(r) => r,
             Err(e) => return generic_fail(args.json, &OmnistError::Materialize(e)),
         };
@@ -786,7 +796,7 @@ fn cmd_check(args: CheckArgs) -> i32 {
         Ok(t) => t,
         Err(e) => return io_fail(args.json, &e),
     };
-    let doc = match read_by_fmt(args.from, &text) {
+    let doc = match read_by_fmt(args.from, &text, None) {
         Ok(d) => d,
         Err(e) => return generic_fail(args.json, &e),
     };
@@ -806,17 +816,17 @@ fn cmd_check(args: CheckArgs) -> i32 {
 }
 
 fn cmd_validate(args: ValidateArgs) -> i32 {
+    let schema = match parse_schema_file(&args.schema, args.json) {
+        Ok(s) => s,
+        Err(code) => return code,
+    };
     let text = match read_input(&args.input) {
         Ok(t) => t,
         Err(e) => return io_fail(args.json, &e),
     };
-    let doc = match read_by_fmt(args.from, &text) {
+    let doc = match read_by_fmt(args.from, &text, Some(&schema)) {
         Ok(d) => d,
         Err(e) => return generic_fail(args.json, &e),
-    };
-    let schema = match parse_schema_file(&args.schema, args.json) {
-        Ok(s) => s,
-        Err(code) => return code,
     };
     let result = schema.validate(&doc.root());
     if args.json {
@@ -851,7 +861,7 @@ fn cmd_infer(args: InferArgs) -> i32 {
             Ok(t) => t,
             Err(e) => return io_fail(args.json, &e),
         };
-        match read_by_fmt(args.from, &text) {
+        match read_by_fmt(args.from, &text, None) {
             Ok(d) => docs.push(d),
             Err(e) => return generic_fail(args.json, &e),
         }

--- a/omnist-cli/tests/cli.rs
+++ b/omnist-cli/tests/cli.rs
@@ -1230,3 +1230,33 @@ fn format_stdin_dash_with_invalid_utf8_hits_read_input_stdin_error_path() {
 // comment) after empirically confirming a real write failure (broken pipe,
 // `/dev/full`) panics *inside* the preceding `print!` call, never at the
 // `flush()` call -- so there was no live branch left to exercise.
+#[test]
+fn validate_xml_with_schema_pretypes_and_succeeds() {
+    let xml = fixture(
+        "val_xml_in.xml",
+        "<order><id>A1</id><qty>3</qty><price>9.99</price><active>true</active></order>",
+    );
+    let osd = fixture(
+        "val_xml_schema.osd",
+        "record Order { \"id\": string, \"qty\": integer, \"price\": number, \"active\": boolean } record Root { \"order\": Order } root Root",
+    );
+    let r = run(&["validate", &xml, "--from", "xml", "--schema", &osd]);
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+}
+
+#[test]
+fn convert_xml_with_schema_pretypes_to_json() {
+    let xml = fixture(
+        "conv_xml_in.xml",
+        "<order><qty>3</qty><price>9.99</price></order>",
+    );
+    let osd = fixture(
+        "conv_xml_schema.osd",
+        "record Order { \"qty\": integer, \"price\": number } record Root { \"order\": Order } root Root",
+    );
+    let r = run(&[
+        "convert", &xml, "--from", "xml", "--to", "json", "--schema", &osd,
+    ]);
+    assert_eq!(r.code, 0, "stderr: {}", r.stderr);
+    assert!(r.stdout.contains("\"qty\": 3"));
+}

--- a/omnist/src/formats/xml.rs
+++ b/omnist/src/formats/xml.rs
@@ -73,13 +73,15 @@
 //! (`_xml_to_node` no longer infers scalar kind from text shape); this
 //! module's fix mirrors that commit.
 //!
-//! Schema-guided pretyping -- recovering `boolean`/`integer`/`number` from
-//! XML's untyped text *before* `materialize` sees it, so a schema-typed
-//! read can still get real numbers/bools instead of only strings, the way
-//! Python's `_xml_pretype` does when `read_xml(text, schema=...)` is
-//! called -- is a distinct, not-yet-ported feature. [`read_xml`] here has
-//! no schema parameter at all yet, so there is nothing to pretype; typing
-//! happens exclusively at `materialize`, same as every other format.
+//! ## Schema-guided pretyping (issue #114)
+//!
+//! Because XML text carries no native type information and `materialize`
+//! intentionally never coerces plain strings to `integer`/`number`/`boolean`
+//! scalars, [`read_xml_with_schema`] performs schema-guided pretyping of
+//! `boolean`, `integer`, and `number` fields before materialization,
+//! mirroring Python's `_xml_pretype`. Fields typed `any`, date/time/datetime,
+//! and mismatched text stay strings for normal stage-2 validation/materialization
+//! reporting.
 //!
 //! ## All-occurrences sanitization (omnist-ts#36 regression)
 //!
@@ -129,15 +131,98 @@ use crate::error::{DocumentError, OmnistError, ParseError};
 use crate::formats::float_fmt;
 use crate::formats::textpos::line_col_bytes;
 use crate::report::{Severity, WriteReport};
+use crate::schema::{FieldType, Resolved, ScalarKind, Schema};
 use indexmap::IndexMap;
 use quick_xml::Reader;
 use quick_xml::events::Event;
 
 // ============================================================== Reader
 
-/// Parse XML text into a [`Doc`], preserving element order/interleaving
-/// exactly (see this module's doc comment).
-pub fn read_xml(text: &str) -> Result<Doc, OmnistError> {
+static XML_INT_RE: std::sync::LazyLock<regex::Regex> =
+    std::sync::LazyLock::new(|| regex::Regex::new(r"^-?(0|[1-9]\d*)$").unwrap());
+
+static XML_NUM_RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+    regex::Regex::new(r"^-?(0|[1-9]\d*)(\.\d+)?([eE][+-]?\d+)?$").unwrap()
+});
+
+fn xml_pretype_scalar(node: RawNode, s: &crate::schema::Scalar) -> RawNode {
+    let RawNode::Leaf(Scalar::Str(ref val)) = node else {
+        return node;
+    };
+    match s.kind() {
+        ScalarKind::Boolean => {
+            if val == "true" {
+                RawNode::Leaf(Scalar::Bool(true))
+            } else if val == "false" {
+                RawNode::Leaf(Scalar::Bool(false))
+            } else {
+                node
+            }
+        }
+        ScalarKind::Integer => {
+            if XML_INT_RE.is_match(val) {
+                let digits = if let Some(stripped) = val.strip_prefix('-') {
+                    stripped
+                } else {
+                    val.as_str()
+                };
+                if digits.len() <= crate::formats::int_cap::MAX_INT_DIGITS {
+                    let i: num_bigint::BigInt = val
+                        .parse()
+                        .expect("XML_INT_RE guarantees valid integer literal");
+                    return RawNode::Leaf(Scalar::Int(i));
+                }
+            }
+            node
+        }
+        ScalarKind::Number => {
+            if XML_NUM_RE.is_match(val) {
+                let digits = if let Some(stripped) = val.strip_prefix('-') {
+                    stripped
+                } else {
+                    val.as_str()
+                };
+                let int_digits = digits
+                    .split(|c| c == '.' || c == 'e' || c == 'E')
+                    .next()
+                    .unwrap_or(digits);
+                if int_digits.len() <= crate::formats::int_cap::MAX_INT_DIGITS {
+                    let f: f64 = val
+                        .parse()
+                        .expect("XML_NUM_RE guarantees valid float literal");
+                    return RawNode::Leaf(Scalar::Float(f));
+                }
+            }
+            node
+        }
+        _ => node,
+    }
+}
+
+fn xml_pretype(node: RawNode, schema: &Schema, ty: &FieldType) -> RawNode {
+    let d = schema.resolve(ty);
+    match d {
+        Resolved::Any => node,
+        Resolved::Scalar(s) => xml_pretype_scalar(node, &s),
+        Resolved::Record(rec) => {
+            let RawNode::Edges(edges) = node else {
+                return node;
+            };
+            let mut out = Vec::with_capacity(edges.len());
+            for (label, child) in edges {
+                let pretyped_child = if let Some(field) = rec.field(&label) {
+                    xml_pretype(child, schema, &field.ty)
+                } else {
+                    child
+                };
+                out.push((label, pretyped_child));
+            }
+            RawNode::Edges(out)
+        }
+    }
+}
+
+fn read_xml_raw(text: &str) -> Result<RawNode, OmnistError> {
     let normalized = normalize_line_endings(text);
     let mut reader = Reader::from_str(&normalized);
     reader.config_mut().trim_text(false);
@@ -248,7 +333,23 @@ pub fn read_xml(text: &str) -> Result<Doc, OmnistError> {
         }
     }
 
-    let doc = Doc::from_raw(root_node)?;
+    Ok(root_node)
+}
+
+/// Parse XML text into a [`Doc`], preserving element order/interleaving
+/// exactly (see this module's doc comment).
+pub fn read_xml(text: &str) -> Result<Doc, OmnistError> {
+    let raw = read_xml_raw(text)?;
+    let doc = Doc::from_raw(raw)?;
+    Ok(doc)
+}
+
+/// Parse XML text into a [`Doc`] with schema-guided pretyping of boolean,
+/// integer, and number scalar fields (spec ?2.2 / issue #114).
+pub fn read_xml_with_schema(text: &str, schema: &Schema) -> Result<Doc, OmnistError> {
+    let raw = read_xml_raw(text)?;
+    let pretyped = xml_pretype(raw, schema, &FieldType::Ref(schema.root().clone()));
+    let doc = Doc::from_raw(pretyped)?;
     Ok(doc)
 }
 

--- a/omnist/src/formats/xml/tests.rs
+++ b/omnist/src/formats/xml/tests.rs
@@ -9,6 +9,14 @@ fn leaf_str(s: &str) -> RawNode {
     RawNode::Leaf(Scalar::Str(s.to_string()))
 }
 
+fn leaf(s: Scalar) -> RawNode {
+    RawNode::Leaf(s)
+}
+
+fn leaf_bool(b: bool) -> RawNode {
+    RawNode::Leaf(Scalar::Bool(b))
+}
+
 /// Only meaningful on the *write* side now (omnist-rs#86: `read_xml` never
 /// produces `Scalar::Int` -- every leaf it builds is a `Scalar::Str`). Kept
 /// for constructing `Doc`s to feed into `write_xml`/`check_xml`.
@@ -906,4 +914,226 @@ fn test_xml_epilog_general_ref_rejected() {
         err.to_string()
             .contains("unexpected text after root element")
     );
+}
+// ---------------------------------------------------------------------------
+// Issue #114: XML schema-guided pretyping
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_xml_pretype_boolean() {
+    let schema_text = "record Data { \"b_true\": boolean, \"b_false\": boolean, \"b_invalid1\": boolean, \"b_invalid2\": boolean } record Root { \"data\": Data } root Root";
+    let schema = crate::osd::parse_schema(schema_text).unwrap();
+    let xml = "<data><b_true>true</b_true><b_false>false</b_false><b_invalid1>True</b_invalid1><b_invalid2>1</b_invalid2></data>";
+    let doc = read_xml_with_schema(xml, &schema).unwrap();
+    assert_eq!(
+        doc.to_raw(),
+        edges(vec![(
+            "data",
+            edges(vec![
+                ("b_true", leaf_bool(true)),
+                ("b_false", leaf_bool(false)),
+                ("b_invalid1", leaf_str("True")),
+                ("b_invalid2", leaf_str("1")),
+            ])
+        )])
+    );
+}
+
+#[test]
+fn test_xml_pretype_integer() {
+    let schema_text = "record Data { \"zero\": integer, \"neg_zero\": integer, \"pos\": integer, \"neg\": integer, \"lead_zero\": integer, \"non_digit\": integer } record Root { \"data\": Data } root Root";
+    let schema = crate::osd::parse_schema(schema_text).unwrap();
+    let xml = "<data><zero>0</zero><neg_zero>-0</neg_zero><pos>42</pos><neg>-123</neg><lead_zero>007</lead_zero><non_digit>abc</non_digit></data>";
+    let doc = read_xml_with_schema(xml, &schema).unwrap();
+    assert_eq!(
+        doc.to_raw(),
+        edges(vec![(
+            "data",
+            edges(vec![
+                ("zero", leaf(Scalar::Int((0).into()))),
+                ("neg_zero", leaf(Scalar::Int((0).into()))),
+                ("pos", leaf(Scalar::Int((42).into()))),
+                ("neg", leaf(Scalar::Int((-123).into()))),
+                ("lead_zero", leaf_str("007")),
+                ("non_digit", leaf_str("abc")),
+            ])
+        )])
+    );
+}
+
+#[test]
+fn test_xml_pretype_number() {
+    let schema_text = "record Data { \"num1\": number, \"num2\": number, \"exp1\": number, \"exp2\": number, \"invalid\": number } record Root { \"data\": Data } root Root";
+    let schema = crate::osd::parse_schema(schema_text).unwrap();
+    let xml = "<data><num1>3.14</num1><num2>-0.5</num2><exp1>1e6</exp1><exp2>-2.5E-3</exp2><invalid>1.2.3</invalid></data>";
+    let doc = read_xml_with_schema(xml, &schema).unwrap();
+    assert_eq!(
+        doc.to_raw(),
+        edges(vec![(
+            "data",
+            edges(vec![
+                ("num1", leaf(Scalar::Float(3.14))),
+                ("num2", leaf(Scalar::Float(-0.5))),
+                ("exp1", leaf(Scalar::Float(1000000.0))),
+                ("exp2", leaf(Scalar::Float(-0.0025))),
+                ("invalid", leaf_str("1.2.3")),
+            ])
+        )])
+    );
+}
+
+#[test]
+fn test_xml_pretype_digit_cap_oversized_literal_stays_string() {
+    use crate::formats::int_cap::MAX_INT_DIGITS;
+    let schema_text = "record Data { \"big_int\": integer, \"big_num\": number } record Root { \"data\": Data } root Root";
+    let schema = crate::osd::parse_schema(schema_text).unwrap();
+    let oversized = "9".repeat(MAX_INT_DIGITS + 1);
+    let xml =
+        format!("<data><big_int>{oversized}</big_int><big_num>{oversized}.5</big_num></data>");
+    let doc = read_xml_with_schema(&xml, &schema).unwrap();
+    assert_eq!(
+        doc.to_raw(),
+        edges(vec![(
+            "data",
+            edges(vec![
+                ("big_int", leaf_str(&oversized)),
+                ("big_num", leaf_str(&format!("{oversized}.5"))),
+            ])
+        )])
+    );
+}
+
+#[test]
+fn test_xml_pretype_any_and_unknown_fields_untouched() {
+    let schema_text = "record Data { \"any_field\": any, \"known\": integer } record Root { \"data\": Data } root Root";
+    let schema = crate::osd::parse_schema(schema_text).unwrap();
+    let xml = "<data><any_field><nested>42</nested><flag>true</flag></any_field><known>10</known><unknown_field>99</unknown_field></data>";
+    let doc = read_xml_with_schema(xml, &schema).unwrap();
+    assert_eq!(
+        doc.to_raw(),
+        edges(vec![(
+            "data",
+            edges(vec![
+                (
+                    "any_field",
+                    edges(vec![("nested", leaf_str("42")), ("flag", leaf_str("true")),])
+                ),
+                ("known", leaf(Scalar::Int((10).into()))),
+                ("unknown_field", leaf_str("99")),
+            ])
+        )])
+    );
+}
+
+#[test]
+fn test_xml_pretype_spec_order_worked_example() {
+    let schema_osd = r#"
+record Address  { "street": string, "city": string }
+record LineItem { "sku": string, "qty": integer, "price": number }
+
+record Order {
+    "id":           string,
+    "status":       string,
+    "total":        number,
+    "address":      Address,
+    "items" [1,]:   LineItem,
+    "coupon" [0,1]: string,
+}
+
+record Root { "order": Order }
+root Root
+"#;
+    let schema = crate::osd::parse_schema(schema_osd).unwrap();
+    let xml = r#"<order>
+  <id>A1</id>
+  <status>shipped</status>
+  <total>29.97</total>
+  <address><street>1 Main</street><city>London</city></address>
+  <items><sku>W</sku><qty>3</qty><price>9.99</price></items>
+  <items><sku>G</sku><qty>1</qty><price>9.99</price></items>
+</order>"#;
+
+    let doc = read_xml_with_schema(xml, &schema).unwrap();
+    assert_eq!(
+        doc.to_raw(),
+        edges(vec![(
+            "order",
+            edges(vec![
+                ("id", leaf_str("A1")),
+                ("status", leaf_str("shipped")),
+                ("total", leaf(Scalar::Float(29.97))),
+                (
+                    "address",
+                    edges(vec![
+                        ("street", leaf_str("1 Main")),
+                        ("city", leaf_str("London")),
+                    ])
+                ),
+                (
+                    "items",
+                    edges(vec![
+                        ("sku", leaf_str("W")),
+                        ("qty", leaf(Scalar::Int((3).into()))),
+                        ("price", leaf(Scalar::Float(9.99))),
+                    ])
+                ),
+                (
+                    "items",
+                    edges(vec![
+                        ("sku", leaf_str("G")),
+                        ("qty", leaf(Scalar::Int((1).into()))),
+                        ("price", leaf(Scalar::Float(9.99))),
+                    ])
+                ),
+            ])
+        )])
+    );
+
+    // Validate passes cleanly
+    assert!(schema.validate(&doc.root()).ok());
+}
+
+#[test]
+fn test_plain_read_xml_unaffected_by_schema_pretyping() {
+    let xml = "<order><qty>3</qty><total>29.97</total><flag>true</flag></order>";
+    let doc = read_xml(xml).unwrap();
+    // Plain read_xml always yields strings
+    assert_eq!(
+        doc.to_raw(),
+        edges(vec![(
+            "order",
+            edges(vec![
+                ("qty", leaf_str("3")),
+                ("total", leaf_str("29.97")),
+                ("flag", leaf_str("true")),
+            ])
+        )])
+    );
+}
+
+#[test]
+fn test_xml_pretype_whitebox_non_string_and_non_edges() {
+    let schema = crate::osd::parse_schema("record Root { \"x\": integer } root Root").unwrap();
+    // Already non-str leaf stays untouched
+    let leaf_node = leaf(Scalar::Int((5).into()));
+    let pretyped_leaf = super::xml_pretype(
+        leaf_node.clone(),
+        &schema,
+        &crate::schema::FieldType::Scalar(crate::schema::INTEGER),
+    );
+    assert_eq!(pretyped_leaf, leaf_node);
+
+    // Leaf passed to Record type resolution returns node
+    let pretyped_rec_on_leaf = super::xml_pretype(
+        leaf_node.clone(),
+        &schema,
+        &crate::schema::FieldType::Ref(schema.root().clone()),
+    );
+    assert_eq!(pretyped_rec_on_leaf, leaf_node);
+}
+#[test]
+fn test_xml_pretype_read_xml_with_schema_parse_error() {
+    let schema = crate::osd::parse_schema("record Root { \"x\": integer } root Root").unwrap();
+    let err = read_xml_with_schema("<unclosed>", &schema).unwrap_err();
+    assert!(err.to_string().contains("invalid XML"));
 }

--- a/src/api.md
+++ b/src/api.md
@@ -478,6 +478,7 @@ the report.
 ```rust
 // omnist::formats::xml
 pub fn read_xml(text: &str) -> Result<Doc, OmnistError>;
+pub fn read_xml_with_schema(text: &str, schema: &Schema) -> Result<Doc, OmnistError>;
 pub fn write_xml(doc: &Doc, strict: bool, report: Option<&mut WriteReport>)
     -> Result<String, WriteError>;
 pub fn check_xml(doc: &Doc) -> WriteReport;

--- a/src/formats/xml.md
+++ b/src/formats/xml.md
@@ -1,6 +1,6 @@
 # XML
 
-`omnist::formats::xml::{read_xml, write_xml, check_xml}`. Ported from
+`omnist::formats::xml::{read_xml, read_xml_with_schema, write_xml, check_xml}`. Ported from
 `~/dev/omnist/omnist/formats.py`'s `read_xml`/`write_xml`/`check_xml`; see
 [`omnist/src/formats/xml.rs`](../../omnist/src/formats/xml.rs)'s module doc
 for the full detail.
@@ -60,15 +60,49 @@ coincides with Python's `ElementTree`-based behavior for the common case
 XML's grammar carries no type information -- `<m>1</m>` and `<m>hi</m>` are
 syntactically identical, a bare text node. `read_xml` builds every leaf as
 a plain string unconditionally; no int/float/bool inference happens at
-parse time. Typing is `materialize`'s job, under a schema, exactly as for
-the other formats.
-
-An earlier version of this module type-inferred leaf text (bool/int/float)
-at parse time, contradicting this and diverging from Python's reference
-`read_xml` -- fixed as `omnist-rs#86` (Python fixed the identical bug in
-its own `read_xml` as `omnist#288`).
+parse time.
 
 Writing a non-string scalar (`bool`/`int`/`float`) to XML now honestly
 reports it: XML has no native typed literals, so it reads back as a
 string, not its original type (`check_xml`'s `value.stringified`
 adjustment).
+
+## Schema-guided pretyping (spec ?2.2 / issue #114)
+
+Because XML text is untyped and `materialize` strictly rejects coercing plain strings to `boolean`/`integer`/`number`, [`read_xml_with_schema`] performs schema-guided pretyping on the raw XML tree before materialization (spec ?2.2 / issue #114).
+
+```rust
+use omnist::formats::xml::read_xml_with_schema;
+use omnist::osd::parse_schema;
+
+let schema_osd = r#"
+record Address  { "street": string, "city": string }
+record LineItem { "sku": string, "qty": integer, "price": number }
+
+record Order {
+    "id":           string,
+    "status":       string,
+    "total":        number,
+    "address":      Address,
+    "items" [1,]:   LineItem,
+    "coupon" [0,1]: string,
+}
+
+record Root { "order": Order }
+root Root
+"#;
+let schema = parse_schema(schema_osd).unwrap();
+
+let xml = r#"<order>
+  <id>A1</id>
+  <status>shipped</status>
+  <total>29.97</total>
+  <address><street>1 Main</street><city>London</city></address>
+  <items><sku>W</sku><qty>3</qty><price>9.99</price></items>
+  <items><sku>G</sku><qty>1</qty><price>9.99</price></items>
+</order>"#;
+
+let doc = read_xml_with_schema(xml, &schema).unwrap();
+assert!(schema.validate(&doc.root()).ok());
+```
+<!-- doc-illustrative -->


### PR DESCRIPTION
Implements read_xml_with_schema for schema-guided pretyping of boolean/integer/number fields before materialization, wires omnist-cli convert/validate, and updates documentation.