### PR TITLE
Reject a second root declaration (D-2, schema.duplicate-root)

### DIFF
--- a/omnist/src/osd.rs
+++ b/omnist/src/osd.rs
@@ -209,7 +209,15 @@ impl Parser {
                 self.define(&mut env, name, rec, name_pos)?;
             } else if t.kind == TokKind::Name && t.text == "root" {
                 self.next_tok();
-                root = Some(self.expect_name()?.text);
+                let name = self.expect_name()?.text;
+                if root.is_some() {
+                    return Err(SchemaError::new(
+                        "$",
+                        "schema.duplicate-root",
+                        "a schema must declare exactly one root",
+                    ));
+                }
+                root = Some(name);
             } else {
                 return Err(SchemaError::new(
                     "$",
@@ -862,6 +870,18 @@ mod tests {
     fn test_code_schema_no_root() {
         let err = parse_schema(r#"record X { "a": string }"#).unwrap_err();
         assert_eq!(err.code, "schema.no-root");
+        assert_eq!(err.path, "$");
+    }
+
+    #[test]
+    fn test_code_schema_duplicate_root() {
+        let src = "record R { \"a\": string, }
+record S { \"b\": string, }
+root R
+root S
+";
+        let err = parse_schema(src).unwrap_err();
+        assert_eq!(err.code, "schema.duplicate-root");
         assert_eq!(err.path, "$");
     }
 

--- a/tools/conformance/src/bin/vector_runner.rs
+++ b/tools/conformance/src/bin/vector_runner.rs
@@ -839,7 +839,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn vector_count_is_152() {
+    fn vector_count_is_153() {
         // 146 -> 152 via vendor/omnist-spec v0.1.1-alpha -> commit f93c569
         // (issue #104: arbitrary-precision `Scalar::Int`). The submodule
         // pin bump brings in several bundled, otherwise-unrelated
@@ -851,8 +851,11 @@ mod tests {
         // vector-by-vector here since several are genuinely unrelated to
         // this fix, matching this file's own precedent (issue #99's pin
         // bump bundled an unrelated NaN/Infinity vector the same way).
+        // 152 -> 153 via vendor/omnist-spec commit 964af7b (issue #154 /
+        // D-2: a second `root` declaration is now a normative error,
+        // `schema.duplicate-root`).
         let vectors = iter_vectors(&suite_dir());
-        assert_eq!(vectors.len(), 152);
+        assert_eq!(vectors.len(), 153);
     }
 
     /// Full-suite regression guard: runs every real vector through every
@@ -861,13 +864,15 @@ mod tests {
     /// calls directly). The exact counts are this step's honest,
     /// freshly-reproduced measurement -- history through (124, 0, 22) at
     /// 146 vectors (issue #99), then (129, 0, 23) at 152 vectors after
-    /// issue #104. (130, 0, 22) after issue #105. Now (146, 0, 6) after issue #122 (`SchemaError` structured path/code)
+    /// issue #104. (130, 0, 22) after issue #105. (146, 0, 6) after issue #122 (`SchemaError` structured path/code)
     /// gained real `Date`/`Time`/`Datetime` variants): the
     /// `formats-json/basic/temporal-leaf-is-stringified-on-write` vector,
     /// previously skipped as structurally unreachable (issue #89, since
     /// `Scalar` had no temporal variant to preserve through
     /// `decode_scalar`), now passes for real -- confirmed via a fresh
-    /// `[PASS]` line in the harness's own output, not assumed. Every
+    /// `[PASS]` line in the harness's own output, not assumed. Now
+    /// (147, 0, 6) after issue #154 (D-2: duplicate `root` is now a
+    /// normative error, `schema.duplicate-root`). Every
     /// count here is freshly reproduced by running the harness, not
     /// computed by hand. Pinned so a future change that silently
     /// regresses pass/fail/skip counts is caught, not a "this must
@@ -877,7 +882,7 @@ mod tests {
         let (passed, failed, skipped) = run_all(&suite_dir());
         assert_eq!(
             (passed, failed, skipped),
-            (146, 0, 6),
+            (147, 0, 6),
             "vector pass/fail/skip counts changed -- if this is an intentional fix or a new \
              vector, update the pinned baseline; if not, something regressed"
         );


### PR DESCRIPTION
## Summary

Closes #154 (D-2). Per omnist-spec section 5.8 (updated in commit 964af7b), an OSD schema with more than one root declaration is now a normative error, code schema.duplicate-root, path $. This used to be implementation-defined; this port previously let a second root silently overwrite the first.

## Changes

- omnist/src/osd.rs: parse_schema now returns schema.duplicate-root at path $ on seeing a second root declaration, following the same pattern as the existing schema.no-root check. Added a unit test (test_code_schema_duplicate_root).
- vendor/omnist-spec: bumped submodule pin from f93c569 to 964af7b, which introduces the osd-grammar/root/duplicate-root-is-an-error conformance vector.
- tools/conformance/src/bin/vector_runner.rs: updated pinned baselines (152 -> 153 total vectors, 146 -> 147 passing, 0 failed, 6 skipped -- unchanged).

Grepped the codebase for any code depending on last-root-wins behavior; found none outside the one assignment site being changed.

## Test plan

- [x] cargo run --bin vector_runner -- new vector osd-grammar/root/duplicate-root-is-an-error passes; 147 passed, 0 failed, 6 skipped (of 153 vectors)
- [x] cargo test --workspace -- all green
- [x] cargo clippy --workspace --all-targets -- clean
- [x] cargo fmt --all -- --check -- clean

Generated with Claude Code
