### PR TITLE
Support structured SchemaError with path and code fields (#122)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -731,7 +731,11 @@ pub struct DocumentError {
     pub message: String,
 }
 
-pub struct SchemaError(pub String);
+pub struct SchemaError {
+    pub path: String,
+    pub code: String,
+    pub message: String,
+}
 
 pub struct ParseError {
     pub line: usize,

--- a/omnist/src/error.rs
+++ b/omnist/src/error.rs
@@ -41,13 +41,13 @@ impl DocumentError {
 ///
 /// Breaking change in issue #122: `SchemaError` now carries machine-readable
 /// `path` and `code` fields alongside human-readable `message`, matching the
-/// spec's schema well-formedness and algebra error taxonomy (spec ?8.3.3 & ?8.3.6).
+/// spec's schema well-formedness and algebra error taxonomy (spec §8.3.3 & §8.3.6).
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 #[error("{message}")]
 pub struct SchemaError {
     /// The path (record/field context or "$") where the schema error occurred.
     pub path: String,
-    /// Stable machine-readable error code (e.g. "schema.unknown-type", spec ?8.3.3).
+    /// Stable machine-readable error code (e.g. "schema.unknown-type", spec §8.3.3).
     pub code: String,
     /// Human-readable error description.
     pub message: String,

--- a/omnist/src/error.rs
+++ b/omnist/src/error.rs
@@ -36,16 +36,35 @@ impl DocumentError {
 }
 
 /// A Schema definition is invalid (bad cardinality, duplicate field label,
-/// unknown scalar/ref name) -- raised by [`crate::schema`] at construction
-/// time, mirroring Python's `SchemaError` in `~/dev/omnist/omnist/errors.py`.
+/// unknown scalar/ref name) -- raised by [`crate::schema`], [`crate::osd`],
+/// [`crate::infer`], and [`crate::ops::extract`].
+///
+/// Breaking change in issue #122: `SchemaError` now carries machine-readable
+/// `path` and `code` fields alongside human-readable `message`, matching the
+/// spec's schema well-formedness and algebra error taxonomy (spec ?8.3.3 & ?8.3.6).
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
-#[error("{0}")]
-pub struct SchemaError(pub String);
+#[error("{message}")]
+pub struct SchemaError {
+    /// The path (record/field context or "$") where the schema error occurred.
+    pub path: String,
+    /// Stable machine-readable error code (e.g. "schema.unknown-type", spec ?8.3.3).
+    pub code: String,
+    /// Human-readable error description.
+    pub message: String,
+}
 
 impl SchemaError {
-    /// Construct a new `SchemaError`.
-    pub fn new(message: impl Into<String>) -> Self {
-        Self(message.into())
+    /// Construct a structured `SchemaError` with path, code, and message.
+    pub fn new(
+        path: impl Into<String>,
+        code: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            path: path.into(),
+            code: code.into(),
+            message: message.into(),
+        }
     }
 }
 
@@ -223,14 +242,17 @@ mod tests {
 
     #[test]
     fn schema_error_display_and_eq() {
-        let e = SchemaError::new("unknown type 'Missing'");
+        let e = SchemaError::new("R.a", "schema.unknown-type", "unknown type 'Missing'");
+        assert_eq!(e.path, "R.a");
+        assert_eq!(e.code, "schema.unknown-type");
+        assert_eq!(e.message, "unknown type 'Missing'");
         assert_eq!(e.to_string(), "unknown type 'Missing'");
         assert_eq!(e.clone(), e);
     }
 
     #[test]
     fn omnist_error_wraps_schema_error_transparently() {
-        let schema_err = SchemaError::new("boom");
+        let schema_err = SchemaError::new("$", "schema.syntax", "boom");
         let wrapped: OmnistError = schema_err.clone().into();
         assert_eq!(wrapped.to_string(), schema_err.to_string());
         assert!(matches!(wrapped, OmnistError::Schema(ref inner) if *inner == schema_err));

--- a/omnist/src/infer.rs
+++ b/omnist/src/infer.rs
@@ -221,7 +221,7 @@ fn infer_type(
         }
         return Err(SchemaError::new(
             format!("$.{label}"),
-            "algebra.infer-incompatible-types",
+            "algebra.infer-mixed-shape",
             format!("label {label:?} mixes objects and values; cannot infer one type"),
         ));
     }
@@ -291,7 +291,7 @@ fn infer_type(
         }
         return Err(SchemaError::new(
             format!("$.{label}"),
-            "algebra.infer-incompatible-types",
+            "algebra.infer-conflicting-scalars",
             format!(
                 "label {label:?} has values of more than one scalar ({}); cannot infer one scalar type",
                 sorted.join(", ")

--- a/omnist/src/infer.rs
+++ b/omnist/src/infer.rs
@@ -90,11 +90,17 @@ pub fn infer_with_report(
     allow_any: bool,
 ) -> Result<(Schema, Vec<AnyFallback>), SchemaError> {
     if samples.is_empty() {
-        return Err(SchemaError::new("cannot infer a schema from zero samples"));
+        return Err(SchemaError::new(
+            "$",
+            "algebra.infer-no-samples",
+            "cannot infer a schema from zero samples",
+        ));
     }
     for s in samples {
         if s.root().is_leaf() {
             return Err(SchemaError::new(
+                "$",
+                "algebra.infer-scalar-root",
                 "infer expects object (record) samples at the root",
             ));
         }
@@ -213,9 +219,11 @@ fn infer_type(
             });
             return Ok(FieldType::Any);
         }
-        return Err(SchemaError::new(format!(
-            "label {label:?} mixes objects and values; cannot infer one type"
-        )));
+        return Err(SchemaError::new(
+            format!("$.{label}"),
+            "algebra.infer-incompatible-types",
+            format!("label {label:?} mixes objects and values; cannot infer one type"),
+        ));
     }
     // All scalars.
     let mut names: IndexSet<&'static str> = IndexSet::new();
@@ -281,11 +289,14 @@ fn infer_type(
             });
             return Ok(FieldType::Any);
         }
-        return Err(SchemaError::new(format!(
-            "label {label:?} has values of more than one scalar ({}); cannot infer one \
-             scalar type",
-            sorted.join(", ")
-        )));
+        return Err(SchemaError::new(
+            format!("$.{label}"),
+            "algebra.infer-incompatible-types",
+            format!(
+                "label {label:?} has values of more than one scalar ({}); cannot infer one scalar type",
+                sorted.join(", ")
+            ),
+        ));
     }
     let kind = ScalarKind::parse(names.iter().next().unwrap())
         .expect("names only ever holds known scalar kind names, inserted above");

--- a/omnist/src/ops/extract.rs
+++ b/omnist/src/ops/extract.rs
@@ -109,9 +109,13 @@ pub fn extract(s: &Schema, keep: &[&str]) -> Result<Schema, SchemaError> {
         let (label, record_name) = first_offender.expect(
             "root invalidated implies step 1 recorded an offender before propagation began",
         );
-        return Err(SchemaError::new(format!(
-            "no valid subschema: removing label {label:?} deletes a mandatory field of record {record_name:?}"
-        )));
+        return Err(SchemaError::new(
+            format!("{record_name}.{label}"),
+            "algebra.extract-invalidates-root",
+            format!(
+                "no valid subschema: removing label {label:?} deletes a mandatory field of record {record_name:?}"
+            ),
+        ));
     }
 
     // Step 5: drop invalidated records and any fields (mandatory or not)

--- a/omnist/src/osd.rs
+++ b/omnist/src/osd.rs
@@ -31,7 +31,7 @@ use regex::Regex;
 use std::sync::LazyLock;
 
 use crate::error::SchemaError;
-use crate::schema::{Field, Record, Ref, Scalar, ScalarKind, Schema};
+use crate::schema::{Field, FieldType, Record, Ref, Scalar, ScalarKind, Schema};
 
 // ---------------------------------------------------------------------------
 // Tokenizer
@@ -80,28 +80,21 @@ fn tokenize(text: &str) -> Result<Vec<Tok>, SchemaError> {
     let mut i = 0usize;
     while i < text.len() {
         let Some(m) = TOKEN_RE.captures(&text[i..]) else {
-            // `i` is always either `0` or a previous iteration's
-            // `whole.len()` -- a match length reported by the `regex`
-            // crate against `&str` input -- so it always lands on a char
-            // boundary. `text[i..]` can't panic here, and `.chars().next()`
-            // always yields a char (the loop guard `i < text.len()` rules
-            // out an empty remainder).
             let ch = text[i..].chars().next().unwrap();
-            return Err(SchemaError::new(format!(
-                "unexpected character {ch:?} at {i}"
-            )));
+            return Err(SchemaError::new(
+                "$",
+                "schema.invalid-syntax",
+                format!("unexpected character {ch:?} at {i}"),
+            ));
         };
-        // The regex has no anchor, so a match not starting at 0 means the
-        // characters at `i` didn't match any alternative.
         let whole = m.get(0).unwrap();
         if whole.start() != 0 {
-            // Same char-boundary invariant as above: `i` hasn't changed
-            // since the last successful match (or loop start), so it's
-            // still a valid boundary and the slice/next() can't fail.
             let ch = text[i..].chars().next().unwrap();
-            return Err(SchemaError::new(format!(
-                "unexpected character {ch:?} at {i}"
-            )));
+            return Err(SchemaError::new(
+                "$",
+                "schema.invalid-syntax",
+                format!("unexpected character {ch:?} at {i}"),
+            ));
         }
         let start = i;
         i += whole.len();
@@ -140,8 +133,8 @@ fn unquote(s: &str) -> String {
     let mut chars = inner.chars();
     while let Some(c) = chars.next() {
         if c == '\\' {
-            if let Some(next) = chars.next() {
-                out.push(next);
+            if let Some(escaped) = chars.next() {
+                out.push(escaped);
             }
         } else {
             out.push(c);
@@ -154,23 +147,7 @@ fn unquote(s: &str) -> String {
 // Parser
 // ---------------------------------------------------------------------------
 
-/// A field's type as produced by the parser, before being wired into
-/// [`Field::new`].
-enum ParsedType {
-    Scalar(Scalar),
-    Ref(Ref),
-    Any,
-}
 
-impl From<ParsedType> for crate::schema::FieldType {
-    fn from(t: ParsedType) -> Self {
-        match t {
-            ParsedType::Scalar(s) => s.into(),
-            ParsedType::Ref(r) => r.into(),
-            ParsedType::Any => crate::schema::FieldType::Any,
-        }
-    }
-}
 
 struct Parser {
     toks: Vec<Tok>,
@@ -195,10 +172,11 @@ impl Parser {
     fn expect_punct(&mut self, text: &str) -> Result<Tok, SchemaError> {
         let t = self.next_tok();
         if t.kind != TokKind::Punct || t.text != text {
-            return Err(SchemaError::new(format!(
-                "expected {text:?} at {}, got {:?}",
-                t.pos, t.text
-            )));
+            return Err(SchemaError::new(
+                "$",
+                "schema.invalid-syntax",
+                format!("expected {text:?} at {}, got {:?}", t.pos, t.text),
+            ));
         }
         Ok(t)
     }
@@ -206,10 +184,11 @@ impl Parser {
     fn expect_name(&mut self) -> Result<Tok, SchemaError> {
         let t = self.next_tok();
         if t.kind != TokKind::Name {
-            return Err(SchemaError::new(format!(
-                "expected a name at {}, got {:?}",
-                t.pos, t.text
-            )));
+            return Err(SchemaError::new(
+                "$",
+                "schema.invalid-syntax",
+                format!("expected a name at {}, got {:?}", t.pos, t.text),
+            ));
         }
         Ok(t)
     }
@@ -226,14 +205,19 @@ impl Parser {
                 self.next_tok();
                 root = Some(self.expect_name()?.text);
             } else {
-                return Err(SchemaError::new(format!(
-                    "expected 'record' or 'root' at {}, got {:?}",
-                    t.pos, t.text
-                )));
+                return Err(SchemaError::new(
+                    "$",
+                    "schema.invalid-syntax",
+                    format!("expected 'record' or 'root' at {}, got {:?}", t.pos, t.text),
+                ));
             }
         }
         let Some(root) = root else {
-            return Err(SchemaError::new("a schema must declare a root"));
+            return Err(SchemaError::new(
+                "$",
+                "schema.no-root",
+                "a schema must declare a root",
+            ));
         };
         Schema::new(Ref::new(root), env)
     }
@@ -246,37 +230,54 @@ impl Parser {
         name_pos: usize,
     ) -> Result<(), SchemaError> {
         if name == "any" {
-            return Err(SchemaError::new(format!(
-                "'any' is a reserved type name and cannot be used as a record name at {name_pos}"
-            )));
+            return Err(SchemaError::new(
+                "any",
+                "schema.reserved-name",
+                format!(
+                    "'any' is a reserved type name and cannot be used as a record name at {name_pos}"
+                ),
+            ));
         }
         if ScalarKind::ALL.iter().any(|k| k.as_str() == name) {
-            return Err(SchemaError::new(format!(
-                "{name:?} is a reserved scalar name; a record cannot be defined with \
-                 this name, or it could never be referenced (a bare name in a type \
-                 position always means the builtin scalar)"
-            )));
+            return Err(SchemaError::new(
+                &name,
+                "schema.reserved-name",
+                format!(
+                    "{name:?} is a reserved scalar name; a record cannot be defined with                      this name, or it could never be referenced (a bare name in a type                      position always means the builtin scalar)"
+                ),
+            ));
         }
         if env.contains_key(&name) {
-            return Err(SchemaError::new(format!("duplicate definition {name:?}")));
+            return Err(SchemaError::new(
+                &name,
+                "schema.duplicate-record",
+                format!("duplicate definition {name:?}"),
+            ));
         }
         env.insert(name, rec);
         Ok(())
     }
 
-    /// Parses a `record NAME { ... }` block. The caller (`parse_schema`'s
-    /// main loop) only invokes this after peeking a `Name` token whose text
-    /// is exactly `"record"`, so consuming that token here can never fail --
-    /// there is no reachable error path for a mismatched keyword, unlike
-    /// `expect_name`/`expect_punct` which validate tokens the caller hasn't
-    /// already checked.
+    /// Parses a `record NAME { ... }` block.
     fn parse_record(&mut self) -> Result<(String, Record, usize), SchemaError> {
-        self.next_tok(); // guaranteed to be the `record` keyword, see above.
+        self.next_tok(); // guaranteed to be the `record` keyword
         let name_tok = self.expect_name()?;
         self.expect_punct("{")?;
         let mut fields = Vec::new();
+        let mut seen = std::collections::BTreeSet::new();
         while self.peek().text != "}" {
-            fields.push(self.parse_field()?);
+            let f = self.parse_field(&name_tok.text)?;
+            if !seen.insert(f.label.clone()) {
+                return Err(SchemaError::new(
+                    &name_tok.text,
+                    "schema.duplicate-field",
+                    format!(
+                        "duplicate field label {:?} in record {:?}",
+                        f.label, name_tok.text
+                    ),
+                ));
+            }
+            fields.push(f);
             if self.peek().text == "," {
                 self.next_tok();
             } else {
@@ -288,86 +289,144 @@ impl Parser {
         Ok((name_tok.text.clone(), rec, name_tok.pos))
     }
 
-    fn parse_field(&mut self) -> Result<Field, SchemaError> {
+    fn parse_field(&mut self, rec_name: &str) -> Result<Field, SchemaError> {
         let label_tok = self.next_tok();
         if label_tok.kind != TokKind::String {
-            return Err(SchemaError::new(format!(
-                "expected a quoted field name at {}, got {:?}",
-                label_tok.pos, label_tok.text
-            )));
+            return Err(SchemaError::new(
+                rec_name,
+                "schema.unquoted-label",
+                format!(
+                    "expected a quoted field name at {}, got {:?}",
+                    label_tok.pos, label_tok.text
+                ),
+            ));
         }
         let label = unquote(&label_tok.text);
         let (min, max) = if self.peek().text == "[" {
-            self.parse_cardinality()?
+            self.parse_cardinality(rec_name, &label)?
         } else {
             (1, Some(1))
         };
         self.expect_punct(":")?;
-        let ty = self.parse_type()?;
+        let ty = self.parse_type(rec_name, &label)?;
         Field::new(label, ty, min, max)
     }
 
-    fn parse_cardinality(&mut self) -> Result<(usize, Option<usize>), SchemaError> {
+    fn parse_cardinality(
+        &mut self,
+        rec_name: &str,
+        label: &str,
+    ) -> Result<(usize, Option<usize>), SchemaError> {
         self.expect_punct("[")?;
-        let mut first: Option<usize> = None;
-        if self.peek().kind == TokKind::Number {
-            first = Some(self.parse_cardinality_int()?);
+        let path = format!("{rec_name}.{label}");
+        if self.peek().text == "]" {
+            return Err(SchemaError::new(
+                path,
+                "schema.empty-cardinality",
+                format!("empty cardinality at {}", self.peek().pos),
+            ));
         }
+        let first = if self.peek().text == "," {
+            None
+        } else {
+            Some(self.parse_cardinality_int(rec_name, label)?)
+        };
         let (lo, hi) = if self.peek().text == "," {
             self.next_tok();
-            let mut second: Option<usize> = None;
-            if self.peek().kind == TokKind::Number {
-                second = Some(self.parse_cardinality_int()?);
-            }
+            let second = if self.peek().text == "]" {
+                None
+            } else {
+                Some(self.parse_cardinality_int(rec_name, label)?)
+            };
             (first.unwrap_or(0), second)
         } else {
-            let Some(first) = first else {
-                return Err(SchemaError::new(format!(
-                    "empty cardinality at {}",
-                    self.peek().pos
-                )));
-            };
-            (first, Some(first))
+            let bound = first.unwrap();
+            (bound, Some(bound))
         };
         self.expect_punct("]")?;
+        if let Some(hi) = hi {
+            if hi < lo {
+                return Err(SchemaError::new(
+                    path,
+                    "schema.invalid-cardinality",
+                    format!("invalid cardinality range [{lo}, {hi}]"),
+                ));
+            }
+        }
         Ok((lo, hi))
     }
 
-    fn parse_cardinality_int(&mut self) -> Result<usize, SchemaError> {
+    fn parse_cardinality_int(&mut self, rec_name: &str, label: &str) -> Result<usize, SchemaError> {
         let t = self.next_tok();
+        let path = format!("{rec_name}.{label}");
         if t.text.contains('.') {
-            return Err(SchemaError::new(format!(
-                "cardinality must be a whole number, got {:?} at {}",
-                t.text, t.pos
-            )));
+            return Err(SchemaError::new(
+                path,
+                "schema.non-integer-cardinality",
+                format!(
+                    "cardinality must be a whole number, got {:?} at {}",
+                    t.text, t.pos
+                ),
+            ));
+        }
+        if t.text.starts_with('-') {
+            return Err(SchemaError::new(
+                path,
+                "schema.invalid-cardinality",
+                format!(
+                    "cardinality must be a non-negative whole number, got {:?} at {}",
+                    t.text, t.pos
+                ),
+            ));
         }
         t.text.parse::<usize>().map_err(|_| {
-            SchemaError::new(format!(
-                "cardinality must be a non-negative whole number, got {:?} at {}",
-                t.text, t.pos
-            ))
+            SchemaError::new(
+                path,
+                "schema.non-integer-cardinality",
+                format!(
+                    "cardinality must be a non-negative whole number, got {:?} at {}",
+                    t.text, t.pos
+                ),
+            )
         })
     }
 
-    fn parse_type(&mut self) -> Result<ParsedType, SchemaError> {
+    fn parse_type(&mut self, rec_name: &str, label: &str) -> Result<FieldType, SchemaError> {
         let t = self.next_tok();
+        let path = format!("{rec_name}.{label}");
         if t.kind != TokKind::Name {
-            return Err(SchemaError::new(format!(
-                "expected a scalar name or a reference at {}, got {:?} (enums and \
-                 literal-valued fields are not supported -- a field's type is \
-                 always one scalar or a reference to a named record)",
-                t.pos, t.text
-            )));
+            if t.kind == TokKind::String {
+                return Err(SchemaError::new(
+                    rec_name,
+                    "schema.quoted-type",
+                    format!(
+                        "expected a scalar name or a reference at {}, got {:?} (enums and                          literal-valued fields are not supported -- a field's type is                          always one scalar or a reference to a named record)",
+                        t.pos, t.text
+                    ),
+                ));
+            }
+            return Err(SchemaError::new(
+                rec_name,
+                "schema.invalid-syntax",
+                format!(
+                    "expected a scalar name or a reference at {}, got {:?} (enums and                      literal-valued fields are not supported -- a field's type is                      always one scalar or a reference to a named record)",
+                    t.pos, t.text
+                ),
+            ));
         }
         if t.text == "any" {
             if self.peek().text == "?" {
                 let q = self.next_tok();
-                return Err(SchemaError::new(format!(
-                    "'any' already includes null; 'any?' is redundant at {}",
-                    q.pos
-                )));
+                return Err(SchemaError::new(
+                    path,
+                    "schema.nullable-any",
+                    format!(
+                        "'any' already includes null; 'any?' is redundant at {}",
+                        q.pos
+                    ),
+                ));
             }
-            return Ok(ParsedType::Any);
+            return Ok(FieldType::Any);
         }
         let mut nullable = false;
         if self.peek().text == "?" {
@@ -375,16 +434,19 @@ impl Parser {
             nullable = true;
         }
         if ScalarKind::ALL.iter().any(|k| k.as_str() == t.text) {
-            return Ok(ParsedType::Scalar(Scalar::named(&t.text, nullable)?));
+            return Ok(FieldType::Scalar(Scalar::named(&t.text, nullable)?));
         }
         if nullable {
-            return Err(SchemaError::new(format!(
-                "'?' cannot apply to the reference {:?}; use cardinality [0,1] for \
-                 an optional field",
-                t.text
-            )));
+            return Err(SchemaError::new(
+                path,
+                "schema.nullable-ref",
+                format!(
+                    "'?' cannot apply to the reference {:?}; use cardinality [0,1] for                      an optional field",
+                    t.text
+                ),
+            ));
         }
-        Ok(ParsedType::Ref(Ref::new(t.text)))
+        Ok(FieldType::Ref(Ref::new(t.text)))
     }
 }
 
@@ -758,6 +820,128 @@ mod tests {
         let err = parse_schema(r#"record any { "a": string } root any"#).unwrap_err();
         assert!(err.to_string().contains("reserved type name"));
         assert!(err.to_string().contains("cannot be used as a record name"));
+    }
+
+    // -- Tests covering every one of the 12 spec schema error codes ----------
+
+    #[test]
+    fn record_name_must_be_a_name_token() {
+        let err = parse_schema(r#"record 123 { "a": string } root X"#).unwrap_err();
+        assert_eq!(err.code, "schema.invalid-syntax");
+    }
+
+    #[test]
+    fn type_position_rejects_punctuation_token() {
+        let err = parse_schema(r#"record X { "a": : } root X"#).unwrap_err();
+        assert_eq!(err.code, "schema.invalid-syntax");
+    }
+    #[test]
+    fn test_code_schema_no_root() {
+        let err = parse_schema(r#"record X { "a": string }"#).unwrap_err();
+        assert_eq!(err.code, "schema.no-root");
+        assert_eq!(err.path, "$");
+    }
+
+    #[test]
+    fn test_code_schema_unknown_type() {
+        let err = parse_schema(r#"record X { "a": Missing } root X"#).unwrap_err();
+        assert_eq!(err.code, "schema.unknown-type");
+        assert_eq!(err.path, "X.a");
+
+        let err_root = parse_schema(r#"record X { "a": string } root Missing"#).unwrap_err();
+        assert_eq!(err_root.code, "schema.unknown-type");
+        assert_eq!(err_root.path, "$");
+    }
+
+    #[test]
+    fn test_code_schema_duplicate_record() {
+        let err = parse_schema(r#"record X { "a": string } record X { "b": string } root X"#)
+            .unwrap_err();
+        assert_eq!(err.code, "schema.duplicate-record");
+        assert_eq!(err.path, "X");
+    }
+
+    #[test]
+    fn test_code_schema_duplicate_field() {
+        let err = parse_schema(r#"record X { "a": string, "a": integer } root X"#).unwrap_err();
+        assert_eq!(err.code, "schema.duplicate-field");
+        assert_eq!(err.path, "X");
+    }
+
+    #[test]
+    fn test_code_schema_reserved_name() {
+        let err_scalar = parse_schema(r#"record string { "a": string } root string"#).unwrap_err();
+        assert_eq!(err_scalar.code, "schema.reserved-name");
+        assert_eq!(err_scalar.path, "string");
+
+        let err_any = parse_schema(r#"record any { "a": string } root any"#).unwrap_err();
+        assert_eq!(err_any.code, "schema.reserved-name");
+        assert_eq!(err_any.path, "any");
+    }
+
+    #[test]
+    fn test_code_schema_invalid_cardinality() {
+        let err_neg = parse_schema(r#"record X { "a" [-1]: string } root X"#).unwrap_err();
+        assert_eq!(err_neg.code, "schema.invalid-cardinality");
+        assert_eq!(err_neg.path, "X.a");
+
+        let err_inverted = parse_schema(r#"record X { "a" [3, 1]: string } root X"#).unwrap_err();
+        assert_eq!(err_inverted.code, "schema.invalid-cardinality");
+        assert_eq!(err_inverted.path, "X.a");
+    }
+
+    #[test]
+    fn cardinality_overflow_is_an_error() {
+        let err = parse_schema(r#"record X { "a" [999999999999999999999999999999999999999]: string } root X"#).unwrap_err();
+        assert_eq!(err.code, "schema.non-integer-cardinality");
+        assert_eq!(err.path, "X.a");
+    }
+
+    #[test]
+    fn test_code_schema_non_integer_cardinality() {
+        let err = parse_schema(r#"record X { "a" [1.5]: string } root X"#).unwrap_err();
+        assert_eq!(err.code, "schema.non-integer-cardinality");
+        assert_eq!(err.path, "X.a");
+    }
+
+    #[test]
+    fn test_code_schema_empty_cardinality() {
+        let err = parse_schema(r#"record X { "a" []: string } root X"#).unwrap_err();
+        assert_eq!(err.code, "schema.empty-cardinality");
+        assert_eq!(err.path, "X.a");
+    }
+
+    #[test]
+    fn test_code_schema_unquoted_label() {
+        let err = parse_schema(r#"record X { a: string } root X"#).unwrap_err();
+        assert_eq!(err.code, "schema.unquoted-label");
+        assert_eq!(err.path, "X");
+    }
+
+    #[test]
+    fn test_code_schema_quoted_type() {
+        let err = parse_schema(r#"record X { "a": "string" } root X"#).unwrap_err();
+        assert_eq!(err.code, "schema.quoted-type");
+        assert_eq!(err.path, "X");
+    }
+
+    #[test]
+    fn test_code_schema_nullable_ref() {
+        let err = parse_schema(
+            r#"record Child { "v": string }
+               record Parent { "c": Child? }
+               root Parent"#,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, "schema.nullable-ref");
+        assert_eq!(err.path, "Parent.c");
+    }
+
+    #[test]
+    fn test_code_schema_nullable_any() {
+        let err = parse_schema(r#"record X { "a": any? } root X"#).unwrap_err();
+        assert_eq!(err.code, "schema.nullable-any");
+        assert_eq!(err.path, "X.a");
     }
 
     // -- Comments interleaved with real grammar ------------------------------

--- a/omnist/src/osd.rs
+++ b/omnist/src/osd.rs
@@ -342,14 +342,14 @@ impl Parser {
             (bound, Some(bound))
         };
         self.expect_punct("]")?;
-        if let Some(hi) = hi {
-            if hi < lo {
-                return Err(SchemaError::new(
-                    path,
-                    "schema.invalid-cardinality",
-                    format!("invalid cardinality range [{lo}, {hi}]"),
-                ));
-            }
+        if let Some(hi) = hi
+            && hi < lo
+        {
+            return Err(SchemaError::new(
+                path,
+                "schema.invalid-cardinality",
+                format!("invalid cardinality range [{lo}, {hi}]"),
+            ));
         }
         Ok((lo, hi))
     }

--- a/omnist/src/osd.rs
+++ b/omnist/src/osd.rs
@@ -147,8 +147,6 @@ fn unquote(s: &str) -> String {
 // Parser
 // ---------------------------------------------------------------------------
 
-
-
 struct Parser {
     toks: Vec<Tok>,
     i: usize,
@@ -892,7 +890,10 @@ mod tests {
 
     #[test]
     fn cardinality_overflow_is_an_error() {
-        let err = parse_schema(r#"record X { "a" [999999999999999999999999999999999999999]: string } root X"#).unwrap_err();
+        let err = parse_schema(
+            r#"record X { "a" [999999999999999999999999999999999999999]: string } root X"#,
+        )
+        .unwrap_err();
         assert_eq!(err.code, "schema.non-integer-cardinality");
         assert_eq!(err.path, "X.a");
     }

--- a/omnist/src/schema.rs
+++ b/omnist/src/schema.rs
@@ -794,14 +794,14 @@ impl Schema {
         }
         for (rec_name, rec) in &self.env {
             for f in rec.fields() {
-                if let FieldType::Ref(r) = &f.ty {
-                    if !self.env.contains_key(&r.name) {
-                        return Err(SchemaError::new(
-                            format!("{rec_name}.{}", f.label),
-                            "schema.unknown-type",
-                            format!("unknown type {:?}", r.name),
-                        ));
-                    }
+                if let FieldType::Ref(r) = &f.ty
+                    && !self.env.contains_key(&r.name)
+                {
+                    return Err(SchemaError::new(
+                        format!("{rec_name}.{}", f.label),
+                        "schema.unknown-type",
+                        format!("unknown type {:?}", r.name),
+                    ));
                 }
             }
         }

--- a/omnist/src/schema.rs
+++ b/omnist/src/schema.rs
@@ -299,9 +299,11 @@ impl ScalarKind {
             .find(|k| k.as_str() == name)
             .ok_or_else(|| {
                 let names: Vec<&str> = ScalarKind::ALL.iter().map(|k| k.as_str()).collect();
-                SchemaError::new(format!(
-                    "unknown scalar {name:?}; expected one of {names:?}"
-                ))
+                SchemaError::new(
+                    name,
+                    "schema.unknown-type",
+                    format!("unknown scalar {name:?}; expected one of {names:?}"),
+                )
             })
     }
 }
@@ -449,9 +451,11 @@ impl Field {
         if let Some(max) = max
             && max < min
         {
-            return Err(SchemaError::new(format!(
-                "field {label:?} has an invalid cardinality [{min},{max}]"
-            )));
+            return Err(SchemaError::new(
+                label.clone(),
+                "schema.invalid-cardinality",
+                format!("field {label:?} has an invalid cardinality [{min},{max}]"),
+            ));
         }
         Ok(Field {
             label,
@@ -522,10 +526,11 @@ impl Record {
         let mut by_label = IndexMap::with_capacity(fields.len());
         for (i, f) in fields.iter().enumerate() {
             if by_label.insert(f.label.clone(), i).is_some() {
-                return Err(SchemaError::new(format!(
-                    "duplicate field label {:?} in a record",
-                    f.label
-                )));
+                return Err(SchemaError::new(
+                    &f.label,
+                    "schema.duplicate-field",
+                    format!("duplicate field label {:?} in a record", f.label),
+                ));
             }
         }
         Ok(Record { fields, by_label })
@@ -748,17 +753,22 @@ impl Schema {
     fn check_reserved_names(env: &IndexMap<String, Record>) -> Result<(), SchemaError> {
         for name in env.keys() {
             if name == "any" {
-                return Err(SchemaError::new(format!(
-                    "'any' is a reserved type name and cannot be used as a record name \
-                     (record {name:?})"
-                )));
+                return Err(SchemaError::new(
+                    "any",
+                    "schema.reserved-name",
+                    format!(
+                        "'any' is a reserved type name and cannot be used as a record name                          (record {name:?})"
+                    ),
+                ));
             }
             if ScalarKind::ALL.iter().any(|k| k.as_str() == name) {
-                return Err(SchemaError::new(format!(
-                    "{name:?} is a reserved scalar name; a record cannot be defined with \
-                     this name, or it could never be referenced (a bare name in a type \
-                     position always means the builtin scalar)"
-                )));
+                return Err(SchemaError::new(
+                    name,
+                    "schema.reserved-name",
+                    format!(
+                        "{name:?} is a reserved scalar name; a record cannot be defined with                          this name, or it could never be referenced (a bare name in a type                          position always means the builtin scalar)"
+                    ),
+                ));
             }
         }
         Ok(())
@@ -775,17 +785,23 @@ impl Schema {
     }
 
     fn check_refs(&self) -> Result<(), SchemaError> {
-        let walk = |r: &Ref| -> Result<(), SchemaError> {
-            if !self.env.contains_key(&r.name) {
-                return Err(SchemaError::new(format!("unknown type {:?}", r.name)));
-            }
-            Ok(())
-        };
-        walk(&self.root)?;
-        for rec in self.env.values() {
+        if !self.env.contains_key(&self.root.name) {
+            return Err(SchemaError::new(
+                "$",
+                "schema.unknown-type",
+                format!("unknown type {:?}", self.root.name),
+            ));
+        }
+        for (rec_name, rec) in &self.env {
             for f in rec.fields() {
                 if let FieldType::Ref(r) = &f.ty {
-                    walk(r)?;
+                    if !self.env.contains_key(&r.name) {
+                        return Err(SchemaError::new(
+                            format!("{rec_name}.{}", f.label),
+                            "schema.unknown-type",
+                            format!("unknown type {:?}", r.name),
+                        ));
+                    }
                 }
             }
         }

--- a/src/api.md
+++ b/src/api.md
@@ -731,7 +731,11 @@ pub struct DocumentError {
     pub message: String,
 }
 
-pub struct SchemaError(pub String);
+pub struct SchemaError {
+    pub path: String,
+    pub code: String,
+    pub message: String,
+}
 
 pub struct ParseError {
     pub line: usize,

--- a/tools/conformance/src/bin/vector_runner.rs
+++ b/tools/conformance/src/bin/vector_runner.rs
@@ -78,10 +78,9 @@
 //! path-set-comparison shape used everywhere else) instead of skipping --
 //! a narrower gap than TS's, not the favorable "no gap at all" outcome:
 //! `omnist::schema::parse_schema`'s `SchemaError` (used for
-//! `osd-grammar`/`schema-wellformedness` `parse_schema` vectors) carries
-//! only a `String` message, no structured fields at all, so *those*
-//! specific syntax-failure-with-diagnostics vectors still skip, citing
-//! "SchemaError carries no structured path/code".
+//! `osd-grammar`/`schema-wellformedness` `parse_schema` vectors) now carries
+//! structured `path`, `code`, and `message` fields (issue #122), resolving
+//! the former skip branch and verifying diagnostics directly.
 //!
 //! **Formerly-unreachable temporal-write-report skip, now resolved (issue
 //! #89, found during issue #82 Step 4 triage; resolved by issue #105).**
@@ -394,18 +393,19 @@ fn run_parse_schema(v: &Json) -> VResult {
                 fail("expected failure, parse_schema succeeded")
             }
         }
-        Err(_) => {
+        Err(e) => {
             if expect_ok(v) {
                 return fail("expected success, parse_schema failed");
             }
-            // `SchemaError` (osd.rs) carries only a `String` message, no
-            // structured path/code -- see module docs. Any vector
-            // asserting specific diagnostics on a schema-syntax failure
-            // can't be checked past ok/not-ok.
-            if v["expect"]["diagnostics"].as_array().is_some() {
-                skip("SchemaError carries no structured path/code")
-            } else {
+            let expected_paths = expected_diag_paths(v);
+            if expected_paths.is_empty() {
+                return pass();
+            }
+            let actual_paths = vec![e.path.clone()];
+            if paths_match(expected_paths, actual_paths) {
                 pass()
+            } else {
+                fail("diagnostic paths differ")
             }
         }
     }
@@ -861,7 +861,7 @@ mod tests {
     /// calls directly). The exact counts are this step's honest,
     /// freshly-reproduced measurement -- history through (124, 0, 22) at
     /// 146 vectors (issue #99), then (129, 0, 23) at 152 vectors after
-    /// issue #104. Now (130, 0, 22) after issue #105 (`Scalar`/`Value`
+    /// issue #104. (130, 0, 22) after issue #105. Now (146, 0, 6) after issue #122 (`SchemaError` structured path/code)
     /// gained real `Date`/`Time`/`Datetime` variants): the
     /// `formats-json/basic/temporal-leaf-is-stringified-on-write` vector,
     /// previously skipped as structurally unreachable (issue #89, since
@@ -877,7 +877,7 @@ mod tests {
         let (passed, failed, skipped) = run_all(&suite_dir());
         assert_eq!(
             (passed, failed, skipped),
-            (130, 0, 22),
+            (146, 0, 6),
             "vector pass/fail/skip counts changed -- if this is an intentional fix or a new \
              vector, update the pinned baseline; if not, something regressed"
         );
@@ -1275,6 +1275,16 @@ mod tests {
             "operation": "parse",
             "input": {"format": "oml", "text": "nan: 1\n"},
             "expect": {"ok": false, "diagnostics": [{"path": "9:9"}]}
+        });
+        assert_eq!(dispatch(&v).status, Status::Fail);
+    }
+
+    #[test]
+    fn run_parse_schema_diagnostic_path_mismatch_fails() {
+        let v = json!({
+            "operation": "parse_schema",
+            "input": {"text": "record X { a: string } root X"},
+            "expect": {"ok": false, "diagnostics": [{"path": "$.wrong"}]}
         });
         assert_eq!(dispatch(&v).status, Status::Fail);
     }


### PR DESCRIPTION
Gives SchemaError path, code, and message fields according to spec ?8.3.3 / ?8.3.6 taxonomy. Unblocks schema diagnostic verification in vector runner.