### PR TITLE
fix: restore corrupted § character from issue #114 docs

### DIFF
--- a/docs/formats/xml.md
+++ b/docs/formats/xml.md
@@ -67,9 +67,9 @@ reports it: XML has no native typed literals, so it reads back as a
 string, not its original type (`check_xml`'s `value.stringified`
 adjustment).
 
-## Schema-guided pretyping (spec ?2.2 / issue #114)
+## Schema-guided pretyping (spec §2.2 / issue #114)
 
-Because XML text is untyped and `materialize` strictly rejects coercing plain strings to `boolean`/`integer`/`number`, [`read_xml_with_schema`] performs schema-guided pretyping on the raw XML tree before materialization (spec ?2.2 / issue #114).
+Because XML text is untyped and `materialize` strictly rejects coercing plain strings to `boolean`/`integer`/`number`, [`read_xml_with_schema`] performs schema-guided pretyping on the raw XML tree before materialization (spec §2.2 / issue #114).
 
 ```rust
 use omnist::formats::xml::read_xml_with_schema;

--- a/omnist/src/formats/xml.rs
+++ b/omnist/src/formats/xml.rs
@@ -342,7 +342,7 @@ pub fn read_xml(text: &str) -> Result<Doc, OmnistError> {
 }
 
 /// Parse XML text into a [`Doc`] with schema-guided pretyping of boolean,
-/// integer, and number scalar fields (spec ?2.2 / issue #114).
+/// integer, and number scalar fields (spec §2.2 / issue #114).
 pub fn read_xml_with_schema(text: &str, schema: &Schema) -> Result<Doc, OmnistError> {
     let raw = read_xml_raw(text)?;
     let pretyped = xml_pretype(raw, schema, &FieldType::Ref(schema.root().clone()));

--- a/src/formats/xml.md
+++ b/src/formats/xml.md
@@ -67,9 +67,9 @@ reports it: XML has no native typed literals, so it reads back as a
 string, not its original type (`check_xml`'s `value.stringified`
 adjustment).
 
-## Schema-guided pretyping (spec ?2.2 / issue #114)
+## Schema-guided pretyping (spec §2.2 / issue #114)
 
-Because XML text is untyped and `materialize` strictly rejects coercing plain strings to `boolean`/`integer`/`number`, [`read_xml_with_schema`] performs schema-guided pretyping on the raw XML tree before materialization (spec ?2.2 / issue #114).
+Because XML text is untyped and `materialize` strictly rejects coercing plain strings to `boolean`/`integer`/`number`, [`read_xml_with_schema`] performs schema-guided pretyping on the raw XML tree before materialization (spec §2.2 / issue #114).
 
 ```rust
 use omnist::formats::xml::read_xml_with_schema;


### PR DESCRIPTION
Small follow-up: the §2.2 spec citation added by PR #130/#131/#132 got corrupted to "?2.2" in three places (xml.rs module doc, docs/formats/xml.md, src/formats/xml.md) -- same class of character corruption previously seen on the omnist-go cycle. Cosmetic only, no functional change. Verified: full workspace build/test/fmt/clippy/coverage/conformance all still green.