### PR TITLE
Escape XML carriage returns as &#13; instead of writing them raw (#162)

### DIFF
--- a/omnist-cli/tests/cli.rs
+++ b/omnist-cli/tests/cli.rs
@@ -276,12 +276,16 @@ fn convert_of_nan_fails_unconditionally_exits_2_regardless_of_strict() {
 // `convert_result_format_json_encodes_the_report`: both used to exercise
 // `--report` against a NaN input that succeeded (with an adjustment)
 // before #161. NaN now fails the write outright, so these two now use an
-// XML target and a genuine still-succeeding warning-severity adjustment
-// (a carriage return, `string.cr_normalized`) to keep testing the
-// `--report`/`--result-format` machinery on a real non-failing case.
+// XML target and a genuine still-succeeding warning-severity adjustment.
+// Originally switched to a carriage return (`string.cr_normalized`), but
+// issue #162 retired that code too (CR now round-trips losslessly via
+// `&#13;`, nothing left to report) -- switched again, to `value.stringified`
+// (writing a non-string scalar to XML, untouched by #159/#160/#161/#162),
+// to keep testing the `--report`/`--result-format` machinery on a real
+// non-failing case.
 #[test]
 fn convert_report_prints_adjustments_to_stderr_and_still_writes() {
-    let input = fixture("convert_report_in", r#"{"a": "x\ry"}"#);
+    let input = fixture("convert_report_in", r#"{"a": 1}"#);
     let r = run(&[
         "convert", &input, "--from", "json", "--to", "xml", "--report",
     ]);
@@ -292,7 +296,7 @@ fn convert_report_prints_adjustments_to_stderr_and_still_writes() {
 
 #[test]
 fn convert_result_format_json_encodes_the_report() {
-    let input = fixture("convert_report_json_in", r#"{"a": "x\ry"}"#);
+    let input = fixture("convert_report_json_in", r#"{"a": 1}"#);
     let r = run(&[
         "convert",
         &input,
@@ -689,12 +693,14 @@ fn convert_to_oml_compact() {
 // that code -- writing a null to TOML now fails unconditionally
 // (`write.unsupported-value`, `Severity::Error` when previewed via
 // `check`) instead of succeeding with a warning. Switched to XML's
-// carriage-return normalization (`string.cr_normalized`), still a real
-// `Severity::Warning` adjustment on a write that still succeeds, to keep
-// exercising the same `--report`/`--result-format` machinery.
+// carriage-return normalization (`string.cr_normalized`), but issue #162
+// retired that code too -- switched again, to `value.stringified` (a
+// non-string scalar written to XML), still a real `Severity::Warning`
+// adjustment on a write that still succeeds, to keep exercising the same
+// `--report`/`--result-format` machinery.
 #[test]
 fn convert_report_with_a_warning_severity_adjustment_json_and_oml() {
-    let input = fixture("convert_warning_report_in", r#"{"a": "x\ry"}"#);
+    let input = fixture("convert_warning_report_in", r#"{"a": 1}"#);
     let r_json = run(&[
         "convert",
         &input,
@@ -725,10 +731,11 @@ fn convert_report_with_a_warning_severity_adjustment_json_and_oml() {
 }
 
 // Was `check_result_format_oml_with_a_warning_adjustment`: same
-// TOML-null -> XML-CR-normalization swap as above, for the same reason.
+// TOML-null -> XML-CR-normalization swap as above, then that -> XML
+// `value.stringified` swap as above, for the same reasons.
 #[test]
 fn check_result_format_oml_with_a_warning_adjustment() {
-    let input = fixture("check_warning_oml_in", r#"{"a": "x\ry"}"#);
+    let input = fixture("check_warning_oml_in", r#"{"a": 1}"#);
     let r = run(&[
         "check",
         &input,

--- a/omnist/src/formats/xml.rs
+++ b/omnist/src/formats/xml.rs
@@ -776,26 +776,25 @@ fn scan_leaf(scalar: &Scalar, path: &str, rep: &mut WriteReport) {
         ),
         Scalar::Str(_) => {}
     }
-    if let Scalar::Str(v) = scalar {
-        if v.chars().any(is_xml_illegal_char) {
-            rep.add(
-                path,
-                "string.illegal_xml_char",
-                "string contains a character XML 1.0 cannot represent (e.g. a C0 control other \
-                 than tab/LF/CR); it is replaced with U+FFFD on write so the output stays \
-                 well-formed",
-                Severity::Error,
-            );
-        }
-        if v.contains('\r') {
-            rep.add(
-                path,
-                "string.cr_normalized",
-                "string contains a carriage return ('\\r'); XML mandates line-ending \
-                 normalization on parse, so '\\r' (and '\\r\\n') read back as '\\n'",
-                Severity::Warning,
-            );
-        }
+    // `string.cr_normalized` retired (spec Sec8.3.8, issue #162): a
+    // literal '\r' is no longer written raw and reported lossy -- it's
+    // escaped as the numeric character reference `&#13;`, which is exempt
+    // from XML's mandatory line-ending normalization on parse and
+    // round-trips losslessly (confirmed live, both a bare '\r' and a
+    // '\r\n' sequence survive intact). See `xml_escape_text`. Nothing left
+    // to report here for '\r' -- the write is now genuinely lossless; only
+    // the illegal-control-character case below still needs reporting.
+    if let Scalar::Str(v) = scalar
+        && v.chars().any(is_xml_illegal_char)
+    {
+        rep.add(
+            path,
+            "string.illegal_xml_char",
+            "string contains a character XML 1.0 cannot represent (e.g. a C0 control other \
+             than tab/LF/CR); it is replaced with U+FFFD on write so the output stays \
+             well-formed",
+            Severity::Error,
+        );
     }
 }
 
@@ -917,9 +916,16 @@ fn is_xml_illegal_char(c: char) -> bool {
 }
 
 /// Escapes the three characters XML text content requires escaped
-/// (`&`, `<`, `>`) -- matching `ElementTree.tostring`'s text-escaping
-/// (quotes are left literal; they only need escaping in attribute values,
-/// which this module never writes).
+/// (`&`, `<`, `>`), plus (spec Sec8.3.8, issue #162) a literal carriage
+/// return as the numeric character reference `&#13;` -- matching
+/// `ElementTree.tostring`'s text-escaping for the first three (quotes are
+/// left literal; they only need escaping in attribute values, which this
+/// module never writes), and going beyond it for CR: XML mandates
+/// line-ending normalization on parse, so a raw CR byte and a raw LF byte
+/// read back identical (confirmed live) -- a numeric character reference
+/// is exempt from that normalization and round-trips intact, so a string
+/// containing a bare CR writes as `a&#13;b`, and a string containing a
+/// CRLF sequence writes as `a&#13;\nb`, not the raw bytes.
 fn xml_escape_text(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
     for c in text.chars() {
@@ -927,6 +933,7 @@ fn xml_escape_text(text: &str) -> String {
             '&' => out.push_str("&amp;"),
             '<' => out.push_str("&lt;"),
             '>' => out.push_str("&gt;"),
+            '\r' => out.push_str("&#13;"),
             c => out.push(c),
         }
     }

--- a/omnist/src/formats/xml/tests.rs
+++ b/omnist/src/formats/xml/tests.rs
@@ -450,7 +450,13 @@ fn sanitizes_every_illegal_character_not_just_the_first() {
 }
 
 #[test]
-fn check_xml_reports_illegal_char_as_error_and_cr_as_warning() {
+fn check_xml_reports_illegal_char_as_error_but_not_cr() {
+    // Was `check_xml_reports_illegal_char_as_error_and_cr_as_warning`:
+    // `string.cr_normalized` retired (spec Sec8.3.8, issue #162) -- a
+    // literal carriage return is escaped as `&#13;` and round-trips
+    // losslessly now (see `write_carriage_return_as_numeric_character_reference`
+    // below), so `check_xml` no longer reports anything for it. The
+    // illegal-control-character case (untouched by #162) still reports.
     let doc = Doc::from_raw(edges(vec![("root", leaf_str("bad\u{01}\rtext"))])).unwrap();
     let rep = check_xml(&doc);
     assert!(
@@ -459,10 +465,48 @@ fn check_xml_reports_illegal_char_as_error_and_cr_as_warning() {
             .any(|a| a.code == "string.illegal_xml_char" && a.severity == Severity::Error)
     );
     assert!(
-        rep.adjustments()
+        !rep.adjustments()
             .iter()
-            .any(|a| a.code == "string.cr_normalized" && a.severity == Severity::Warning)
+            .any(|a| a.code == "string.cr_normalized"),
+        "string.cr_normalized was retired by issue #162"
     );
+}
+
+// Was implicit in the retired `string.cr_normalized` warning: writing a
+// literal '\r' to XML must now escape it as the numeric character
+// reference `&#13;` (spec Sec8.3.8, issue #162) instead of writing it raw
+// -- a raw '\r' and a raw '\n' read back identical under XML's mandatory
+// line-ending normalization on parse, but `&#13;` is exempt from that
+// normalization and round-trips intact. Covers both a bare CR and a
+// CRLF sequence.
+#[test]
+fn write_carriage_return_as_numeric_character_reference() {
+    let doc = Doc::from_raw(edges(vec![("root", edges(vec![("x", leaf_str("a\rb"))]))])).unwrap();
+    let text = write_xml(&doc, false, None).unwrap();
+    assert_eq!(text, "<root>\n  <x>a&#13;b</x>\n</root>\n");
+
+    let doc2 = Doc::from_raw(edges(vec![(
+        "root",
+        edges(vec![("x", leaf_str("a\r\nb"))]),
+    )]))
+    .unwrap();
+    let text2 = write_xml(&doc2, false, None).unwrap();
+    assert_eq!(text2, "<root>\n  <x>a&#13;\nb</x>\n</root>\n");
+}
+
+#[test]
+fn check_xml_reports_nothing_for_a_carriage_return() {
+    let doc = Doc::from_raw(edges(vec![("root", leaf_str("a\rb"))])).unwrap();
+    assert!(check_xml(&doc).is_empty());
+}
+
+#[test]
+fn strict_write_of_a_carriage_return_succeeds() {
+    // `strict` never affects this -- the write is genuinely lossless now,
+    // not an adjustment `strict` could refuse.
+    let doc = Doc::from_raw(edges(vec![("root", leaf_str("a\rb"))])).unwrap();
+    let text = write_xml(&doc, true, None).unwrap();
+    assert_eq!(text, "<root>a&#13;b</root>");
 }
 
 #[test]

--- a/tools/conformance/src/bin/vector_runner.rs
+++ b/tools/conformance/src/bin/vector_runner.rs
@@ -851,13 +851,12 @@ pub fn run_all(dir: &Path) -> (u32, u32, u32) {
 /// its issue -- an entry lingering after its fix would silently stop
 /// verifying that the fix stuck.
 const KNOWN_FAILING_VECTORS: &[&str] = &[
-    // Pre-existing, unrelated to the 0ac1eac pin bump's own new content --
-    // XML write-side CR-as-numeric-character-reference isn't yet
-    // implemented (this crate currently normalizes CR to LF via the
-    // read-side rule instead of encoding it on write).
-    "formats-xml/basic/carriage-return-written-as-numeric-character-reference",
-    // Issues #162-166 (grammar/diagnostic-shape fixes from the same
-    // 0ac1eac pin bump as #159/#160/#161, not implemented by this PR).
+    // Issue #162 fixed this entry (XML write-side CR-as-numeric-character-
+    // reference) -- removed here in the same PR, per this constant's own
+    // doc comment above.
+    //
+    // Issues #163-166 (grammar/diagnostic-shape fixes from the same
+    // 0ac1eac pin bump as #159/#160/#161/#162, not implemented by this PR).
     "oml-grammar/numbers/leading-zero-integer-is-an-error",
     "oml-grammar/numbers/leading-zero-in-decimal-is-an-error",
     "oml-grammar/temporals/date-with-out-of-range-month-is-an-error",
@@ -976,11 +975,10 @@ mod tests {
     /// (`formats-json/json.json`, write-time, via
     /// `Doc::has_interleaving_loss`) all now pass for real.
     /// (149, 0, 6) -> (153, 13, 6) via the 0ac1eac submodule pin bump
-    /// (issues #158-166) plus this PR's own fixes (#159/#160/#161). The
-    /// pin bump alone added 17 new/changed failures at 172 total vectors;
-    /// this PR fixed 4 of them, all write-side unconditional-failure
-    /// vectors newly added by #159/#160/#161 (verified fail -> pass by
-    /// name, not assumed):
+    /// (issues #158-166) plus PR#167's write-side unconditional-failure
+    /// fixes (#159/#160/#161). The pin bump alone added 17 new/changed
+    /// failures at 172 total vectors; PR#167 fixed 4 of them (verified
+    /// fail -> pass by name, not assumed):
     ///   - `formats-xml/basic/label-with-illegal-xml-characters-cannot-be-written` (#159)
     ///   - `formats-toml/nulls/null-leaf-cannot-be-written` (#160)
     ///   - `formats-json/basic/nan-cannot-be-written` (#161, renamed+flipped from
@@ -988,23 +986,33 @@ mod tests {
     ///   - `formats-xml/basic/empty-internal-node-cannot-be-written` (#161, new)
     ///
     /// `formats-toml/nulls/null-leaf-cannot-be-written-strict-is-the-same`
-    /// (#160's strict-mode companion) was already passing before this PR
+    /// (#160's strict-mode companion) was already passing before PR#167
     /// (TOML's null-write already failed in strict mode; only the
     /// non-strict/unconditional-failure behavior needed fixing).
     ///
-    /// The remaining 13 failures are real, but out of scope for this PR --
-    /// they belong to other issues in the #158-166 batch (#158,
-    /// #162-#166) and to pre-existing oml-grammar/osd-grammar gaps this
-    /// pin bump's bundled vectors also touch. Left failing deliberately;
-    /// not this PR's job. Pinned so a future change that silently
-    /// regresses pass/fail/skip counts is caught, not a "this must always
-    /// be 0 fails" gate.
+    /// (153, 13, 6) -> (154, 12, 6) via issue #162 (XML write-side
+    /// carriage returns escaped as the numeric character reference
+    /// `&#13;` instead of written raw): `formats-xml/basic/carriage-
+    /// return-written-as-numeric-character-reference` moves fail -> pass
+    /// (verified, not assumed), and its entry is removed from
+    /// `KNOWN_FAILING_VECTORS` in the same PR, per that constant's own
+    /// doc comment.
+    ///
+    /// The remaining 12 failures are real, but out of scope -- they
+    /// belong to issues #163-#166 (still open) and to pre-existing
+    /// oml-grammar/osd-grammar gaps this pin bump's bundled vectors also
+    /// touch. Left failing deliberately; every one of them is also on
+    /// `KNOWN_FAILING_VECTORS`, so CI still passes -- see that constant's
+    /// doc comment for why this and `main_with_dir`'s exit code no longer
+    /// treat every failure as fatal. Pinned so a future change that
+    /// silently regresses pass/fail/skip counts is caught, not a "this
+    /// must always be 0 fails" gate.
     #[test]
     fn full_suite_counts_match_the_measured_baseline() {
         let (passed, failed, skipped) = run_all(&suite_dir());
         assert_eq!(
             (passed, failed, skipped),
-            (153, 13, 6),
+            (154, 12, 6),
             "vector pass/fail/skip counts changed -- if this is an intentional fix or a new \
              vector, update the pinned baseline; if not, something regressed"
         );


### PR DESCRIPTION
## Summary

Closes #162. Per omnist-spec §8.3.8 (updated 2026-08-24, commit `802566f`): a literal carriage return written to XML now escapes as the numeric character reference `&#13;` instead of being written as a raw byte.

Unlike the write.unsupported-value series in #159/#160/#161, this isn't a "fail the write" fix — a genuine lossless representation exists (a numeric character reference is exempt from XML's mandatory line-ending normalization on parse), so the fix is to escape it correctly. Confirmed live: a raw `\r` and a raw `\n` written as-is read back identical; `&#13;` round-trips both a bare `\r` and a `\r\n` sequence intact.

- `xml_escape_text` now escapes `\r` as `&#13;`, alongside the existing `&`/`<`/`>` escaping.
- Retires the `string.cr_normalized` diagnostic entirely — the write is genuinely lossless now, in every mode.
- Updates the existing tests that asserted the old raw-byte-plus-warning behavior; adds direct tests for a bare CR, a CRLF sequence, and strict mode.
- The four PR #167 CLI tests that borrowed a carriage return as their "still-succeeding warning-severity adjustment" example now use XML's `value.stringified` instead.
- Removes the vector from `KNOWN_FAILING_VECTORS` (added in #167) and updates the pinned baseline from `(153, 13, 6)` to `(154, 12, 6)`.

No `vendor/omnist-spec` submodule bump needed — `802566f` is already an ancestor of the `0ac1eac` pin #167 landed.

## Test plan

- [x] Red-before-green: confirmed the target vector failed before the fix
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — all green
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo llvm-cov --workspace --fail-under-lines 100` — 100.00% Lines (12465/12465)
- [x] `cargo run -p conformance --bin vector_runner` — 154 passed, 12 failed (all pre-existing/known, unrelated to this issue), 6 skipped, of 172
- [x] `cargo run -p check-doc-examples -- --base-ref origin/main` — passed

## Vector moved fail → pass

- `formats-xml/basic/carriage-return-written-as-numeric-character-reference`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
