### PR TITLE
Reconcile stale architecture claims, limitations, and duplicate docs (#123)

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,6 +1,6 @@
 # Limitations & stability
 
-## Alpha status: `0.1.0-alpha`, per this project's versioning rule
+## Alpha status: `0.1.3-alpha`, per this project's versioning rule
 
 The Rust port's first feature-complete milestone (issue #28) plus its own
 conformance-test harness against
@@ -14,31 +14,14 @@ them); accumulating further features or fixes alone never moves it past
 `-alpha` on its own. Treat every public API in this crate as subject to
 change without a deprecation cycle until that further sign-off happens.
 
-## The `any`-type scoping gap (deferred, not forgotten)
+## The `any`-type support (landed)
 
 Python's schema model has an `AnyType`/`ANY` type and an `allow_any` option
 several APIs (`osd`, schema algebra, inference) use as a fallback when a
-precise type can't otherwise be resolved. This Rust port's
-`omnist::schema` module (issue #6) **deliberately does not implement
-`any`** -- its inclusion in the public API is an explicitly deferred design
-question pending user sign-off, not an oversight. The same scoping choice
-threads through every module that would otherwise need it:
-
-- `omnist::osd` still recognizes `"any"` as a reserved schema-text keyword
-  (so it can't be used as a record name), but using it as a field's type
-  returns a clear `SchemaError` explaining it isn't supported yet, rather
-  than silently misparsing.
-- `omnist::infer::infer` has no `allow_any` fallback: a label whose samples
-  mix objects and scalars, or whose scalars disagree on kind outside the
-  integer/number subset relation, returns a `SchemaError` instead of
-  silently degrading to `any`.
-- The CLI's `infer --allow-any` flag is accepted by the argument parser
-  (matching Python's surface) but returns the same "not supported yet"
-  error rather than doing something different from plain `infer`.
-
-Closing this gap is 1.0-gating work, not a bug to fix incrementally --
-see the sibling `omnist` project's own `any`-openness decision, which this
-port's scoping deliberately mirrors rather than resolves independently.
+precise type can't otherwise be resolved. In this Rust port, `FieldType::Any`
+is fully supported across `omnist::schema`, `omnist::osd` parsing (`record X { "a": any }`),
+and `omnist::infer` (with `allow_any` fallback mode when schemas have ambiguous
+types or mixed structures, also wired into the CLI's `infer --allow-any` flag).
 
 ## `Scalar::Int` is arbitrary-precision (issue #104)
 

--- a/docs/workflow-playbook.md
+++ b/docs/workflow-playbook.md
@@ -171,6 +171,14 @@ catch a signature that changed while the name stayed the same (e.g.
 `Int(i64)` → `Int(BigInt)`); that half is still on the "update it in the
 same PR" discipline above, not a mechanical check.
 
+**Mechanical identifier and claim sweep on core model changes (issue #123).**
+Whenever a core model type changes (e.g. its internal representation like
+`i64` -> `BigInt`, an added/removed variant, or a parser refactor like
+`Vec<char>` -> byte-indexed `&str`), in addition to human review for semantic
+claims, mechanically grep the entire repository (`git grep -rn '<old_claim>'`)
+for stale doc comments and prose claims justifying old architectural choices
+(such as justifying the absence of guards based on an outdated `i64` assumption).
+
 ## When the port disagrees with upstream Python or TypeScript
 
 Porting will surface cases where this implementation's behavior differs

--- a/omnist/src/document.rs
+++ b/omnist/src/document.rs
@@ -20,15 +20,13 @@
 //!   possible, so the whole bug class is closed by the type system rather
 //!   than checked at runtime (see the workflow playbook's "what NOT to
 //!   carry over unexamined").
-//! - **No integer-digit guard.** Python's `_check_int_digits` defends
+//! - **Integer-digit security cap.** Python's `_check_int_digits` defends
 //!   against `str()`-converting an arbitrary-precision `int` with
-//!   thousands of digits (a superlinear operation). This port's `Scalar`
-//!   uses `i64`, which tops out at 19 digits — nowhere near the 4300-digit
-//!   cap — so the guard would be permanently-dead code with no reachable
-//!   branch to test (the TypeScript port kept a dormant version of this
-//!   check under an explicit coverage-ignore for parity; this port omits
-//!   it entirely rather than ship untestable dead code for a guard that
-//!   can't fire for `i64`).
+//!   thousands of digits (a superlinear operation). Since issue #104,
+//!   `Scalar::Int` is backed by arbitrary-precision `num_bigint::BigInt`,
+//!   and format decoders (JSON, YAML, TOML) enforce the security cap
+//!   (`crate::limits::MAX_INT_DIGITS`, 4300 digits) during lexing/parsing
+//!   before BigInt construction.
 //!
 //! Observable behavior for everything else (construction, depth guard,
 //! edge ordering, mutation semantics) matches the Python spec.

--- a/omnist/src/formats/toml.rs
+++ b/omnist/src/formats/toml.rs
@@ -91,13 +91,12 @@
 //! implementation for an oversized hex/octal/binary literal to reach
 //! `Scalar::Int` uncapped the way Python's arbitrary-precision `int` does.
 //! This is a **disclosed divergence from Python**, not parity: kept
-//! deliberately rather than special-cased away, because (a) `Scalar::Int`
-//! is `i64`-backed regardless of the literal's original radix, so an
-//! "uncapped hex" path would still have to fail *somewhere* for anything
+//! deliberately rather than special-cased away, because (a) TOML 1.0 itself
+//! specifies 64-bit signed integers and `toml_edit` enforces 64-bit bounds
+//! at parse time, so an "uncapped hex" path would still fail for anything
 //! over `i64::MAX`, and (b) capping the digit run uniformly preserves the
 //! same superlinear-conversion DoS protection `json.rs`/`yaml.rs` apply,
-//! without carving out a radix-specific exemption this port has no
-//! representational way to honor past 64 bits anyway.
+//! without carving out a radix-specific exemption.
 //!
 //! Where this module's implementation had to diverge from `json.rs`'s
 //! straight-line reuse: **`toml_edit` itself enforces a strict 64-bit

--- a/omnist/src/oml.rs
+++ b/omnist/src/oml.rs
@@ -29,7 +29,7 @@
 //! construction until actually needed -- a Python-performance-specific
 //! design (see the module's PR #168 for the profile that motivated it), not
 //! a behavioral requirement. This port uses a straightforward hand-written
-//! recursive-descent scanner/parser over `Vec<char>` instead: idiomatic
+//! recursive-descent scanner/parser over byte-indexed `&str` instead: idiomatic
 //! Rust, and there's no equivalent hot-path reason to defer decoding here.
 //! Observable behavior (parse results, round-trips, error content) matches
 //! the Python reference; exact error wording does not need to.

--- a/omnist/src/schema.rs
+++ b/omnist/src/schema.rs
@@ -717,7 +717,6 @@ pub(crate) fn value_kind_name(v: &DocScalar) -> &'static str {
 // ---------------------------------------------------------------------------
 
 /// A resolved field type: a record (via a `Ref`), a bare `Scalar`, or `Any`.
-/// A resolved field type: a record (via a `Ref`), a bare `Scalar`, or `Any`.
 pub enum Resolved<'a> {
     /// A resolved record in the schema environment.
     Record(&'a Record),


### PR DESCRIPTION
Updates doc comments and limitations regarding BigInt Scalar backing, OML scanner representation, landed any-type support, removes duplicate schema doc line, and adds mechanical grep sweep checklist item.