### PR TITLE
Build grouped tree once per write_json/write_yaml call (#126)

### DIFF
--- a/omnist/Cargo.toml
+++ b/omnist/Cargo.toml
@@ -26,3 +26,7 @@ serde_json = { version = "1", features = ["preserve_order"] }
 [[bench]]
 name = "yaml_merge"
 harness = false
+
+[[bench]]
+name = "writer_grouped_tree"
+harness = false

--- a/omnist/benches/writer_grouped_tree.rs
+++ b/omnist/benches/writer_grouped_tree.rs
@@ -1,0 +1,69 @@
+use omnist::document::{Doc, RawNode, Scalar};
+use omnist::formats::json::write_json;
+use omnist::formats::yaml::write_yaml;
+use std::time::Instant;
+
+fn make_unique_keys_doc(n: usize) -> Doc {
+    let edges = (0..n)
+        .map(|i| (format!("key_{i}"), RawNode::Leaf(Scalar::Int((i as i64).into()))))
+        .collect();
+    Doc::from_raw(RawNode::Edges(edges)).unwrap()
+}
+
+fn make_repeated_keys_doc(keys: usize, reps: usize) -> Doc {
+    let mut edges = Vec::with_capacity(keys * reps);
+    for i in 0..reps {
+        for k in 0..keys {
+            edges.push((format!("key_{k}"), RawNode::Leaf(Scalar::Int((i as i64).into()))));
+        }
+    }
+    Doc::from_raw(RawNode::Edges(edges)).unwrap()
+}
+
+fn main() {
+    println!("=== Benchmark: JSON & YAML writer grouped-tree ===");
+
+    let unique_doc = make_unique_keys_doc(5000);
+    let repeated_doc = make_repeated_keys_doc(10, 500);
+
+    // Warmup
+    let _ = write_json(&unique_doc, None, false, None).unwrap();
+    let _ = write_json(&repeated_doc, None, false, None).unwrap();
+    let _ = write_yaml(&unique_doc, false, None).unwrap();
+    let _ = write_yaml(&repeated_doc, false, None).unwrap();
+
+    let iters = 50;
+
+    // 1. JSON - Unique Keys (5,000 keys)
+    let start = Instant::now();
+    for _ in 0..iters {
+        let _ = write_json(&unique_doc, None, false, None).unwrap();
+    }
+    let json_unique_ms = (start.elapsed().as_micros() as f64 / iters as f64) / 1000.0;
+
+    // 2. JSON - Repeated Keys (10 keys x 500 reps = 5,000 edges)
+    let start = Instant::now();
+    for _ in 0..iters {
+        let _ = write_json(&repeated_doc, None, false, None).unwrap();
+    }
+    let json_repeated_ms = (start.elapsed().as_micros() as f64 / iters as f64) / 1000.0;
+
+    // 3. YAML - Unique Keys (5,000 keys)
+    let start = Instant::now();
+    for _ in 0..iters {
+        let _ = write_yaml(&unique_doc, false, None).unwrap();
+    }
+    let yaml_unique_ms = (start.elapsed().as_micros() as f64 / iters as f64) / 1000.0;
+
+    // 4. YAML - Repeated Keys (10 keys x 500 reps = 5,000 edges)
+    let start = Instant::now();
+    for _ in 0..iters {
+        let _ = write_yaml(&repeated_doc, false, None).unwrap();
+    }
+    let yaml_repeated_ms = (start.elapsed().as_micros() as f64 / iters as f64) / 1000.0;
+
+    println!("JSON unique keys (5,000):     {:>8.3} ms / iter", json_unique_ms);
+    println!("JSON repeated keys (5,000):   {:>8.3} ms / iter", json_repeated_ms);
+    println!("YAML unique keys (5,000):     {:>8.3} ms / iter", yaml_unique_ms);
+    println!("YAML repeated keys (5,000):   {:>8.3} ms / iter", yaml_repeated_ms);
+}

--- a/omnist/benches/writer_grouped_tree.rs
+++ b/omnist/benches/writer_grouped_tree.rs
@@ -5,7 +5,12 @@ use std::time::Instant;
 
 fn make_unique_keys_doc(n: usize) -> Doc {
     let edges = (0..n)
-        .map(|i| (format!("key_{i}"), RawNode::Leaf(Scalar::Int((i as i64).into()))))
+        .map(|i| {
+            (
+                format!("key_{i}"),
+                RawNode::Leaf(Scalar::Int((i as i64).into())),
+            )
+        })
         .collect();
     Doc::from_raw(RawNode::Edges(edges)).unwrap()
 }
@@ -14,7 +19,10 @@ fn make_repeated_keys_doc(keys: usize, reps: usize) -> Doc {
     let mut edges = Vec::with_capacity(keys * reps);
     for i in 0..reps {
         for k in 0..keys {
-            edges.push((format!("key_{k}"), RawNode::Leaf(Scalar::Int((i as i64).into()))));
+            edges.push((
+                format!("key_{k}"),
+                RawNode::Leaf(Scalar::Int((i as i64).into())),
+            ));
         }
     }
     Doc::from_raw(RawNode::Edges(edges)).unwrap()
@@ -62,8 +70,20 @@ fn main() {
     }
     let yaml_repeated_ms = (start.elapsed().as_micros() as f64 / iters as f64) / 1000.0;
 
-    println!("JSON unique keys (5,000):     {:>8.3} ms / iter", json_unique_ms);
-    println!("JSON repeated keys (5,000):   {:>8.3} ms / iter", json_repeated_ms);
-    println!("YAML unique keys (5,000):     {:>8.3} ms / iter", yaml_unique_ms);
-    println!("YAML repeated keys (5,000):   {:>8.3} ms / iter", yaml_repeated_ms);
+    println!(
+        "JSON unique keys (5,000):     {:>8.3} ms / iter",
+        json_unique_ms
+    );
+    println!(
+        "JSON repeated keys (5,000):   {:>8.3} ms / iter",
+        json_repeated_ms
+    );
+    println!(
+        "YAML unique keys (5,000):     {:>8.3} ms / iter",
+        yaml_unique_ms
+    );
+    println!(
+        "YAML repeated keys (5,000):   {:>8.3} ms / iter",
+        yaml_repeated_ms
+    );
 }

--- a/omnist/src/formats/json.rs
+++ b/omnist/src/formats/json.rs
@@ -96,8 +96,8 @@ pub fn write_json(
     strict: bool,
     report: Option<&mut WriteReport>,
 ) -> Result<String, WriteError> {
-    let rep = check_json(doc);
     let grouped = doc.to_grouped();
+    let rep = check_json_grouped(&grouped);
     let prepared = if strict { grouped } else { prepare(grouped) };
     let mut out = String::new();
     write_value(&prepared, indent, 0, &mut out);
@@ -112,10 +112,14 @@ pub fn write_json(
 /// for the (rare) NaN/Infinity leaf -- not for every leaf up front (issue
 /// #44), since `visit_grouped` reuses one path buffer for the whole walk.
 pub fn check_json(doc: &Doc) -> WriteReport {
-    let mut rep = WriteReport::new();
     let grouped = doc.to_grouped();
+    check_json_grouped(&grouped)
+}
+
+fn check_json_grouped(grouped: &Value) -> WriteReport {
+    let mut rep = WriteReport::new();
     let mut path = String::from("$");
-    crate::formats::visit_grouped(&grouped, &mut path, &mut |visited, path| {
+    crate::formats::visit_grouped(grouped, &mut path, &mut |visited, path| {
         let crate::formats::Visited::Node { value } = visited else {
             return;
         };

--- a/omnist/src/formats/yaml.rs
+++ b/omnist/src/formats/yaml.rs
@@ -902,8 +902,8 @@ pub fn write_yaml(
     strict: bool,
     report: Option<&mut WriteReport>,
 ) -> Result<String, WriteError> {
-    let rep = check_yaml(doc);
     let grouped = doc.to_grouped();
+    let rep = check_yaml_grouped(&grouped);
     let mut out = String::new();
     write_node(&grouped, 0, &mut out, true);
     if out.ends_with('\n') {
@@ -916,10 +916,14 @@ pub fn write_yaml(
 /// adjustment YAML ever needs is forcing double-quoted style for a U+0085
 /// (NEL) string/label -- see this module's doc comment.
 pub fn check_yaml(doc: &Doc) -> WriteReport {
-    let mut rep = WriteReport::new();
     let grouped = doc.to_grouped();
+    check_yaml_grouped(&grouped)
+}
+
+fn check_yaml_grouped(grouped: &Value) -> WriteReport {
+    let mut rep = WriteReport::new();
     let mut path = String::from("$");
-    crate::formats::visit_grouped(&grouped, &mut path, &mut |visited, path| match visited {
+    crate::formats::visit_grouped(grouped, &mut path, &mut |visited, path| match visited {
         crate::formats::Visited::Edge { label } if label.contains('\u{0085}') => {
             rep.add(
                 path,


### PR DESCRIPTION
Tier 1 optimization: refactors write_json and write_yaml to build the grouped tree once per write call, sharing it with internal check scanners.