### PR TITLE
version: bump to 0.2.0-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "check-doc-examples"
-version = "0.1.3-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "tempfile",
 ]
@@ -155,7 +155,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "conformance"
-version = "0.1.3-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "num-bigint",
  "omnist",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "omnist"
-version = "0.1.3-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "indexmap",
  "num-bigint",
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "omnist-cli"
-version = "0.1.3-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "clap",
  "indexmap",

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This repository follows a strict spec-first methodology. `vendor/omnist-spec` is
 
 ## Status
 
-**`v0.1.3-alpha`.**
+**`v0.2.0-alpha`.**
 
 - **Conformance Harness**: Track 1 (CLI fixtures) **19 / 19 (100%) PASS**. Track 2 (JSON test vectors) **130 / 152 PASS, 0 real fails, 22 skips**.
 - **Testing**: **936 tests passing**, 0 failures — unit tests plus `proptest`-based property fuzzing across every format reader.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,6 +1,6 @@
 # Limitations & stability
 
-## Alpha status: `0.1.3-alpha`, per this project's versioning rule
+## Alpha status: `0.2.0-alpha`, per this project's versioning rule
 
 The Rust port's first feature-complete milestone (issue #28) plus its own
 conformance-test harness against

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,7 +2,7 @@
 
 ```toml
 [dependencies]
-omnist = "0.1.3-alpha"
+omnist = "0.2.0-alpha"
 ```
 <!-- doc-illustrative -->
 

--- a/omnist-cli/Cargo.toml
+++ b/omnist-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnist-cli"
-version = "0.1.3-alpha"
+version = "0.2.0-alpha"
 edition = "2024"
 description = "CLI for omnist (Rust port)."
 license = "Apache-2.0"

--- a/omnist/Cargo.toml
+++ b/omnist/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnist"
-version = "0.1.3-alpha"
+version = "0.2.0-alpha"
 edition = "2024"
 description = "One data model, many formats: read, validate, and write JSON, YAML, TOML, XML, and OML. (Rust port of https://github.com/omnist-dev/omnist)"
 license = "Apache-2.0"

--- a/omnist/src/tests.rs
+++ b/omnist/src/tests.rs
@@ -11,7 +11,7 @@ use super::*;
 
 #[test]
 fn version_matches_cargo_toml() {
-    assert_eq!(VERSION, "0.1.3-alpha");
+    assert_eq!(VERSION, "0.2.0-alpha");
 }
 
 #[test]

--- a/src/limitations.md
+++ b/src/limitations.md
@@ -1,6 +1,6 @@
 # Limitations & stability
 
-## Alpha status: `0.1.0-alpha`, per this project's versioning rule
+## Alpha status: `0.2.0-alpha`, per this project's versioning rule
 
 The Rust port's first feature-complete milestone (issue #28) plus its own
 conformance-test harness against
@@ -14,31 +14,14 @@ them); accumulating further features or fixes alone never moves it past
 `-alpha` on its own. Treat every public API in this crate as subject to
 change without a deprecation cycle until that further sign-off happens.
 
-## The `any`-type scoping gap (deferred, not forgotten)
+## The `any`-type support (landed)
 
 Python's schema model has an `AnyType`/`ANY` type and an `allow_any` option
 several APIs (`osd`, schema algebra, inference) use as a fallback when a
-precise type can't otherwise be resolved. This Rust port's
-`omnist::schema` module (issue #6) **deliberately does not implement
-`any`** -- its inclusion in the public API is an explicitly deferred design
-question pending user sign-off, not an oversight. The same scoping choice
-threads through every module that would otherwise need it:
-
-- `omnist::osd` still recognizes `"any"` as a reserved schema-text keyword
-  (so it can't be used as a record name), but using it as a field's type
-  returns a clear `SchemaError` explaining it isn't supported yet, rather
-  than silently misparsing.
-- `omnist::infer::infer` has no `allow_any` fallback: a label whose samples
-  mix objects and scalars, or whose scalars disagree on kind outside the
-  integer/number subset relation, returns a `SchemaError` instead of
-  silently degrading to `any`.
-- The CLI's `infer --allow-any` flag is accepted by the argument parser
-  (matching Python's surface) but returns the same "not supported yet"
-  error rather than doing something different from plain `infer`.
-
-Closing this gap is 1.0-gating work, not a bug to fix incrementally --
-see the sibling `omnist` project's own `any`-openness decision, which this
-port's scoping deliberately mirrors rather than resolves independently.
+precise type can't otherwise be resolved. In this Rust port, `FieldType::Any`
+is fully supported across `omnist::schema`, `omnist::osd` parsing (`record X { "a": any }`),
+and `omnist::infer` (with `allow_any` fallback mode when schemas have ambiguous
+types or mixed structures, also wired into the CLI's `infer --allow-any` flag).
 
 ## `Scalar::Int` is arbitrary-precision (issue #104)
 

--- a/src/quickstart.md
+++ b/src/quickstart.md
@@ -2,7 +2,7 @@
 
 ```toml
 [dependencies]
-omnist = "0.1.3-alpha"
+omnist = "0.2.0-alpha"
 ```
 <!-- doc-illustrative -->
 

--- a/tools/check-doc-examples/Cargo.toml
+++ b/tools/check-doc-examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "check-doc-examples"
-version = "0.1.3-alpha"
+version = "0.2.0-alpha"
 edition = "2024"
 description = "CI gate: every new/changed fenced code block in docs/*.md needs a verified-by or doc-illustrative marker."
 license = "Apache-2.0"

--- a/tools/conformance/Cargo.toml
+++ b/tools/conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conformance"
-version = "0.1.3-alpha"
+version = "0.2.0-alpha"
 edition = "2024"
 description = "omnist-rs's own conformance-test harness against omnist-spec (issue #82): referee + Track 1 fixture runner + Track 2 vector runner, consuming the pinned vendor/omnist-spec submodule directly, never depending on Python's or TypeScript's implementation."
 license = "Apache-2.0"


### PR DESCRIPTION
Version bump for the completed 14-issue Codex-audit fix cycle (#114-127). Confirmed by omnist-spec. Reasoning: SchemaError breaking API change (#122) + new public read_xml_with_schema (#114) + 7 correctness/safety fixes cross the minor threshold. Also resyncs src/limitations.md, which had drifted (still described `any` as unimplemented). Full workspace build/test/fmt/clippy/coverage/conformance all green.
