### PR TITLE
fix: OML scanner mis-tokenizes labels like nan_/inf_ that start with a reserved word

### DIFF
--- a/omnist/src/oml/scanner.rs
+++ b/omnist/src/oml/scanner.rs
@@ -122,7 +122,7 @@ impl<'a> Scanner<'a> {
     fn word_boundary_ok(&self, end: usize) -> bool {
         !self
             .byte_at(end)
-            .is_some_and(|b| b.is_ascii_alphanumeric() || b == b'-')
+            .is_some_and(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
     }
 
     /// Advance past (and describe) the next significant token.

--- a/omnist/src/oml/tests.rs
+++ b/omnist/src/oml/tests.rs
@@ -1310,6 +1310,28 @@ fn bare_lowercase_nan_inf_neg_inf_cannot_be_a_label() {
 }
 
 #[test]
+fn a_label_starting_with_nan_or_inf_but_continuing_with_underscore_is_a_real_identifier() {
+    // Regression: `word_boundary_ok` (scanner.rs) checked
+    // alphanumeric-or-'-' to decide whether "nan"/"inf" ends a reserved
+    // float keyword, but identifier continuation (`scan_word`'s own loop)
+    // also allows '_' -- so a label like `nan_` was wrongly tokenized as
+    // the keyword `nan` (TokKind::Float(NAN)) followed by a stray `_`,
+    // instead of the single identifier `nan_`. Found by proptest fuzzing
+    // (fuzz.rs::oml_round_trips) against a real Value with an object field
+    // labeled "nan_".
+    for label in ["nan_", "inf_", "nan_x", "infinity_ish"] {
+        let doc = read_oml(&format!("a: {{ {label}: 1 }}")).unwrap();
+        let RawNode::Edges(edges) = &doc else {
+            panic!("expected edges")
+        };
+        let RawNode::Edges(inner) = &edges[0].1 else {
+            panic!("expected edges")
+        };
+        assert_eq!(inner[0].0, label, "label {label:?} was mis-tokenized");
+    }
+}
+
+#[test]
 fn quoted_reserved_spelling_is_a_valid_label_and_round_trips() {
     // Grammar-doc conformance, mirroring Python's
     // `test_oml_ex9_nan_is_a_number_token_never_a_label` /


### PR DESCRIPTION
Found by CI fuzz testing on an unrelated docs PR -- proptest generated a Value with field label "nan_", which failed to round-trip through OML with "expected a label, got nan". Root cause: `word_boundary_ok` (scanner.rs) checked alphanumeric-or-`-` to decide whether `nan`/`inf` ends the reserved float keyword, but identifier continuation also allows `_`. Confirmed deterministic (not flaky) via a hand-written repro before fixing. One-line fix plus a real regression test.
