### PR TITLE
Optimize check_toml and write_toml with borrowed grouped tree inspection (#126)

### DIFF
--- a/omnist/Cargo.toml
+++ b/omnist/Cargo.toml
@@ -34,3 +34,7 @@ harness = false
 [[bench]]
 name = "record_partial_eq"
 harness = false
+
+[[bench]]
+name = "toml_writer"
+harness = false

--- a/omnist/benches/toml_writer.rs
+++ b/omnist/benches/toml_writer.rs
@@ -1,0 +1,88 @@
+use omnist::document::{Doc, RawNode, Scalar};
+use omnist::formats::toml::{check_toml, write_toml};
+use std::time::Instant;
+
+fn make_unique_keys_doc(n: usize) -> Doc {
+    let edges = (0..n)
+        .map(|i| {
+            (
+                format!("key_{i}"),
+                RawNode::Leaf(Scalar::Int((i as i64).into())),
+            )
+        })
+        .collect();
+    Doc::from_raw(RawNode::Edges(edges)).unwrap()
+}
+
+fn make_repeated_keys_doc(keys: usize, reps: usize) -> Doc {
+    let mut edges = Vec::with_capacity(keys * reps);
+    for i in 0..reps {
+        for k in 0..keys {
+            edges.push((
+                format!("key_{k}"),
+                RawNode::Leaf(Scalar::Int((i as i64).into())),
+            ));
+        }
+    }
+    Doc::from_raw(RawNode::Edges(edges)).unwrap()
+}
+
+fn main() {
+    println!("=== Benchmark: TOML writer and checker ===");
+
+    let unique_doc = make_unique_keys_doc(5000);
+    let repeated_doc = make_repeated_keys_doc(10, 500);
+
+    // Warmup
+    let _ = write_toml(&unique_doc, false, None).unwrap();
+    let _ = write_toml(&repeated_doc, false, None).unwrap();
+    let _ = check_toml(&unique_doc);
+    let _ = check_toml(&repeated_doc);
+
+    let iters = 50;
+
+    // 1. TOML Write - Unique Keys (5,000 keys)
+    let start = Instant::now();
+    for _ in 0..iters {
+        let _ = write_toml(&unique_doc, false, None).unwrap();
+    }
+    let toml_write_unique_ms = (start.elapsed().as_micros() as f64 / iters as f64) / 1000.0;
+
+    // 2. TOML Write - Repeated Keys (10 keys x 500 reps = 5,000 edges)
+    let start = Instant::now();
+    for _ in 0..iters {
+        let _ = write_toml(&repeated_doc, false, None).unwrap();
+    }
+    let toml_write_repeated_ms = (start.elapsed().as_micros() as f64 / iters as f64) / 1000.0;
+
+    // 3. TOML Check - Unique Keys (5,000 keys)
+    let start = Instant::now();
+    for _ in 0..iters {
+        let _ = check_toml(&unique_doc);
+    }
+    let toml_check_unique_ms = (start.elapsed().as_micros() as f64 / iters as f64) / 1000.0;
+
+    // 4. TOML Check - Repeated Keys (10 keys x 500 reps = 5,000 edges)
+    let start = Instant::now();
+    for _ in 0..iters {
+        let _ = check_toml(&repeated_doc);
+    }
+    let toml_check_repeated_ms = (start.elapsed().as_micros() as f64 / iters as f64) / 1000.0;
+
+    println!(
+        "TOML write unique keys (5,000):     {:>8.3} ms / iter",
+        toml_write_unique_ms
+    );
+    println!(
+        "TOML write repeated keys (5,000):   {:>8.3} ms / iter",
+        toml_write_repeated_ms
+    );
+    println!(
+        "TOML check unique keys (5,000):     {:>8.3} ms / iter",
+        toml_check_unique_ms
+    );
+    println!(
+        "TOML check repeated keys (5,000):   {:>8.3} ms / iter",
+        toml_check_repeated_ms
+    );
+}

--- a/omnist/src/formats/toml.rs
+++ b/omnist/src/formats/toml.rs
@@ -421,8 +421,62 @@ pub fn write_toml(
 pub fn check_toml(doc: &Doc) -> WriteReport {
     let mut rep = WriteReport::new();
     let grouped = doc.to_grouped();
-    let _ = strip_nulls(grouped, "$", &mut rep);
+    check_toml_grouped(&grouped, "$", &mut rep);
     rep
+}
+
+fn check_toml_grouped(node: &Value, path: &str, rep: &mut WriteReport) {
+    match node {
+        Value::Object(map) => {
+            for (label, child) in map {
+                match child {
+                    Value::Null => {
+                        rep.add(
+                            crate::report::child_path(path, label, 0),
+                            "null.omitted",
+                            "null value dropped (TOML has no null)",
+                            Severity::Warning,
+                        );
+                    }
+                    Value::Array(items) => {
+                        for (i, item) in items.iter().enumerate() {
+                            let p = crate::report::child_path(path, label, i);
+                            if matches!(item, Value::Null) {
+                                rep.add(
+                                    p,
+                                    "null.omitted",
+                                    "null value dropped (TOML has no null)",
+                                    Severity::Warning,
+                                );
+                            } else {
+                                check_toml_grouped(item, &p, rep);
+                            }
+                        }
+                    }
+                    other => {
+                        let p = crate::report::child_path(path, label, 0);
+                        check_toml_grouped(other, &p, rep);
+                    }
+                }
+            }
+        }
+        Value::Array(items) => {
+            for (i, item) in items.iter().enumerate() {
+                let p = crate::report::child_path(path, "", i);
+                if matches!(item, Value::Null) {
+                    rep.add(
+                        p,
+                        "null.omitted",
+                        "null value dropped (TOML has no null)",
+                        Severity::Warning,
+                    );
+                } else {
+                    check_toml_grouped(item, &p, rep);
+                }
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Marker type implementing [`crate::formats::Codec`] for TOML -- adapts
@@ -620,6 +674,41 @@ mod tests {
 
     fn obj(pairs: Vec<(&str, Value)>) -> Value {
         Value::Object(pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect())
+    }
+
+    #[test]
+    fn check_toml_reports_null_omitted_across_objects_and_arrays() {
+        let doc = doc_of(obj(vec![
+            ("null_field", Value::Null),
+            (
+                "nested",
+                obj(vec![
+                    ("inner_null", Value::Null),
+                    ("valid", Value::Int(1.into())),
+                ]),
+            ),
+            (
+                "arr",
+                Value::Array(vec![
+                    Value::Null,
+                    Value::Int(2.into()),
+                    obj(vec![("arr_inner_null", Value::Null)]),
+                ]),
+            ),
+        ]));
+        let rep = check_toml(&doc);
+        assert_eq!(rep.adjustments().len(), 4);
+        assert_eq!(rep.adjustments()[0].path, "$.null_field");
+        assert_eq!(rep.adjustments()[0].code, "null.omitted");
+    }
+
+    #[test]
+    fn check_toml_grouped_handles_array_root() {
+        let arr = Value::Array(vec![Value::Null, Value::Int(42.into())]);
+        let mut rep = WriteReport::new();
+        check_toml_grouped(&arr, "$", &mut rep);
+        assert_eq!(rep.adjustments().len(), 1);
+        assert_eq!(rep.adjustments()[0].path, "$.");
     }
 
     #[test]


### PR DESCRIPTION
Eliminates redundant strip_nulls allocations in check_toml by inspecting the grouped tree by reference (&Value), matching the Phase 3 check_json/check_yaml pattern.