### PR TITLE
Report XML attribute/namespace drops and cross-label interleaving loss (D-3, #156)

### DIFF
--- a/omnist/src/document.rs
+++ b/omnist/src/document.rs
@@ -450,6 +450,44 @@ impl Doc {
         self.grouped_at(self.root)
     }
 
+    /// `true` iff [`Doc::to_grouped`]'s grouping (same-label edges
+    /// collapsed into an array, in first-seen order) changes the relative
+    /// order of edges anywhere in the document -- i.e. some node has two
+    /// edges under the same label with a *different* label's edge between
+    /// them (`[(m,A),(x,X),(m,B)]`), as opposed to a label merely
+    /// repeating contiguously (`[(m,A),(m,B),(x,X)]`), which grouping
+    /// reorders nothing for. Used by the JSON-family writers
+    /// (`json.rs`/`yaml.rs`/`toml.rs`, all built on `to_grouped`) to emit
+    /// `format.interleaving-lost` (spec Sec8.3.8, D-3) at the whole-document
+    /// path `$`, since the loss isn't localized to one label's edges.
+    pub(crate) fn has_interleaving_loss(&self) -> bool {
+        self.node_has_interleaving_loss(self.root)
+    }
+
+    fn node_has_interleaving_loss(&self, id: NodeId) -> bool {
+        match &self.entry(id).data {
+            NodeData::Leaf(_) => false,
+            NodeData::Internal(edges) => {
+                let mut closed: std::collections::HashSet<&str> = std::collections::HashSet::new();
+                let mut prev_label: Option<&str> = None;
+                for (label, _) in edges {
+                    if let Some(p) = prev_label
+                        && p != label.as_str()
+                    {
+                        closed.insert(p);
+                    }
+                    if closed.contains(label.as_str()) {
+                        return true;
+                    }
+                    prev_label = Some(label.as_str());
+                }
+                edges
+                    .iter()
+                    .any(|(_, child)| self.node_has_interleaving_loss(*child))
+            }
+        }
+    }
+
     // Note: unlike `build_node`/`data_at`, this has no depth parameter --
     // it walks an already-validated tree (every node was depth-checked at
     // construction time), so there's nothing left to guard here.

--- a/omnist/src/formats/json.rs
+++ b/omnist/src/formats/json.rs
@@ -97,11 +97,28 @@ pub fn write_json(
     report: Option<&mut WriteReport>,
 ) -> Result<String, WriteError> {
     let grouped = doc.to_grouped();
-    let rep = check_json_grouped(&grouped);
+    let mut rep = check_json_grouped(&grouped);
+    add_interleaving_diagnostic(doc, &mut rep);
     let prepared = if strict { grouped } else { prepare(grouped) };
     let mut out = String::new();
     write_value(&prepared, indent, 0, &mut out);
     crate::report::finish_write(out, rep, strict, report)
+}
+
+/// `format.interleaving-lost` (spec Sec8.3.8, D-3) is a whole-document
+/// diagnostic that depends on the original `Doc`'s edge order, not on the
+/// already-grouped `Value` `check_json_grouped` scans -- so it is detected
+/// separately via `Doc::has_interleaving_loss` and added here rather than
+/// folded into that grouped-`Value` walk.
+fn add_interleaving_diagnostic(doc: &Doc, rep: &mut WriteReport) {
+    if doc.has_interleaving_loss() {
+        rep.add(
+            "$",
+            "format.interleaving-lost",
+            "cross-label interleaving could not be written; same-label edges were grouped",
+            Severity::Warning,
+        );
+    }
 }
 
 /// Report what writing JSON would adjust, without producing output.
@@ -113,7 +130,9 @@ pub fn write_json(
 /// #44), since `visit_grouped` reuses one path buffer for the whole walk.
 pub fn check_json(doc: &Doc) -> WriteReport {
     let grouped = doc.to_grouped();
-    check_json_grouped(&grouped)
+    let mut rep = check_json_grouped(&grouped);
+    add_interleaving_diagnostic(doc, &mut rep);
+    rep
 }
 
 fn check_json_grouped(grouped: &Value) -> WriteReport {
@@ -1366,5 +1385,80 @@ mod tests {
         let nested = "[".repeat(50_000) + &"]".repeat(50_000);
         let err = read_json(&nested).unwrap_err();
         assert!(err.to_string().contains("maximum depth"));
+    }
+
+    // ---------------------------------------------- D-3: format.interleaving-lost
+    // (issue #156, spec Sec8.3.8. See
+    // formats-json/basic/cross-label-interleaving-lost-and-reported in the
+    // conformance suite for the normative vector this mirrors; the same MUST
+    // applies to YAML/TOML for the identical grouping reason -- see the
+    // matching tests in yaml.rs/toml.rs.)
+
+    fn interleaved_doc() -> Doc {
+        // [(m,A),(x,X),(m,B)]: m's two edges are not contiguous.
+        Doc::from_raw(crate::document::RawNode::Edges(vec![
+            (
+                "m".to_string(),
+                crate::document::RawNode::Leaf(Scalar::Str("A".to_string())),
+            ),
+            (
+                "x".to_string(),
+                crate::document::RawNode::Leaf(Scalar::Str("X".to_string())),
+            ),
+            (
+                "m".to_string(),
+                crate::document::RawNode::Leaf(Scalar::Str("B".to_string())),
+            ),
+        ]))
+        .unwrap()
+    }
+
+    fn contiguous_repeat_doc() -> Doc {
+        // [(m,A),(m,B),(x,X)]: m's two edges are contiguous -- not interleaved.
+        Doc::from_raw(crate::document::RawNode::Edges(vec![
+            (
+                "m".to_string(),
+                crate::document::RawNode::Leaf(Scalar::Str("A".to_string())),
+            ),
+            (
+                "m".to_string(),
+                crate::document::RawNode::Leaf(Scalar::Str("B".to_string())),
+            ),
+            (
+                "x".to_string(),
+                crate::document::RawNode::Leaf(Scalar::Str("X".to_string())),
+            ),
+        ]))
+        .unwrap()
+    }
+
+    #[test]
+    fn reports_interleaving_lost_on_write() {
+        let doc = interleaved_doc();
+        let mut report = crate::report::WriteReport::new();
+        let text = write_json(&doc, None, false, Some(&mut report)).unwrap();
+        assert_eq!(text, r#"{"m": ["A", "B"], "x": "X"}"#);
+        let adjustments = report.adjustments();
+        assert_eq!(adjustments.len(), 1);
+        assert_eq!(adjustments[0].path, "$");
+        assert_eq!(adjustments[0].code, "format.interleaving-lost");
+        assert_eq!(adjustments[0].severity, Severity::Warning);
+    }
+
+    #[test]
+    fn check_json_reports_interleaving_lost() {
+        let rep = check_json(&interleaved_doc());
+        assert_eq!(rep.adjustments().len(), 1);
+        assert_eq!(rep.adjustments()[0].code, "format.interleaving-lost");
+    }
+
+    #[test]
+    fn contiguous_repeated_label_does_not_report_interleaving_lost() {
+        let doc = contiguous_repeat_doc();
+        let mut report = crate::report::WriteReport::new();
+        let text = write_json(&doc, None, false, Some(&mut report)).unwrap();
+        assert_eq!(text, r#"{"m": ["A", "B"], "x": "X"}"#);
+        assert!(report.is_empty());
+        assert!(check_json(&doc).is_empty());
     }
 }

--- a/omnist/src/formats/toml.rs
+++ b/omnist/src/formats/toml.rs
@@ -405,6 +405,7 @@ pub fn write_toml(
     report: Option<&mut WriteReport>,
 ) -> Result<String, WriteError> {
     let mut rep = WriteReport::new();
+    add_interleaving_diagnostic(doc, &mut rep);
     let grouped = doc.to_grouped();
     let stripped = strip_nulls(grouped, "$", &mut rep);
     let Value::Object(map) = &stripped else {
@@ -417,9 +418,26 @@ pub fn write_toml(
     crate::report::finish_write(out, rep, strict, report)
 }
 
+/// `format.interleaving-lost` (spec Sec8.3.8, D-3) is a whole-document
+/// diagnostic that depends on the original `Doc`'s edge order, lost by the
+/// time `to_grouped` runs -- so it is detected separately via
+/// `Doc::has_interleaving_loss` rather than folded into the grouped-`Value`
+/// scanners below.
+fn add_interleaving_diagnostic(doc: &Doc, rep: &mut WriteReport) {
+    if doc.has_interleaving_loss() {
+        rep.add(
+            "$",
+            "format.interleaving-lost",
+            "cross-label interleaving could not be written; same-label edges were grouped",
+            Severity::Warning,
+        );
+    }
+}
+
 /// Report what writing TOML would adjust, without producing output.
 pub fn check_toml(doc: &Doc) -> WriteReport {
     let mut rep = WriteReport::new();
+    add_interleaving_diagnostic(doc, &mut rep);
     let grouped = doc.to_grouped();
     check_toml_grouped(&grouped, "$", &mut rep);
     rep
@@ -1451,5 +1469,75 @@ mod tests {
             *doc2.root().get_one("a").unwrap().value().unwrap(),
             Scalar::Str("back\\slash cr\r back\u{08}space form\u{0c}feed ctl\u{01}".to_string())
         );
+    }
+
+    // ---------------------------------------------- D-3: format.interleaving-lost
+    // (issue #156, spec Sec8.3.8. Same MUST as formats-json/basic/
+    // cross-label-interleaving-lost-and-reported -- TOML shares JSON's
+    // `to_grouped` grouping, so the loss and the report are identical
+    // in shape; see json.rs's mirrored tests.)
+
+    fn interleaved_doc() -> Doc {
+        Doc::from_raw(crate::document::RawNode::Edges(vec![
+            (
+                "m".to_string(),
+                crate::document::RawNode::Leaf(Scalar::Str("A".to_string())),
+            ),
+            (
+                "x".to_string(),
+                crate::document::RawNode::Leaf(Scalar::Str("X".to_string())),
+            ),
+            (
+                "m".to_string(),
+                crate::document::RawNode::Leaf(Scalar::Str("B".to_string())),
+            ),
+        ]))
+        .unwrap()
+    }
+
+    fn contiguous_repeat_doc() -> Doc {
+        Doc::from_raw(crate::document::RawNode::Edges(vec![
+            (
+                "m".to_string(),
+                crate::document::RawNode::Leaf(Scalar::Str("A".to_string())),
+            ),
+            (
+                "m".to_string(),
+                crate::document::RawNode::Leaf(Scalar::Str("B".to_string())),
+            ),
+            (
+                "x".to_string(),
+                crate::document::RawNode::Leaf(Scalar::Str("X".to_string())),
+            ),
+        ]))
+        .unwrap()
+    }
+
+    #[test]
+    fn reports_interleaving_lost_on_write() {
+        let doc = interleaved_doc();
+        let mut report = crate::report::WriteReport::new();
+        write_toml(&doc, false, Some(&mut report)).unwrap();
+        let adjustments = report.adjustments();
+        assert_eq!(adjustments.len(), 1);
+        assert_eq!(adjustments[0].path, "$");
+        assert_eq!(adjustments[0].code, "format.interleaving-lost");
+        assert_eq!(adjustments[0].severity, crate::report::Severity::Warning);
+    }
+
+    #[test]
+    fn check_toml_reports_interleaving_lost() {
+        let rep = check_toml(&interleaved_doc());
+        assert_eq!(rep.adjustments().len(), 1);
+        assert_eq!(rep.adjustments()[0].code, "format.interleaving-lost");
+    }
+
+    #[test]
+    fn contiguous_repeated_label_does_not_report_interleaving_lost() {
+        let doc = contiguous_repeat_doc();
+        let mut report = crate::report::WriteReport::new();
+        write_toml(&doc, false, Some(&mut report)).unwrap();
+        assert!(report.is_empty());
+        assert!(check_toml(&doc).is_empty());
     }
 }

--- a/omnist/src/formats/xml.rs
+++ b/omnist/src/formats/xml.rs
@@ -219,7 +219,7 @@ fn xml_pretype(node: RawNode, schema: &Schema, ty: &FieldType) -> RawNode {
     }
 }
 
-fn read_xml_raw(text: &str) -> Result<RawNode, OmnistError> {
+fn read_xml_raw(text: &str, mut report: Option<&mut WriteReport>) -> Result<RawNode, OmnistError> {
     let normalized = normalize_line_endings(text);
     let mut reader = Reader::from_str(&normalized);
     reader.config_mut().trim_text(false);
@@ -233,11 +233,16 @@ fn read_xml_raw(text: &str) -> Result<RawNode, OmnistError> {
             Event::Start(e) => {
                 let mut node_count = 1;
                 let tag = local_name(e.name());
-                let content = parse_content(&mut reader, &normalized, 1, &mut node_count)?;
+                let path = crate::report::child_path("$", &tag, 0);
+                record_elem_diagnostics(&e, &path, report.as_deref_mut());
+                let content =
+                    parse_content(&mut reader, &normalized, 1, &mut node_count, &path, report)?;
                 break RawNode::Edges(vec![(tag, content)]);
             }
             Event::Empty(e) => {
                 let tag = local_name(e.name());
+                let path = crate::report::child_path("$", &tag, 0);
+                record_elem_diagnostics(&e, &path, report.as_deref_mut());
                 break RawNode::Edges(vec![(tag, RawNode::Leaf(Scalar::Str(String::new())))]);
             }
             Event::Eof => {
@@ -337,7 +342,20 @@ fn read_xml_raw(text: &str) -> Result<RawNode, OmnistError> {
 /// Parse XML text into a [`Doc`], preserving element order/interleaving
 /// exactly (see this module's doc comment).
 pub fn read_xml(text: &str) -> Result<Doc, OmnistError> {
-    let raw = read_xml_raw(text)?;
+    let raw = read_xml_raw(text, None)?;
+    let doc = Doc::from_raw(raw)?;
+    Ok(doc)
+}
+
+/// Same as [`read_xml`], but also reports `format.attribute-dropped` and
+/// `format.namespace-dropped` adjustments (spec Sec8.3.8, D-3) into
+/// `report` for every element that had an attribute or a namespace prefix
+/// discarded, mirroring the write-side `report: Option<&mut WriteReport>`
+/// pattern every writer in this crate already uses -- see
+/// `crate::report`'s module doc. `report: None` behaves exactly like
+/// [`read_xml`].
+pub fn read_xml_report(text: &str, report: Option<&mut WriteReport>) -> Result<Doc, OmnistError> {
+    let raw = read_xml_raw(text, report)?;
     let doc = Doc::from_raw(raw)?;
     Ok(doc)
 }
@@ -345,7 +363,7 @@ pub fn read_xml(text: &str) -> Result<Doc, OmnistError> {
 /// Parse XML text into a [`Doc`] with schema-guided pretyping of boolean,
 /// integer, and number scalar fields (spec §2.2 / issue #114).
 pub fn read_xml_with_schema(text: &str, schema: &Schema) -> Result<Doc, OmnistError> {
-    let raw = read_xml_raw(text)?;
+    let raw = read_xml_raw(text, None)?;
     let pretyped = xml_pretype(raw, schema, &FieldType::Ref(schema.root().clone()));
     let doc = Doc::from_raw(pretyped)?;
     Ok(doc)
@@ -361,6 +379,8 @@ fn parse_content(
     source: &str,
     depth: usize,
     node_count: &mut usize,
+    path: &str,
+    mut report: Option<&mut WriteReport>,
 ) -> Result<RawNode, OmnistError> {
     if depth > MAX_DEPTH {
         return Err(DocumentError::new(
@@ -371,6 +391,12 @@ fn parse_content(
     }
     let mut text = String::new();
     let mut children: Vec<(String, RawNode)> = Vec::new();
+    // Same-label occurrence counts, tracked incrementally (O(1) amortized
+    // per child) rather than by rescanning children on every element via
+    // children.iter().filter(...).count(), which is O(n) per element and
+    // made a MAX_NODES-sized sibling run O(n^2).
+    let mut label_counts: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
     let mut buf = Vec::new();
     loop {
         buf.clear();
@@ -388,7 +414,20 @@ fn parse_content(
                     .into());
                 }
                 let tag = local_name(e.name());
-                let child = parse_content(reader, source, depth + 1, node_count)?;
+                let index = *label_counts
+                    .entry(tag.clone())
+                    .and_modify(|n| *n += 1)
+                    .or_insert(0);
+                let child_path = crate::report::child_path(path, &tag, index);
+                record_elem_diagnostics(&e, &child_path, report.as_deref_mut());
+                let child = parse_content(
+                    reader,
+                    source,
+                    depth + 1,
+                    node_count,
+                    &child_path,
+                    report.as_deref_mut(),
+                )?;
                 children.push((tag, child));
             }
             Event::Empty(e) => {
@@ -401,6 +440,12 @@ fn parse_content(
                     .into());
                 }
                 let tag = local_name(e.name());
+                let index = *label_counts
+                    .entry(tag.clone())
+                    .and_modify(|n| *n += 1)
+                    .or_insert(0);
+                let child_path = crate::report::child_path(path, &tag, index);
+                record_elem_diagnostics(&e, &child_path, report.as_deref_mut());
                 children.push((tag, RawNode::Leaf(Scalar::Str(String::new()))));
             }
             Event::End(_) => break,
@@ -461,6 +506,38 @@ fn located_error(reader: &Reader<&[u8]>, source: &str, message: &str) -> OmnistE
     let pos = (reader.buffer_position() as usize).min(source.len());
     let (line, col) = line_col_bytes(source, pos);
     ParseError::new(line, col, message).into()
+}
+
+/// Records `format.attribute-dropped` and `format.namespace-dropped`
+/// (spec Sec8.3.8, D-3) for one just-opened element (`Start`/`Empty`
+/// event), at `path` -- the path of the element itself, matching the
+/// vectors' convention (the element the attribute/prefix was lost *from*,
+/// not its parent or child). A no-op when `report` is `None`, matching
+/// every other `Option<&mut WriteReport>` consumer in this crate.
+fn record_elem_diagnostics(
+    e: &quick_xml::events::BytesStart<'_>,
+    path: &str,
+    report: Option<&mut WriteReport>,
+) {
+    let Some(rep) = report else { return };
+    if e.attributes().next().is_some() {
+        rep.add(
+            path,
+            "format.attribute-dropped",
+            "an XML attribute was discarded on read",
+            Severity::Warning,
+        );
+    }
+    let name = e.name();
+    let raw = std::str::from_utf8(name.as_ref()).unwrap_or_default();
+    if raw.contains(':') {
+        rep.add(
+            path,
+            "format.namespace-dropped",
+            "an XML namespace prefix was discarded on read",
+            Severity::Warning,
+        );
+    }
 }
 
 /// The local (unprefixed) part of a tag name -- see this module's doc

--- a/omnist/src/formats/xml/tests.rs
+++ b/omnist/src/formats/xml/tests.rs
@@ -1267,3 +1267,59 @@ fn write_xml_temporal_scalars() {
         "<root>2024-01-01T12:00:00Z</root>"
     );
 }
+
+// ------------------------------------------------------- reader: D-3 diagnostics
+// (issue #156: format.attribute-dropped / format.namespace-dropped, spec
+// Sec8.3.8. See formats-xml/basic/attributes-are-dropped-on-read and
+// formats-xml/basic/namespace-prefix-is-dropped-on-read in the conformance
+// suite for the normative vectors this mirrors.)
+
+#[test]
+fn reports_attribute_dropped_on_read() {
+    let mut report = crate::report::WriteReport::new();
+    let doc = read_xml_report("<a x=\"1\"><b>hi</b></a>", Some(&mut report)).unwrap();
+    assert_eq!(
+        doc.to_raw(),
+        edges(vec![("a", edges(vec![("b", leaf_str("hi"))]))])
+    );
+    let adjustments = report.adjustments();
+    assert_eq!(adjustments.len(), 1);
+    assert_eq!(adjustments[0].path, "$.a");
+    assert_eq!(adjustments[0].code, "format.attribute-dropped");
+    assert_eq!(adjustments[0].severity, crate::report::Severity::Warning);
+}
+
+#[test]
+fn reports_namespace_dropped_on_read() {
+    let mut report = crate::report::WriteReport::new();
+    let doc = read_xml_report("<a><ns:b>hi</ns:b></a>", Some(&mut report)).unwrap();
+    assert_eq!(
+        doc.to_raw(),
+        edges(vec![("a", edges(vec![("b", leaf_str("hi"))]))])
+    );
+    let adjustments = report.adjustments();
+    assert_eq!(adjustments.len(), 1);
+    assert_eq!(adjustments[0].path, "$.a.b");
+    assert_eq!(adjustments[0].code, "format.namespace-dropped");
+    assert_eq!(adjustments[0].severity, crate::report::Severity::Warning);
+}
+
+#[test]
+fn no_diagnostics_when_nothing_is_dropped() {
+    let mut report = crate::report::WriteReport::new();
+    let doc = read_xml_report("<a><b>hi</b></a>", Some(&mut report)).unwrap();
+    assert_eq!(
+        doc.to_raw(),
+        edges(vec![("a", edges(vec![("b", leaf_str("hi"))]))])
+    );
+    assert!(report.is_empty());
+}
+
+#[test]
+fn read_xml_report_with_no_report_behaves_like_read_xml() {
+    let doc = read_xml_report("<a x=\"1\"><ns:b>hi</ns:b></a>", None).unwrap();
+    assert_eq!(
+        doc.to_raw(),
+        edges(vec![("a", edges(vec![("b", leaf_str("hi"))]))])
+    );
+}

--- a/omnist/src/formats/yaml.rs
+++ b/omnist/src/formats/yaml.rs
@@ -903,7 +903,8 @@ pub fn write_yaml(
     report: Option<&mut WriteReport>,
 ) -> Result<String, WriteError> {
     let grouped = doc.to_grouped();
-    let rep = check_yaml_grouped(&grouped);
+    let mut rep = check_yaml_grouped(&grouped);
+    add_interleaving_diagnostic(doc, &mut rep);
     let mut out = String::new();
     write_node(&grouped, 0, &mut out, true);
     if out.ends_with('\n') {
@@ -912,12 +913,30 @@ pub fn write_yaml(
     crate::report::finish_write(out, rep, strict, report)
 }
 
+/// `format.interleaving-lost` (spec Sec8.3.8, D-3) is a whole-document
+/// diagnostic that depends on the original `Doc`'s edge order, lost by the
+/// time `to_grouped` runs -- so it is detected separately via
+/// `Doc::has_interleaving_loss` rather than folded into `check_yaml_grouped`'s
+/// grouped-`Value` walk.
+fn add_interleaving_diagnostic(doc: &Doc, rep: &mut WriteReport) {
+    if doc.has_interleaving_loss() {
+        rep.add(
+            "$",
+            "format.interleaving-lost",
+            "cross-label interleaving could not be written; same-label edges were grouped",
+            Severity::Warning,
+        );
+    }
+}
+
 /// Report what writing YAML would adjust, without producing output. The only
 /// adjustment YAML ever needs is forcing double-quoted style for a U+0085
 /// (NEL) string/label -- see this module's doc comment.
 pub fn check_yaml(doc: &Doc) -> WriteReport {
     let grouped = doc.to_grouped();
-    check_yaml_grouped(&grouped)
+    let mut rep = check_yaml_grouped(&grouped);
+    add_interleaving_diagnostic(doc, &mut rep);
+    rep
 }
 
 fn check_yaml_grouped(grouped: &Value) -> WriteReport {
@@ -2676,5 +2695,75 @@ child:
             *child.get_one("c").unwrap().value().unwrap(),
             Scalar::Int((3).into())
         );
+    }
+
+    // ---------------------------------------------- D-3: format.interleaving-lost
+    // (issue #156, spec Sec8.3.8. Same MUST as formats-json/basic/
+    // cross-label-interleaving-lost-and-reported -- YAML shares JSON's
+    // `to_grouped` grouping, so the loss and the report are identical
+    // in shape; see json.rs's mirrored tests.)
+
+    fn interleaved_doc() -> Doc {
+        Doc::from_raw(crate::document::RawNode::Edges(vec![
+            (
+                "m".to_string(),
+                crate::document::RawNode::Leaf(Scalar::Str("A".to_string())),
+            ),
+            (
+                "x".to_string(),
+                crate::document::RawNode::Leaf(Scalar::Str("X".to_string())),
+            ),
+            (
+                "m".to_string(),
+                crate::document::RawNode::Leaf(Scalar::Str("B".to_string())),
+            ),
+        ]))
+        .unwrap()
+    }
+
+    fn contiguous_repeat_doc() -> Doc {
+        Doc::from_raw(crate::document::RawNode::Edges(vec![
+            (
+                "m".to_string(),
+                crate::document::RawNode::Leaf(Scalar::Str("A".to_string())),
+            ),
+            (
+                "m".to_string(),
+                crate::document::RawNode::Leaf(Scalar::Str("B".to_string())),
+            ),
+            (
+                "x".to_string(),
+                crate::document::RawNode::Leaf(Scalar::Str("X".to_string())),
+            ),
+        ]))
+        .unwrap()
+    }
+
+    #[test]
+    fn reports_interleaving_lost_on_write() {
+        let doc = interleaved_doc();
+        let mut report = crate::report::WriteReport::new();
+        write_yaml(&doc, false, Some(&mut report)).unwrap();
+        let adjustments = report.adjustments();
+        assert_eq!(adjustments.len(), 1);
+        assert_eq!(adjustments[0].path, "$");
+        assert_eq!(adjustments[0].code, "format.interleaving-lost");
+        assert_eq!(adjustments[0].severity, crate::report::Severity::Warning);
+    }
+
+    #[test]
+    fn check_yaml_reports_interleaving_lost() {
+        let rep = check_yaml(&interleaved_doc());
+        assert_eq!(rep.adjustments().len(), 1);
+        assert_eq!(rep.adjustments()[0].code, "format.interleaving-lost");
+    }
+
+    #[test]
+    fn contiguous_repeated_label_does_not_report_interleaving_lost() {
+        let doc = contiguous_repeat_doc();
+        let mut report = crate::report::WriteReport::new();
+        write_yaml(&doc, false, Some(&mut report)).unwrap();
+        assert!(report.is_empty());
+        assert!(check_yaml(&doc).is_empty());
     }
 }

--- a/tools/conformance/src/bin/vector_runner.rs
+++ b/tools/conformance/src/bin/vector_runner.rs
@@ -1315,6 +1315,36 @@ mod tests {
     }
 
     #[test]
+    fn run_parse_success_with_matching_read_diagnostics_passes() {
+        // format.attribute-dropped (Sec8.3.8, D-3): a *successful* XML
+        // parse can still carry warning-severity read diagnostics.
+        let v = json!({
+            "operation": "parse",
+            "input": {"format": "xml", "text": "<a x=\"1\"><b>hi</b></a>"},
+            "expect": {
+                "ok": true,
+                "document": {"edges": [["a", {"edges": [["b", {"scalar": {"kind": "string", "value": "hi"}}]]}]]},
+                "diagnostics": [{"path": "$.a"}]
+            }
+        });
+        assert_eq!(dispatch(&v).status, Status::Pass);
+    }
+
+    #[test]
+    fn run_parse_success_with_mismatched_read_diagnostics_fails() {
+        let v = json!({
+            "operation": "parse",
+            "input": {"format": "xml", "text": "<a x=\"1\"><b>hi</b></a>"},
+            "expect": {
+                "ok": true,
+                "document": {"edges": [["a", {"edges": [["b", {"scalar": {"kind": "string", "value": "hi"}}]]}]]},
+                "diagnostics": [{"path": "$.wrong"}]
+            }
+        });
+        assert_eq!(dispatch(&v).status, Status::Fail);
+    }
+
+    #[test]
     fn run_parse_schema_diagnostic_path_mismatch_fails() {
         let v = json!({
             "operation": "parse_schema",

--- a/tools/conformance/src/bin/vector_runner.rs
+++ b/tools/conformance/src/bin/vector_runner.rs
@@ -107,7 +107,7 @@ use omnist::document::{Doc, RawNode, Scalar};
 use omnist::error::OmnistError;
 use omnist::formats::json::{read_json, write_json};
 use omnist::formats::toml::{read_toml, write_toml};
-use omnist::formats::xml::{read_xml, write_xml};
+use omnist::formats::xml::{read_xml_report, write_xml};
 use omnist::formats::yaml::{read_yaml, write_yaml};
 use omnist::infer::infer_with_report;
 use omnist::materialize::materialize;
@@ -293,6 +293,12 @@ fn run_parse(v: &Json) -> VResult {
     // formats return `Doc` + `OmnistError`. Normalize both into
     // `Result<RawNode, Option<ErrPos>>` (an optional structural position) so
     // the rest of this driver is format-agnostic.
+    // `format.attribute-dropped`/`format.namespace-dropped` (spec Sec8.3.8,
+    // D-3) are read-time diagnostics only xml's reader emits, via
+    // `read_xml_report`'s `report: Option<&mut WriteReport>` (mirroring the
+    // write-side pattern) -- so only the "xml" arm below wires up a report;
+    // the other four formats have no read-time diagnostics to check.
+    let mut xml_report = WriteReport::new();
     let result: Result<RawNode, Option<ErrPos>> = match format {
         "oml" => read_oml(text).map_err(|e| Some(ErrPos::LineCol(e.line, e.col))),
         "json" => read_json(text)
@@ -301,7 +307,9 @@ fn run_parse(v: &Json) -> VResult {
         "toml" => read_toml(text)
             .map(|d| d.to_raw())
             .map_err(omnist_error_pos),
-        "xml" => read_xml(text).map(|d| d.to_raw()).map_err(omnist_error_pos),
+        "xml" => read_xml_report(text, Some(&mut xml_report))
+            .map(|d| d.to_raw())
+            .map_err(omnist_error_pos),
         "yaml" => read_yaml(text)
             .map(|d| d.to_raw())
             .map_err(omnist_error_pos),
@@ -314,11 +322,21 @@ fn run_parse(v: &Json) -> VResult {
                 return fail("expected failure, parse succeeded");
             }
             let expected = decode_document(&v["expect"]["document"]);
-            if raw == expected {
-                pass()
-            } else {
-                fail("parsed document does not match expected")
+            if raw != expected {
+                return fail("parsed document does not match expected");
             }
+            let expected_paths = expected_diag_paths(v);
+            if !expected_paths.is_empty() {
+                let actual_paths: Vec<String> = xml_report
+                    .adjustments()
+                    .iter()
+                    .map(|a| a.path.clone())
+                    .collect();
+                if !paths_match(expected_paths, actual_paths) {
+                    return fail("diagnostic paths differ");
+                }
+            }
+            pass()
         }
         Err(pos) => {
             if expect_ok(v) {
@@ -839,7 +857,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn vector_count_is_153() {
+    fn vector_count_is_155() {
         // 146 -> 152 via vendor/omnist-spec v0.1.1-alpha -> commit f93c569
         // (issue #104: arbitrary-precision `Scalar::Int`). The submodule
         // pin bump brings in several bundled, otherwise-unrelated
@@ -854,8 +872,15 @@ mod tests {
         // 152 -> 153 via vendor/omnist-spec commit 964af7b (issue #154 /
         // D-2: a second `root` declaration is now a normative error,
         // `schema.duplicate-root`).
+        // 153 -> 155 via vendor/omnist-spec commit 7f7690c (issue #156 /
+        // D-3: `format.attribute-dropped` and `format.namespace-dropped`
+        // read-time diagnostics each get their own new vector;
+        // `format.interleaving-lost` reuses the pre-existing
+        // `formats-json/basic/cross-label-interleaving-lost-and-reported`
+        // vector, only adding its `expect.diagnostics`, so it does not add
+        // a vector of its own).
         let vectors = iter_vectors(&suite_dir());
-        assert_eq!(vectors.len(), 153);
+        assert_eq!(vectors.len(), 155);
     }
 
     /// Full-suite regression guard: runs every real vector through every
@@ -876,13 +901,18 @@ mod tests {
     /// count here is freshly reproduced by running the harness, not
     /// computed by hand. Pinned so a future change that silently
     /// regresses pass/fail/skip counts is caught, not a "this must
-    /// always be 0 fails" gate.
+    /// always be 0 fails" gate. Now (149, 0, 6) after issue #156 (D-3):
+    /// `format.attribute-dropped`/`format.namespace-dropped`
+    /// (`formats-xml/xml.json`, read-time, via `read_xml_report`'s new
+    /// `WriteReport` parameter) and `format.interleaving-lost`
+    /// (`formats-json/json.json`, write-time, via
+    /// `Doc::has_interleaving_loss`) all now pass for real.
     #[test]
     fn full_suite_counts_match_the_measured_baseline() {
         let (passed, failed, skipped) = run_all(&suite_dir());
         assert_eq!(
             (passed, failed, skipped),
-            (147, 0, 6),
+            (149, 0, 6),
             "vector pass/fail/skip counts changed -- if this is an intentional fix or a new \
              vector, update the pinned baseline; if not, something regressed"
         );


### PR DESCRIPTION
## Summary

- Closes #156 (D-3): three previously-silent codec adjustments are now warning-severity diagnostics per spec §8.3.8, instead of silent data loss.
- `format.attribute-dropped` / `format.namespace-dropped`: new `read_xml_report(text, Option<&mut WriteReport>)`, additive alongside the existing `read_xml`/`read_xml_with_schema`, reports a discarded XML attribute or namespace prefix at the path of the element it was lost from (`$.a`, `$.a.b`).
- `format.interleaving-lost`: `write_json`/`write_yaml`/`write_toml` (and their `check_*` counterparts) report cross-label interleaving lost by grouping, at path `$`, via the existing `Doc::has_interleaving_loss()` helper.
- `vendor/omnist-spec` bumped to pick up the new/updated conformance vectors (`formats-xml/basic/attributes-are-dropped-on-read`, `formats-xml/basic/namespace-prefix-is-dropped-on-read`, `formats-json/basic/cross-label-interleaving-lost-and-reported`).
- Along the way, fixed an O(n²) same-label sibling-index computation in the XML reader's new path-tracking (rescanning `children` per element) that blew up at the `MAX_NODES` limit; replaced with an incrementally-updated `HashMap`.

## Test plan

- [x] `cargo test --workspace` — 716+ tests pass, 0 failures
- [x] `cargo run --bin vector_runner` (via `cargo test -p conformance`) — 155 vectors, 149 passed / 0 failed / 6 skipped (up from 153 / 147 / 0 / 6)
- [x] `cargo clippy --workspace --all-targets` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] New unit tests: `format.attribute-dropped`/`format.namespace-dropped` positive + negative cases in `omnist/src/formats/xml/tests.rs`; `format.interleaving-lost` positive case + a negative "contiguous repeat" case already covered in `json.rs`/`yaml.rs`/`toml.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
