### PR TITLE
Add CI workflow to publish omnist to crates.io on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - name: fmt
+        run: cargo fmt --all -- --check
+      - name: clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: test
+        run: cargo test --workspace
+      - name: dry-run package check
+        run: cargo publish -p omnist --dry-run
+
+  publish:
+    needs: verify
+    runs-on: ubuntu-latest
+    environment: crates-io
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@stable
+      - name: publish omnist to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p omnist


### PR DESCRIPTION
Two-job workflow triggered on v* tags: verify (fmt/clippy/test/cargo publish --dry-run) must pass before publish runs cargo publish -p omnist for real, using a CARGO_REGISTRY_TOKEN secret. Uses a crates-io GitHub Environment so you can optionally require manual approval before the publish job runs, as an extra safety net on top of the dry-run gate.

To activate: add a CARGO_REGISTRY_TOKEN secret (Settings > Secrets and variables > Actions, or scoped to a crates-io Environment under Settings > Environments) with your own crates.io API token. Then push a v0.2.0-alpha tag (already exists locally) or a new one to trigger it.