### PR TITLE
version: bump to 0.2.2-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "check-doc-examples"
-version = "0.2.1-alpha"
+version = "0.2.2-alpha"
 dependencies = [
  "tempfile",
 ]
@@ -155,7 +155,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "conformance"
-version = "0.2.1-alpha"
+version = "0.2.2-alpha"
 dependencies = [
  "num-bigint",
  "omnist",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "omnist"
-version = "0.2.1-alpha"
+version = "0.2.2-alpha"
 dependencies = [
  "indexmap",
  "num-bigint",
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "omnist-cli"
-version = "0.2.1-alpha"
+version = "0.2.2-alpha"
 dependencies = [
  "clap",
  "indexmap",

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Docs: [rs.omnist.dev](https://rs.omnist.dev) — includes generated [rustdoc API
 
 ```toml
 [dependencies]
-omnist = "0.2.1-alpha"
+omnist = "0.2.2-alpha"
 ```
 
 Published on [crates.io](https://crates.io/crates/omnist); API reference on [docs.rs](https://docs.rs/omnist).
@@ -35,7 +35,7 @@ This repository follows a strict spec-first methodology. `vendor/omnist-spec` is
 
 ## Status
 
-**`v0.2.1-alpha`.**
+**`v0.2.2-alpha`.**
 
 - **Conformance Harness**: Track 1 (CLI fixtures) **19 / 19 (100%) PASS**. Track 2 (JSON test vectors) **130 / 152 PASS, 0 real fails, 22 skips**.
 - **Testing**: **936 tests passing**, 0 failures — unit tests plus `proptest`-based property fuzzing across every format reader.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,6 +1,6 @@
 # Limitations & stability
 
-## Alpha status: `0.2.1-alpha`, per this project's versioning rule
+## Alpha status: `0.2.2-alpha`, per this project's versioning rule
 
 The Rust port's first feature-complete milestone (issue #28) plus its own
 conformance-test harness against

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,7 +2,7 @@
 
 ```toml
 [dependencies]
-omnist = "0.2.1-alpha"
+omnist = "0.2.2-alpha"
 ```
 <!-- doc-illustrative -->
 

--- a/omnist-cli/Cargo.toml
+++ b/omnist-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnist-cli"
-version = "0.2.1-alpha"
+version = "0.2.2-alpha"
 edition = "2024"
 description = "CLI for omnist (Rust port)."
 license = "Apache-2.0"

--- a/omnist/Cargo.toml
+++ b/omnist/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnist"
-version = "0.2.1-alpha"
+version = "0.2.2-alpha"
 edition = "2024"
 description = "One data model, many formats: read, validate, and write JSON, YAML, TOML, XML, and OML. (Rust port of https://github.com/omnist-dev/omnist)"
 license = "Apache-2.0"

--- a/omnist/src/tests.rs
+++ b/omnist/src/tests.rs
@@ -11,7 +11,7 @@ use super::*;
 
 #[test]
 fn version_matches_cargo_toml() {
-    assert_eq!(VERSION, "0.2.1-alpha");
+    assert_eq!(VERSION, "0.2.2-alpha");
 }
 
 #[test]

--- a/src/limitations.md
+++ b/src/limitations.md
@@ -1,6 +1,6 @@
 # Limitations & stability
 
-## Alpha status: `0.2.1-alpha`, per this project's versioning rule
+## Alpha status: `0.2.2-alpha`, per this project's versioning rule
 
 The Rust port's first feature-complete milestone (issue #28) plus its own
 conformance-test harness against

--- a/src/quickstart.md
+++ b/src/quickstart.md
@@ -2,7 +2,7 @@
 
 ```toml
 [dependencies]
-omnist = "0.2.1-alpha"
+omnist = "0.2.2-alpha"
 ```
 <!-- doc-illustrative -->
 

--- a/tools/check-doc-examples/Cargo.toml
+++ b/tools/check-doc-examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "check-doc-examples"
-version = "0.2.1-alpha"
+version = "0.2.2-alpha"
 edition = "2024"
 description = "CI gate: every new/changed fenced code block in docs/*.md needs a verified-by or doc-illustrative marker."
 license = "Apache-2.0"

--- a/tools/conformance/Cargo.toml
+++ b/tools/conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conformance"
-version = "0.2.1-alpha"
+version = "0.2.2-alpha"
 edition = "2024"
 description = "omnist-rs's own conformance-test harness against omnist-spec (issue #82): referee + Track 1 fixture runner + Track 2 vector runner, consuming the pinned vendor/omnist-spec submodule directly, never depending on Python's or TypeScript's implementation."
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Patch version bump, `0.2.1-alpha` -> `0.2.2-alpha`, closing out the #158-166 batch (PRs #167-170: write-side unconditional-failure fixes, XML carriage-return escaping, OSD schema-construction validation, OML numeric/temporal grammar fixes). Per this project's beta-versioning rule, a batch of correctness/spec-conformance fixes with no new features is a patch bump.

Bumps every workspace crate's `Cargo.toml` version, the `VERSION` pin test (`omnist/src/tests.rs`), and every doc that hardcodes the version string (`README.md`, `docs/quickstart.md`, `docs/limitations.md`, `src/quickstart.md`, `src/limitations.md`). `Cargo.lock` regenerated by `cargo build`.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — all green (version pin test included)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo llvm-cov --workspace --fail-under-lines 100` — 100.00% Lines (12517/12517)
- [x] `cargo run -p conformance --bin vector_runner` — 165 passed, 1 failed (known/tracked, omnist-spec#51), 6 skipped, of 172
- [x] `cargo run -p check-doc-examples -- --base-ref origin/main` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
