### PR TITLE
docs: add crates.io/docs.rs badges and install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
 # omnist-rs
 
+[![Crates.io](https://img.shields.io/crates/v/omnist.svg)](https://crates.io/crates/omnist)
+[![docs.rs](https://img.shields.io/docsrs/omnist)](https://docs.rs/omnist)
+
 From-scratch Rust port of the [Omnist data-interchange specification](https://github.com/omnist-dev/omnist-spec).
 
 Docs: [rs.omnist.dev](https://rs.omnist.dev) — includes generated [rustdoc API reference](https://rs.omnist.dev/api/omnist/index.html)
+
+## Install
+
+```toml
+[dependencies]
+omnist = "0.2.0-alpha"
+```
+
+Published on [crates.io](https://crates.io/crates/omnist); API reference on [docs.rs](https://docs.rs/omnist).
 
 ## Methodology
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,8 +10,10 @@ reproduced verbatim. For *why* each operation behaves the way it does, see
 [omnist-spec](https://github.com/omnist-dev/omnist-spec) sections (the
 normative behavior).
 
-`omnist` has `publish = false` in `Cargo.toml`, so there is no docs.rs page
-for this crate -- this is the closest equivalent. All items below are
+`omnist` is published on [crates.io](https://crates.io/crates/omnist), so
+[docs.rs/omnist](https://docs.rs/omnist) is the canonical generated API
+reference; this page and the rustdoc mirror above are curated
+alternatives, not a substitute for the real thing. All items below are
 re-exported at the crate root or reachable through their listed module path
 (`omnist::document::Doc`, `omnist::materialize`, etc).
 

--- a/src/api.md
+++ b/src/api.md
@@ -10,8 +10,10 @@ reproduced verbatim. For *why* each operation behaves the way it does, see
 [omnist-spec](https://github.com/omnist-dev/omnist-spec) sections (the
 normative behavior).
 
-`omnist` has `publish = false` in `Cargo.toml`, so there is no docs.rs page
-for this crate -- this is the closest equivalent. All items below are
+`omnist` is published on [crates.io](https://crates.io/crates/omnist), so
+[docs.rs/omnist](https://docs.rs/omnist) is the canonical generated API
+reference; this page and the rustdoc mirror above are curated
+alternatives, not a substitute for the real thing. All items below are
 re-exported at the crate root or reachable through their listed module path
 (`omnist::document::Doc`, `omnist::materialize`, etc).
 


### PR DESCRIPTION
omnist is now published on crates.io -- adds version and docs.rs badges plus an Install section to README.md, and fixes api.md/src/api.md's stale publish = false claim (the crate has a real docs.rs page now).