### PR TITLE
Reject [0,0] cardinality, empty field labels, and bracket labels (#158, #163, #166)

### DIFF
--- a/omnist/src/osd.rs
+++ b/omnist/src/osd.rs
@@ -316,6 +316,42 @@ impl Parser {
             ));
         }
         let label = unquote(&label_tok.text);
+        // Empty field label is a normative error (spec Sec5.4, issue #163,
+        // updated 2026-08-29): "" is a legal OSD *string* generally, but a
+        // label is an identifier, not a value -- an empty label names
+        // nothing a caller could ever reference. Path is the enclosing
+        // record (no usable label to point at), same convention
+        // `schema.unquoted-label` above already uses for the analogous
+        // "the label itself is the problem" case.
+        if label.is_empty() {
+            return Err(SchemaError::new(
+                rec_name,
+                "schema.empty-label",
+                format!("field label at {} is empty", label_tok.pos),
+            ));
+        }
+        // '[' / ']' in a field label is a normative error (spec Sec5.4,
+        // issue #166, updated 2026-08-29): Sec3.6.1's diagnostic-path
+        // convention appends "[i]" to a repeated label's second and later
+        // occurrences, so a repeatable field "a" and a separately
+        // declared field literally named "a[1]" can produce the identical
+        // diagnostic path "$.a[1]" for two genuinely different validation
+        // problems -- indistinguishable in a diagnostic. Narrowest fix
+        // (per the issue): reject the character vocabulary outright at
+        // schema-construction time, not just the specific "[i]" shape --
+        // a lone, unmatched ']' (e.g. "total]") is rejected too. Same
+        // path convention as the empty-label check above.
+        if label.contains('[') || label.contains(']') {
+            return Err(SchemaError::new(
+                rec_name,
+                "schema.bracket-in-label",
+                format!(
+                    "field label {label:?} at {} contains '[' or ']', which collides with the \
+                     [i] diagnostic-path convention for repeated labels",
+                    label_tok.pos
+                ),
+            ));
+        }
         let (min, max) = if self.peek().text == "[" {
             self.parse_cardinality(rec_name, &label)?
         } else {
@@ -365,6 +401,22 @@ impl Parser {
                 path,
                 "schema.invalid-cardinality",
                 format!("invalid cardinality range [{lo}, {hi}]"),
+            ));
+        }
+        // [0,0] is a normative error (spec Sec5.5, issue #158, updated
+        // 2026-08-24): a field that must occur zero times is
+        // indistinguishable, in every observable respect, from a field
+        // never declared at all -- records are closed by default, so an
+        // undeclared label present in a document is already an error
+        // (`validate.unexpected-field`). [0,0] was a second spelling for
+        // the same thing, redundant with just not declaring the field.
+        // Reuses the existing `schema.invalid-cardinality` code -- the
+        // spec explicitly calls for no new code here.
+        if lo == 0 && hi == Some(0) {
+            return Err(SchemaError::new(
+                path,
+                "schema.invalid-cardinality",
+                "cardinality [0, 0] is redundant with not declaring the field at all".to_string(),
             ));
         }
         Ok((lo, hi))
@@ -931,6 +983,46 @@ root S
         let err_inverted = parse_schema(r#"record X { "a" [3, 1]: string } root X"#).unwrap_err();
         assert_eq!(err_inverted.code, "schema.invalid-cardinality");
         assert_eq!(err_inverted.path, "X.a");
+    }
+
+    // Issue #158 (spec Sec5.5, updated 2026-08-24): [0,0] is now a
+    // normative error, redundant with not declaring the field at all --
+    // reuses `schema.invalid-cardinality`, no new code.
+    #[test]
+    fn test_code_schema_invalid_cardinality_zero_zero() {
+        let err = parse_schema(r#"record R { "a" [0,0]: string } root R"#).unwrap_err();
+        assert_eq!(err.code, "schema.invalid-cardinality");
+        assert_eq!(err.path, "R.a");
+
+        // [0,1] and [0,] (unbounded) remain legal -- only the exact [0,0]
+        // spelling is rejected.
+        assert!(parse_schema(r#"record R { "a" [0,1]: string } root R"#).is_ok());
+        assert!(parse_schema(r#"record R { "a" [0,]: string } root R"#).is_ok());
+    }
+
+    // Issue #163 (spec Sec5.4, updated 2026-08-29): an empty-string field
+    // label is a normative error, path is the enclosing record -- same
+    // convention `schema.unquoted-label` uses.
+    #[test]
+    fn test_code_schema_empty_label() {
+        let err = parse_schema(r#"record R { "": string } root R"#).unwrap_err();
+        assert_eq!(err.code, "schema.empty-label");
+        assert_eq!(err.path, "R");
+    }
+
+    // Issue #166 (spec Sec5.4, updated 2026-08-29): '[' or ']' anywhere in
+    // a field label is a normative error -- both a matched-pair shape
+    // ("a[1]") and a lone, unmatched ']' ("total]") are rejected, since
+    // the rule is about the character vocabulary, not a specific pattern.
+    #[test]
+    fn test_code_schema_bracket_in_label() {
+        let err = parse_schema(r#"record R { "a[1]": string } root R"#).unwrap_err();
+        assert_eq!(err.code, "schema.bracket-in-label");
+        assert_eq!(err.path, "R");
+
+        let err_lone = parse_schema(r#"record R { "total]": string } root R"#).unwrap_err();
+        assert_eq!(err_lone.code, "schema.bracket-in-label");
+        assert_eq!(err_lone.path, "R");
     }
 
     #[test]

--- a/tools/conformance/src/bin/vector_runner.rs
+++ b/tools/conformance/src/bin/vector_runner.rs
@@ -855,8 +855,12 @@ const KNOWN_FAILING_VECTORS: &[&str] = &[
     // reference) -- removed here in the same PR, per this constant's own
     // doc comment above.
     //
-    // Issues #163-166 (grammar/diagnostic-shape fixes from the same
-    // 0ac1eac pin bump as #159/#160/#161/#162, not implemented by this PR).
+    // Issues #158/#163/#166 fixed these four entries (OSD
+    // schema-construction-time validation: [0,0] cardinality, empty field
+    // labels, brackets in field labels) -- removed here in the same PR.
+    //
+    // Issues #164-165 (OML tokenizer grammar fixes from the same 0ac1eac
+    // pin bump as #158-163/#166, not implemented by this PR).
     "oml-grammar/numbers/leading-zero-integer-is-an-error",
     "oml-grammar/numbers/leading-zero-in-decimal-is-an-error",
     "oml-grammar/temporals/date-with-out-of-range-month-is-an-error",
@@ -865,10 +869,6 @@ const KNOWN_FAILING_VECTORS: &[&str] = &[
     "oml-grammar/temporals/leap-second-is-an-error",
     "oml-grammar/temporals/tz-offset-minute-out-of-range-is-an-error",
     "oml-grammar/temporals/tz-offset-within-range-is-valid",
-    "osd-grammar/cardinality/zero-max-is-invalid-redundant-with-absence",
-    "osd-grammar/labels/empty-label-is-rejected",
-    "osd-grammar/labels/bracket-in-label-is-rejected",
-    "osd-grammar/labels/closing-bracket-alone-in-label-is-rejected",
 ];
 
 fn main_with_dir(dir: &Path) -> u8 {
@@ -998,21 +998,36 @@ mod tests {
     /// `KNOWN_FAILING_VECTORS` in the same PR, per that constant's own
     /// doc comment.
     ///
-    /// The remaining 12 failures are real, but out of scope -- they
-    /// belong to issues #163-#166 (still open) and to pre-existing
-    /// oml-grammar/osd-grammar gaps this pin bump's bundled vectors also
-    /// touch. Left failing deliberately; every one of them is also on
-    /// `KNOWN_FAILING_VECTORS`, so CI still passes -- see that constant's
-    /// doc comment for why this and `main_with_dir`'s exit code no longer
-    /// treat every failure as fatal. Pinned so a future change that
-    /// silently regresses pass/fail/skip counts is caught, not a "this
-    /// must always be 0 fails" gate.
+    /// (154, 12, 6) -> (158, 8, 6) via issues #158/#163/#166 (OSD
+    /// schema-construction-time validation): `[0,0]` cardinality, an
+    /// empty-string field label, and a field label containing `[`/`]`
+    /// (both a matched-pair shape and a lone, unmatched `]`) each now
+    /// fail to parse. Four vectors move fail -> pass (verified, not
+    /// assumed):
+    ///   - `osd-grammar/cardinality/zero-max-is-invalid-redundant-with-absence` (#158)
+    ///   - `osd-grammar/labels/empty-label-is-rejected` (#163)
+    ///   - `osd-grammar/labels/bracket-in-label-is-rejected` (#166)
+    ///   - `osd-grammar/labels/closing-bracket-alone-in-label-is-rejected` (#166)
+    ///
+    /// All four removed from `KNOWN_FAILING_VECTORS` in the same PR, per
+    /// that constant's own doc comment.
+    ///
+    /// The remaining 8 failures are real, but out of scope -- they belong
+    /// to issues #164-#165 (still open, OML tokenizer grammar fixes) and
+    /// to pre-existing oml-grammar temporal-diagnostic gaps this pin
+    /// bump's bundled vectors also touch. Left failing deliberately;
+    /// every one of them is also on `KNOWN_FAILING_VECTORS`, so CI still
+    /// passes -- see that constant's doc comment for why this and
+    /// `main_with_dir`'s exit code no longer treat every failure as
+    /// fatal. Pinned so a future change that silently regresses
+    /// pass/fail/skip counts is caught, not a "this must always be 0
+    /// fails" gate.
     #[test]
     fn full_suite_counts_match_the_measured_baseline() {
         let (passed, failed, skipped) = run_all(&suite_dir());
         assert_eq!(
             (passed, failed, skipped),
-            (154, 12, 6),
+            (158, 8, 6),
             "vector pass/fail/skip counts changed -- if this is an intentional fix or a new \
              vector, update the pinned baseline; if not, something regressed"
         );


### PR DESCRIPTION
## Summary

Closes #158, #163, #166. Three OSD schema-construction-time validation gaps, all closed at parse time in the same area of `osd.rs` (`parse_field`/`parse_cardinality`):

- **#158**: cardinality `[0,0]` is now a normative error — a field that must occur zero times is indistinguishable from a field never declared at all (records are closed by default, so an undeclared label is already `validate.unexpected-field`). Reuses the existing `schema.invalid-cardinality` code. `[0,1]` and unbounded `[0,]` remain legal.
- **#163**: an empty-string field label (`"": string`) is now rejected with the new `schema.empty-label` code. Path is the enclosing record, same convention `schema.unquoted-label` already uses.
- **#166**: a field label containing `[` or `]` is now rejected with the new `schema.bracket-in-label` code — both a matched-pair shape (`"a[1]"`) and a lone, unmatched `]` (`"total]"`). Without this, a repeatable field `"a"` and a field literally named `"a[1]"` can produce the identical diagnostic path `$.a[1]` for two genuinely different problems.

No `vendor/omnist-spec` submodule bump needed — `cea3b3e`, `211c2e2`, and `5e4b2fc` (the commits all three issues cite) are already ancestors of the `0ac1eac` pin PR #167 landed.

Adds direct unit tests for all three new rejections alongside the conformance vectors, and removes all four fixed vectors from `KNOWN_FAILING_VECTORS`, updating the pinned baseline from `(154, 12, 6)` to `(158, 8, 6)`.

## Test plan

- [x] Red-before-green: confirmed all 4 target vectors failed before the fix
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — all green
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo llvm-cov --workspace --fail-under-lines 100` — 100.00% Lines (12510/12510)
- [x] `cargo run -p conformance --bin vector_runner` — 158 passed, 8 failed (all pre-existing/known, issues #164/#165 + oml-grammar temporal gaps, unrelated to this PR), 6 skipped, of 172
- [x] `cargo run -p check-doc-examples -- --base-ref origin/main` — passed

## Vectors moved fail → pass

- `osd-grammar/cardinality/zero-max-is-invalid-redundant-with-absence` (#158)
- `osd-grammar/labels/empty-label-is-rejected` (#163)
- `osd-grammar/labels/bracket-in-label-is-rejected` (#166)
- `osd-grammar/labels/closing-bracket-alone-in-label-is-rejected` (#166)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
