### PR TITLE
Reject leading-zero numeric literals; fix temporal error position (#164, #165)

### DIFF
--- a/omnist/src/oml/scanner.rs
+++ b/omnist/src/oml/scanner.rs
@@ -470,7 +470,14 @@ impl<'a> Scanner<'a> {
                 TemporalKind::Time => "time",
                 TemporalKind::Datetime => "datetime",
             };
-            return Err(self.error_at(end, format!("invalid {label} {text:?}")));
+            // spec Sec4.2.4 (issue #165, added 2026-08-29): the diagnostic
+            // position is the start of the temporal token, matching every
+            // other scanner error in this file (e.g. `scan_number`'s
+            // digit-cap error) -- was `end` (the token's *end* position),
+            // which put the reported line:col well past the literal for
+            // any multi-char token, disagreeing with every conformance
+            // vector's expected `{line}:{col}` (all point at `start`).
+            return Err(self.error_at(start, format!("invalid {label} {text:?}")));
         }
         self.pos = end;
         let canonical = match kind {
@@ -554,6 +561,22 @@ impl<'a> Scanner<'a> {
         let int_start = p;
         p = self.digits_from(p);
         debug_assert!(p > int_start, "caller guarantees at least one digit");
+        // parse.leading-zero (spec Sec4.2.3, issue #164, added 2026-08-29):
+        // the integer part's grammar is `int-part = "0" / (nonzero digit
+        // followed by any digits)` -- a bare "0" is legal, but any run of
+        // more than one digit starting with "0" is not, and the fractional
+        // part doesn't exempt it ("00.5" is rejected just like "00").
+        // Genuinely undefined before this: confirmed live against the
+        // Python reference that "01"/"00" both silently tokenized as 1/0.
+        // Matches JSON's and TOML's own numeric-literal grammar, which OML
+        // already round-trips through.
+        let int_digits = &self.text[int_start..p];
+        if int_digits.len() > 1 && int_digits.as_bytes()[0] == b'0' {
+            return Err(self.error_at(
+                start,
+                format!("leading zero in numeric literal {int_digits:?} is not allowed"),
+            ));
+        }
         let mut end = p;
         let mut is_float = false;
         let frac_end = if self.byte_at(p) == Some(b'.') {

--- a/omnist/src/oml/tests.rs
+++ b/omnist/src/oml/tests.rs
@@ -56,6 +56,40 @@ fn number_round_trips_decimal_and_whole_valued_float() {
     ]));
 }
 
+// spec Sec4.2.3 (issue #164, added 2026-08-29): the integer part's
+// grammar is `int-part = "0" / (nonzero digit followed by any digits)` --
+// a leading zero followed by more digits is now a normative error,
+// matching JSON's and TOML's own numeric-literal grammar. Genuinely
+// undefined before this: confirmed live against the Python reference that
+// "01"/"00" both silently tokenized as 1/0.
+#[test]
+fn leading_zero_integer_is_rejected() {
+    let err = read_oml("n: 01\n").unwrap_err();
+    assert!(err.message.contains("leading zero"));
+    // "n: " is 3 chars, so the literal starts at column 4.
+    assert_eq!((err.line, err.col), (1, 4));
+}
+
+#[test]
+fn leading_zero_in_decimal_is_rejected() {
+    // The fractional part does not exempt the integer part -- "00.5" is
+    // rejected exactly like "00" alone.
+    let err = read_oml("n: 00.5\n").unwrap_err();
+    assert!(err.message.contains("leading zero"));
+    assert_eq!((err.line, err.col), (1, 4));
+}
+
+#[test]
+fn single_zero_and_negative_forms_remain_valid() {
+    // A bare "0" is never a leading zero -- only a run of more than one
+    // digit starting with "0" is rejected.
+    roundtrip_value(&obj(&[
+        ("a", Value::Int((0).into())),
+        ("b", Value::Float(0.5)),
+        ("c", Value::Int((-12).into())),
+    ]));
+}
+
 #[test]
 fn number_round_trips_nan_and_infinities() {
     let doc = Doc::of(&obj(&[
@@ -493,18 +527,92 @@ fn quoted_reserved_words_are_valid_labels_and_round_trip() {
 fn invalid_date_reports_a_clear_error() {
     let err = read_oml("a: 2024-02-30").unwrap_err();
     assert!(err.message.contains("invalid date"));
+    // spec Sec4.2.4 (issue #165): diagnostic position is the start of the
+    // temporal token, not its end -- "a: " is 3 chars, so the literal
+    // starts at column 4.
+    assert_eq!((err.line, err.col), (1, 4));
 }
 
 #[test]
 fn invalid_time_reports_a_clear_error() {
     let err = read_oml("a: 25:00:00").unwrap_err();
     assert!(err.message.contains("invalid time"));
+    assert_eq!((err.line, err.col), (1, 4));
 }
 
 #[test]
 fn invalid_datetime_reports_a_clear_error() {
     let err = read_oml("a: 2024-13-01T12:00:00").unwrap_err();
     assert!(err.message.contains("invalid datetime"));
+    assert_eq!((err.line, err.col), (1, 4));
+}
+
+// spec Sec4.2.4 (issue #165, added 2026-08-29): month/day range validation
+// -- an out-of-range month and a day invalid for its month (independent of
+// leap-year status: February never has 30 days, in any year) are both
+// `invalid date`, not just malformed-shape errors.
+#[test]
+fn date_with_out_of_range_month_is_rejected() {
+    let err = read_oml("n: 2024-13-01\n").unwrap_err();
+    assert!(err.message.contains("invalid date"));
+    assert_eq!((err.line, err.col), (1, 4));
+}
+
+#[test]
+fn date_with_day_invalid_for_month_is_rejected() {
+    let err = read_oml("n: 2024-02-30\n").unwrap_err();
+    assert!(err.message.contains("invalid date"));
+}
+
+// spec Sec4.2.4: February 29 is only valid in an actual leap year --
+// 1900 is divisible by 100 but not 400, so it is NOT a leap year in the
+// proleptic Gregorian calendar (distinct from 2000, which is).
+#[test]
+fn february_29_in_a_non_leap_year_is_rejected() {
+    let err = read_oml("n: 1900-02-29\n").unwrap_err();
+    assert!(err.message.contains("invalid date"));
+}
+
+#[test]
+fn february_29_in_a_leap_year_is_accepted() {
+    let doc = Doc::from_raw(read_oml("n: 2000-02-29\n").unwrap()).unwrap();
+    let root = doc.root();
+    let value = root.get_one("n").unwrap().value().unwrap();
+    assert!(matches!(value, crate::document::Scalar::Date(s) if s == "2000-02-29"));
+}
+
+// spec Sec4.2.4: OML has no leap-second spelling -- second is 00-59 with
+// no exception, unlike ISO 8601 which permits 60 in some contexts.
+#[test]
+fn leap_second_is_rejected() {
+    let err = read_oml("n: 23:59:60\n").unwrap_err();
+    assert!(err.message.contains("invalid time"));
+    assert_eq!((err.line, err.col), (1, 4));
+}
+
+// spec Sec4.2.4 (issue #165, the real bug this issue fixes): tz-offset
+// MUST use the exact same minute range as TIME (00-59), not a wider or
+// separately-implemented one. Confirmed live against a pre-fix reference:
+// "+00:60" used to be silently normalized to a 1-hour offset instead of
+// rejected, colliding with a document that legitimately wrote "+01:00".
+#[test]
+fn tz_offset_minute_out_of_range_is_rejected_not_normalized() {
+    let err = read_oml("n: 2024-01-01T10:30+00:60\n").unwrap_err();
+    assert!(err.message.contains("invalid datetime"));
+    assert_eq!((err.line, err.col), (1, 4));
+}
+
+#[test]
+fn tz_offset_within_range_is_accepted() {
+    let doc = Doc::from_raw(read_oml("n: 2024-01-01T10:30+05:30\n").unwrap()).unwrap();
+    let root = doc.root();
+    let value = root.get_one("n").unwrap().value().unwrap();
+    // Seconds canonicalize to ":00" per issue #90 (deliberate, pre-existing
+    // behavior a missing `:SS` always triggers) -- this is the OML reader's
+    // own canonical string, not what the source text spelled out.
+    assert!(
+        matches!(value, crate::document::Scalar::Datetime(s) if s == "2024-01-01T10:30:00+05:30")
+    );
 }
 
 #[test]

--- a/tools/conformance/src/bin/vector_runner.rs
+++ b/tools/conformance/src/bin/vector_runner.rs
@@ -859,15 +859,23 @@ const KNOWN_FAILING_VECTORS: &[&str] = &[
     // schema-construction-time validation: [0,0] cardinality, empty field
     // labels, brackets in field labels) -- removed here in the same PR.
     //
-    // Issues #164-165 (OML tokenizer grammar fixes from the same 0ac1eac
-    // pin bump as #158-163/#166, not implemented by this PR).
-    "oml-grammar/numbers/leading-zero-integer-is-an-error",
-    "oml-grammar/numbers/leading-zero-in-decimal-is-an-error",
-    "oml-grammar/temporals/date-with-out-of-range-month-is-an-error",
-    "oml-grammar/temporals/date-with-day-invalid-for-month-is-an-error",
-    "oml-grammar/temporals/february-29-in-a-non-leap-year-is-an-error",
-    "oml-grammar/temporals/leap-second-is-an-error",
-    "oml-grammar/temporals/tz-offset-minute-out-of-range-is-an-error",
+    // Issue #164 fixed both leading-zero entries, and #165 fixed the five
+    // temporal error-case entries (all removed here in the same PR) --
+    // but NOT `tz-offset-within-range-is-valid` below, which stays. That
+    // one vector's `expect.document.value` is un-canonicalized (missing
+    // the `:00` seconds every sibling OML-datetime vector in this same
+    // file has -- e.g. `date-then-time-lookahead-yields-one-datetime-
+    // token`, right above the temporals block), which is a genuine
+    // omnist-spec test-suite defect (filed:
+    // https://github.com/omnist-dev/omnist-spec/issues/51), not an
+    // omnist-rs gap -- omnist-rs's OML reader canonicalizes a missing
+    // `:SS` to `:00` deliberately and consistently (issue #90), and
+    // reverting that to match this one vector would silently regress
+    // every other datetime vector depending on it. The actual subject of
+    // #165 (tz-offset sharing TIME's exact minute range, not a wider or
+    // separately-implemented one) is confirmed correct and covered by the
+    // adjacent `tz-offset-minute-out-of-range-is-an-error` vector, which
+    // now passes.
     "oml-grammar/temporals/tz-offset-within-range-is-valid",
 ];
 
@@ -1012,22 +1020,42 @@ mod tests {
     /// All four removed from `KNOWN_FAILING_VECTORS` in the same PR, per
     /// that constant's own doc comment.
     ///
-    /// The remaining 8 failures are real, but out of scope -- they belong
-    /// to issues #164-#165 (still open, OML tokenizer grammar fixes) and
-    /// to pre-existing oml-grammar temporal-diagnostic gaps this pin
-    /// bump's bundled vectors also touch. Left failing deliberately;
-    /// every one of them is also on `KNOWN_FAILING_VECTORS`, so CI still
-    /// passes -- see that constant's doc comment for why this and
-    /// `main_with_dir`'s exit code no longer treat every failure as
-    /// fatal. Pinned so a future change that silently regresses
-    /// pass/fail/skip counts is caught, not a "this must always be 0
-    /// fails" gate.
+    /// (158, 8, 6) -> (165, 1, 6) via issues #164/#165 (OML tokenizer
+    /// numeric/temporal-literal grammar, `omnist/src/oml/scanner.rs`):
+    ///   - #164: a leading zero in a numeric literal's integer part (e.g.
+    ///     "01", "00.5") is now `parse.leading-zero`.
+    ///   - #165: DATE/TIME/DATETIME calendar/clock range validation was
+    ///     already correctly implemented (month 01-12, day valid for
+    ///     month/leap-year, hour/minute/second in range, no leap-second
+    ///     spelling, tz-offset sharing TIME's exact minute range rather
+    ///     than a separate, looser one) -- the real gap was a diagnostic-
+    ///     position bug (`finish_temporal` reported the token's *end*
+    ///     position, not its *start*, disagreeing with every conformance
+    ///     vector's expected `line:col`). Fixed by reporting at `start`.
+    ///
+    /// Seven vectors move fail -> pass (verified, not assumed):
+    ///   - `oml-grammar/numbers/leading-zero-integer-is-an-error` (#164)
+    ///   - `oml-grammar/numbers/leading-zero-in-decimal-is-an-error` (#164)
+    ///   - `oml-grammar/temporals/date-with-out-of-range-month-is-an-error` (#165)
+    ///   - `oml-grammar/temporals/date-with-day-invalid-for-month-is-an-error` (#165)
+    ///   - `oml-grammar/temporals/february-29-in-a-non-leap-year-is-an-error` (#165)
+    ///   - `oml-grammar/temporals/leap-second-is-an-error` (#165)
+    ///   - `oml-grammar/temporals/tz-offset-minute-out-of-range-is-an-error` (#165)
+    ///
+    /// All seven removed from `KNOWN_FAILING_VECTORS` in the same PR.
+    /// `tz-offset-within-range-is-valid` (#165's 6th, happy-path vector)
+    /// deliberately stays on `KNOWN_FAILING_VECTORS` -- see that
+    /// constant's doc comment: it's a genuine omnist-spec test-suite
+    /// defect (filed as omnist-spec#51), not an omnist-rs gap.
+    ///
+    /// This closes out every issue in the #158-166 batch. The one
+    /// remaining failure is entirely outside this port's control.
     #[test]
     fn full_suite_counts_match_the_measured_baseline() {
         let (passed, failed, skipped) = run_all(&suite_dir());
         assert_eq!(
             (passed, failed, skipped),
-            (158, 8, 6),
+            (165, 1, 6),
             "vector pass/fail/skip counts changed -- if this is an intentional fix or a new \
              vector, update the pinned baseline; if not, something regressed"
         );


### PR DESCRIPTION
## Summary

Closes #164, #165. Two OML tokenizer grammar gaps in `omnist/src/oml/scanner.rs`, closing out the last two issues in the #158-166 batch.

- **#164**: a leading zero followed by more digits in a numeric literal's integer part (`"01"`, `"00.5"`) is now rejected with the new `parse.leading-zero` code, matching JSON/TOML's own grammar. A bare `"0"`/`"-0"` remain legal.
- **#165**: DATE/TIME/DATETIME calendar/clock range validation (month 01-12, day valid for month/leap-year, no leap-second, tz-offset sharing TIME's exact minute range) was already correctly implemented — the real gap was a diagnostic-position bug: `finish_temporal` reported the token's *end* position instead of its *start*, disagreeing with every conformance vector's expected `line:col`. Fixed.

No `vendor/omnist-spec` submodule bump needed — `4a2b4ed` and `a8a878a` are already ancestors of the `0ac1eac` pin PR #167 landed.

## A genuine omnist-spec test-suite defect found and filed

`oml-grammar/temporals/tz-offset-within-range-is-valid` (the happy-path vector in #165's batch) has an un-canonicalized expected value (`"2024-01-01T10:30+05:30"`, missing the `:00` seconds every sibling OML-datetime vector in the same file has). Confirmed empirically against both this port and the Python reference: Python's harness compares parsed `datetime` objects (semantically equal either way), so the omission is invisible there; this port's `Scalar::Datetime` is a literal canonical string with no native temporal type, so it's a real mismatch here. The fix belongs in the vector, not this port — reverting our own deliberate, tested `:SS`-canonicalization (issue #90) would regress every other datetime vector depending on it. Filed as [omnist-spec#51](https://github.com/omnist-dev/omnist-spec/issues/51). This one vector stays on `KNOWN_FAILING_VECTORS`.

## Test plan

- [x] Red-before-green: confirmed all target vectors failed before the fix
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — all green
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo llvm-cov --workspace --fail-under-lines 100` — 100.00% Lines (12517/12517)
- [x] `cargo run -p conformance --bin vector_runner` — 165 passed, 1 failed (the spec-suite defect above), 6 skipped, of 172
- [x] `cargo run -p check-doc-examples -- --base-ref origin/main` — passed

## Vectors moved fail → pass

- `oml-grammar/numbers/leading-zero-integer-is-an-error` (#164)
- `oml-grammar/numbers/leading-zero-in-decimal-is-an-error` (#164)
- `oml-grammar/temporals/date-with-out-of-range-month-is-an-error` (#165)
- `oml-grammar/temporals/date-with-day-invalid-for-month-is-an-error` (#165)
- `oml-grammar/temporals/february-29-in-a-non-leap-year-is-an-error` (#165)
- `oml-grammar/temporals/leap-second-is-an-error` (#165)
- `oml-grammar/temporals/tz-offset-minute-out-of-range-is-an-error` (#165)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
