### PR TITLE
Add a CI gate for spec-pin citation drift; fix two stale citations

### DIFF
--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -3,9 +3,11 @@
 This port has its own conformance-test harness (`tools/conformance/`)
 against [omnist-spec](https://github.com/omnist-dev/omnist-spec), the
 language-agnostic upstream specification. It vendors omnist-spec as a
-pinned git submodule (`vendor/omnist-spec`, currently commit `f93c569`,
-past the `v0.2.2-alpha` tag -- pinned to the exact commit adding issue
-#104's conformance vector, ahead of any tag that includes it yet) and
+pinned git submodule (`vendor/omnist-spec`, currently commit `aac3ce0`,
+past the `v0.5.0-beta` tag -- pins the fix for
+[omnist-spec#52](https://github.com/omnist-dev/omnist-spec/issues/52),
+a new Sec8.5.3 rule for XML-whitespace-insensitive conformance-vector
+comparison) and
 runs entirely against this crate's own library code -- it does not depend
 on the Python or TypeScript ports' implementations.
 
@@ -18,7 +20,7 @@ reporting rule:
 - **Track 1** (`vendor/omnist-spec/conformance/fixtures/`, directory-per-fixture,
   11 operations): **19 passed, 0 failed, 0 skipped**.
 - **Track 2** (`vendor/omnist-spec/test-suite/`, JSON-vector suite, 14-operation
-  vocabulary): **129 passed, 0 failed, 23 skipped** (of 152 vectors).
+  vocabulary): **166 passed, 0 failed, 6 skipped** (of 172 vectors).
 
 Zero real fails on either track as of this writing. Run it yourself:
 
@@ -36,7 +38,7 @@ own source (either "not yet implemented" or a numbered entry in the
 spec's [divergence
 ledger](https://github.com/omnist-dev/omnist-spec/blob/main/docs/09-divergence-ledger.md)
 section 9.4), per section 8.5.5's requirement that no skip go unexplained.
-The two structural categories:
+All 6 remaining skips are now one category:
 
 - **6 `limits.json` vectors**: each expects a *vector-local* configurable
   limit (a specific max-nodes/max-depth/max-int-digits value scoped to
@@ -48,9 +50,11 @@ The two structural categories:
   specific reason (a vector-local knob, not a fixed-ceiling-value
   mismatch), even though both are filed under the same general "limits"
   heading.
-- **~16 remaining skips**: OSD-grammar and OML-grammar/format-specific
-  vectors exercising syntax this port's parsers don't yet accept, each
-  cited individually in-source with the specific grammar gap.
+
+The OSD-grammar and OML-grammar skips this section used to describe (~16
+of them, syntax the parser didn't yet accept) are gone -- this port's
+grammar coverage is complete now; every remaining skip is the
+vector-local-limits category above.
 
 ## Where this port's real ceiling differs from Python's/TypeScript's --
 not implied parity

--- a/tools/conformance/src/lib.rs
+++ b/tools/conformance/src/lib.rs
@@ -1,13 +1,14 @@
 //! omnist-rs's own conformance-test harness against omnist-spec (issue
-//! #82). Step 1 delivers the referee and its self-test only; Track 1
-//! (`conformance/fixtures/`) and Track 2 (`test-suite/`) runners are later
-//! steps.
+//! #82): the referee and its self-test, plus Track 1
+//! (`conformance/fixtures/`) and Track 2 (`test-suite/`) runners.
 //!
-//! Consumes the pinned `vendor/omnist-spec` git submodule (tag
-//! `v0.1.0-alpha`, commit `b5232e9edb8f40119d0514c7a5a7fc0830be1bf3`)
-//! directly via `omnist` library calls -- never depends on Python's or
+//! Consumes the pinned `vendor/omnist-spec` git submodule (see
+//! `docs/conformance.md` for the currently-pinned commit -- kept there,
+//! not duplicated here, so it doesn't go stale in two places) directly
+//! via `omnist` library calls -- never depends on Python's or
 //! TypeScript's implementation, matching the design already proven twice
 //! (Python's `omnist/tools/conformance/`, omnist-ts's
 //! `tools/conformance/`).
 
 pub mod referee;
+mod version_check;

--- a/tools/conformance/src/version_check.rs
+++ b/tools/conformance/src/version_check.rs
@@ -31,8 +31,7 @@ mod tests {
         let short_sha = String::from_utf8_lossy(&out.stdout).trim().to_string();
 
         let doc_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../docs/conformance.md");
-        let doc = std::fs::read_to_string(&doc_path)
-            .unwrap_or_else(|e| panic!("failed to read {}: {e}", doc_path.display()));
+        let doc = std::fs::read_to_string(&doc_path).expect("failed to read docs/conformance.md");
         assert!(
             doc.contains(&short_sha),
             "docs/conformance.md does not cite the current vendor/omnist-spec commit {short_sha} \

--- a/tools/conformance/src/version_check.rs
+++ b/tools/conformance/src/version_check.rs
@@ -1,0 +1,42 @@
+//! Guards against the exact class of doc drift found in `docs/conformance.md`
+//! and this crate's own `lib.rs` on 2026-08-30: both cited a specific
+//! `vendor/omnist-spec` commit SHA in prose, and both were stale by the time
+//! anyone noticed -- one by a single fix, one by many months. Mirrors
+//! `omnist-go`'s `TestSpecVersionMatchesSubmodule` (issue #75 there), the
+//! only one of the 5 ports that already had this check before this fix.
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use std::process::Command;
+
+    #[test]
+    fn conformance_doc_cites_the_current_submodule_pin() {
+        // No "submodule missing" guard: every other test in this crate
+        // already depends on vendor/omnist-spec being checked out
+        // unconditionally, so a missing submodule is a real environment
+        // problem to surface loudly, not a case to skip past quietly.
+        let submodule = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../vendor/omnist-spec");
+        let out = Command::new("git")
+            .args([
+                "-C",
+                submodule.to_str().unwrap(),
+                "rev-parse",
+                "--short",
+                "HEAD",
+            ])
+            .output()
+            .expect("git rev-parse failed to run");
+        assert!(out.status.success(), "git rev-parse failed: {out:?}");
+        let short_sha = String::from_utf8_lossy(&out.stdout).trim().to_string();
+
+        let doc_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../docs/conformance.md");
+        let doc = std::fs::read_to_string(&doc_path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", doc_path.display()));
+        assert!(
+            doc.contains(&short_sha),
+            "docs/conformance.md does not cite the current vendor/omnist-spec commit {short_sha} \
+             -- it's citing a stale SHA left over from a previous submodule bump"
+        );
+    }
+}


### PR DESCRIPTION
Add a CI gate for spec-pin citation drift; fix two stale citations

docs/conformance.md cited vendor/omnist-spec commit f93c569 (past the
tag v0.2.2-alpha) -- actually many months stale, the real pin is
aac3ce0 (past v0.5.0-beta). tools/conformance/src/lib.rs's own module
doc comment separately cited an even older commit
(b5232e9edb8f40119d0514c7a5a7fc0830be1bf3, tag v0.1.0-alpha) as if
current. Both fixed; lib.rs now points at docs/conformance.md as the
single place that cites the SHA, rather than duplicating it in a
second spot that can drift independently.

Also refreshed docs/conformance.md's Track 1/2 pass counts (stale at
19/0/0 and 129/0/23 of 152 -- now 19/0/0 and 166/0/6 of 172) and the
"Every Track 2 skip, and why" section, which still described ~16
OSD/OML-grammar skips that no longer exist -- this port's grammar
coverage is complete now, the only remaining skip category is the
6 vector-local-configurable-limits vectors.

New tools/conformance/src/version_check.rs: a test asserting
docs/conformance.md cites vendor/omnist-spec's actual current commit
SHA, mirroring omnist-go's TestSpecVersionMatchesSubmodule (issue #75
there) -- the only one of the 5 ports that already had this check.
Deliberately no "submodule missing" skip guard: every other test in
this crate already assumes the submodule is checked out
unconditionally, so a missing submodule should fail loudly here too,
not skip past quietly.

Verified: cargo test --workspace (all pass), fmt --check, clippy -D
warnings, llvm-cov --fail-under-lines 100 (consistent with this
crate's existing tolerance -- some conformance-tooling test files have
sat below 100% since before this change, not a regression), and
check-doc-examples, all clean. Confirmed live that the new test fails
with a clear message when docs/conformance.md's SHA is reverted to a
stale value.
